### PR TITLE
PERS-222: Implement failed payment recovery / dunning flow

### DIFF
--- a/scripts/test-dunning-flow.mjs
+++ b/scripts/test-dunning-flow.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * Stripe Test Clock — Dunning Flow Simulation
+ *
+ * Creates a Stripe test clock and simulates the full dunning flow:
+ *   1. Create customer with a card that will fail
+ *   2. Create subscription
+ *   3. Advance clock to trigger payment failure at day 3, 5, 7
+ *   4. Verify webhook events are received
+ *
+ * Usage:
+ *   STRIPE_SECRET_KEY=sk_test_... node scripts/test-dunning-flow.mjs
+ *
+ * Prerequisites:
+ *   - Stripe CLI for webhook forwarding: stripe listen --forward-to localhost:3000/api/stripe/webhook
+ *   - A test price with lookup_key "base_monthly" in your Stripe account
+ */
+
+import Stripe from 'stripe'
+
+const STRIPE_KEY = process.env.STRIPE_SECRET_KEY
+if (!STRIPE_KEY) {
+  console.error('Set STRIPE_SECRET_KEY environment variable (use a test key)')
+  process.exit(1)
+}
+
+const stripe = new Stripe(STRIPE_KEY)
+
+// Stripe test card tokens that simulate failures
+// See: https://docs.stripe.com/testing#declined-payments
+const DECLINE_CARD_TOKEN = 'tok_chargeCustomerFail' // Generic decline
+
+async function run() {
+  console.log('\n=== Dunning Flow Test (Stripe Test Clock) ===\n')
+
+  // 1. Create test clock
+  const now = Math.floor(Date.now() / 1000)
+  const testClock = await stripe.testHelpers.testClocks.create({
+    frozen_time: now,
+    name: `Dunning test ${new Date().toISOString()}`,
+  })
+  console.log(`Test clock created: ${testClock.id}`)
+
+  // 2. Create customer attached to test clock
+  const customer = await stripe.customers.create({
+    email: 'dunning-test@clapcheeks.tech',
+    name: 'Dunning Test User',
+    test_clock: testClock.id,
+  })
+  console.log(`Customer created: ${customer.id}`)
+
+  // 3. Attach a card that will decline
+  // Use a token that always declines charges
+  const paymentMethod = await stripe.paymentMethods.create({
+    type: 'card',
+    card: { token: DECLINE_CARD_TOKEN },
+  })
+  await stripe.paymentMethods.attach(paymentMethod.id, { customer: customer.id })
+  await stripe.customers.update(customer.id, {
+    invoice_settings: { default_payment_method: paymentMethod.id },
+  })
+  console.log(`Payment method attached: ${paymentMethod.id} (will decline)`)
+
+  // 4. Create subscription
+  // Find or create a test price
+  let priceId
+  const prices = await stripe.prices.list({ lookup_keys: ['base_monthly'], limit: 1 })
+  if (prices.data.length > 0) {
+    priceId = prices.data[0].id
+  } else {
+    console.log('No price with lookup_key "base_monthly" found. Creating test product + price...')
+    const product = await stripe.products.create({ name: 'Base Plan (Test)' })
+    const price = await stripe.prices.create({
+      product: product.id,
+      unit_amount: 9700, // $97
+      currency: 'usd',
+      recurring: { interval: 'month' },
+      lookup_key: 'base_monthly',
+    })
+    priceId = price.id
+  }
+
+  const subscription = await stripe.subscriptions.create({
+    customer: customer.id,
+    items: [{ price: priceId }],
+    payment_behavior: 'default_incomplete',
+    payment_settings: {
+      payment_method_types: ['card'],
+      save_default_payment_method: 'on_subscription',
+    },
+    metadata: { plan: 'base', test_clock: 'true' },
+  })
+  console.log(`Subscription created: ${subscription.id} (status: ${subscription.status})`)
+
+  // 5. Advance test clock to trigger retries
+  const DAY = 86400 // seconds in a day
+
+  console.log('\n--- Advancing to Day 3 (first retry) ---')
+  await stripe.testHelpers.testClocks.advance(testClock.id, {
+    frozen_time: now + (3 * DAY),
+  })
+  await waitForClockReady(testClock.id)
+  console.log('Clock advanced to day 3. Check webhook logs for invoice.payment_failed event.')
+
+  console.log('\n--- Advancing to Day 5 (second retry) ---')
+  await stripe.testHelpers.testClocks.advance(testClock.id, {
+    frozen_time: now + (5 * DAY),
+  })
+  await waitForClockReady(testClock.id)
+  console.log('Clock advanced to day 5. Check webhook logs for invoice.payment_failed event.')
+
+  console.log('\n--- Advancing to Day 7 (final retry) ---')
+  await stripe.testHelpers.testClocks.advance(testClock.id, {
+    frozen_time: now + (7 * DAY),
+  })
+  await waitForClockReady(testClock.id)
+  console.log('Clock advanced to day 7. Check webhook logs for invoice.payment_failed event.')
+
+  console.log('\n--- Advancing to Day 10 (subscription should be canceled) ---')
+  await stripe.testHelpers.testClocks.advance(testClock.id, {
+    frozen_time: now + (10 * DAY),
+  })
+  await waitForClockReady(testClock.id)
+
+  // Check final subscription status
+  const finalSub = await stripe.subscriptions.retrieve(subscription.id)
+  console.log(`Final subscription status: ${finalSub.status}`)
+
+  // List events for verification
+  const events = await stripe.events.list({
+    limit: 20,
+    types: ['invoice.payment_failed', 'customer.subscription.deleted', 'invoice.paid'],
+  })
+  console.log('\n--- Recent Stripe Events ---')
+  for (const event of events.data) {
+    const invoice = event.data.object
+    if (invoice.customer === customer.id) {
+      console.log(`  ${event.type} — ${new Date(event.created * 1000).toISOString()} — attempt: ${invoice.attempt_count ?? 'n/a'}`)
+    }
+  }
+
+  console.log('\n--- Cleanup ---')
+  console.log(`Test clock ID: ${testClock.id}`)
+  console.log(`Customer ID: ${customer.id}`)
+  console.log('To clean up: stripe test_helpers test_clocks delete ' + testClock.id)
+  console.log('\nDone! Verify:')
+  console.log('  1. Dunning emails were sent (check Resend dashboard)')
+  console.log('  2. Database shows past_due → canceled transition')
+  console.log('  3. /billing page shows canceled state with re-subscribe CTA')
+}
+
+async function waitForClockReady(clockId) {
+  for (let i = 0; i < 30; i++) {
+    const clock = await stripe.testHelpers.testClocks.retrieve(clockId)
+    if (clock.status === 'ready') return
+    await new Promise(resolve => setTimeout(resolve, 2000))
+  }
+  console.warn('Warning: Test clock did not reach ready status within 60s')
+}
+
+run().catch(err => {
+  console.error('Error:', err.message)
+  process.exit(1)
+})

--- a/web/app/(main)/billing/billing-client.tsx
+++ b/web/app/(main)/billing/billing-client.tsx
@@ -112,6 +112,36 @@ export default function BillingClient({ plan, subscriptionStatus, hasStripeCusto
     return `$${(cents / 100).toFixed(2)}`
   }
 
+  // Canceled state — re-subscribe CTA
+  if (subscriptionStatus === 'canceled') {
+    return (
+      <div className="space-y-6">
+        <div className="bg-red-500/5 border border-red-500/15 rounded-xl p-6 text-center">
+          <div className="inline-flex items-center gap-1.5 bg-red-500/10 border border-red-500/20 rounded-full px-3 py-1 mb-4">
+            <span className="text-red-400 text-xs font-medium">Subscription canceled</span>
+          </div>
+          <h2 className="text-xl font-bold text-white mb-2">Your subscription has ended</h2>
+          <p className="text-white/40 text-sm mb-2">Your agent has been paused and premium features are disabled.</p>
+          <p className="text-white/30 text-xs mb-6">Your data is safe — re-subscribe to pick up where you left off.</p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-4">
+            <button
+              onClick={() => handleCheckout('base')}
+              className="bg-white/10 hover:bg-white/15 text-white font-semibold px-6 py-2.5 rounded-xl transition-all text-sm w-full sm:w-auto"
+            >
+              Base — $97/mo
+            </button>
+            <button
+              onClick={() => handleCheckout('elite')}
+              className="bg-brand-600 hover:bg-brand-500 text-white font-semibold px-6 py-2.5 rounded-xl transition-all text-sm shadow-lg shadow-brand-900/40 w-full sm:w-auto"
+            >
+              Elite — $197/mo
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
   // Not subscribed state
   if (!hasStripeCustomer || subscriptionStatus === 'inactive') {
     return (
@@ -341,6 +371,13 @@ function StatusBadge({ status, cancelAtPeriodEnd }: { status: string; cancelAtPe
     return (
       <span className="inline-flex items-center gap-1 bg-red-900/30 border border-red-500/40 rounded-full px-2.5 py-0.5 text-[10px] font-medium text-red-300">
         Past Due
+      </span>
+    )
+  }
+  if (status === 'canceled') {
+    return (
+      <span className="inline-flex items-center gap-1 bg-red-900/30 border border-red-500/40 rounded-full px-2.5 py-0.5 text-[10px] font-medium text-red-300">
+        Canceled
       </span>
     )
   }

--- a/web/app/(main)/dashboard/page.tsx
+++ b/web/app/(main)/dashboard/page.tsx
@@ -99,7 +99,7 @@ export default async function Dashboard() {
       .single(),
     supabase
       .from('profiles')
-      .select('subscription_tier, subscription_status')
+      .select('subscription_tier, subscription_status, access_expires_at')
       .eq('id', user.id)
       .single(),
   ])
@@ -110,6 +110,7 @@ export default async function Dashboard() {
   const isSubscribed = subRes.data?.status === 'active'
   const userPlan = (profileRes.data?.subscription_tier || 'base') as 'base' | 'elite'
   const userSubStatus = profileRes.data?.subscription_status || 'inactive'
+  const accessExpiresAt = profileRes.data?.access_expires_at || null
   const userIsElite = userPlan === 'elite' && userSubStatus === 'active'
 
   const rows: DailyRow[] = analyticsRes.data || []
@@ -382,6 +383,47 @@ export default async function Dashboard() {
         <div className="mb-6">
           <AgentStatusBadge initialDevice={device} />
         </div>
+
+        {/* Dunning: grace period warning */}
+        {userSubStatus === 'past_due' && (
+          <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-xl p-4 mb-6">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+              <div>
+                <p className="text-yellow-300 font-semibold text-sm">Payment failed</p>
+                <p className="text-white/40 text-xs mt-0.5">
+                  Your agent is still running{accessExpiresAt ? ` until ${new Date(accessExpiresAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}` : ''}.
+                  Update your payment method to avoid interruption.
+                </p>
+              </div>
+              <a
+                href="/billing"
+                className="text-sm bg-yellow-500/20 hover:bg-yellow-500/30 text-yellow-300 px-4 py-2 rounded-lg transition-colors whitespace-nowrap"
+              >
+                Fix payment
+              </a>
+            </div>
+          </div>
+        )}
+
+        {/* Dunning: canceled state */}
+        {userSubStatus === 'canceled' && (
+          <div className="bg-red-500/10 border border-red-500/20 rounded-xl p-4 mb-6">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+              <div>
+                <p className="text-red-400 font-semibold text-sm">Subscription canceled</p>
+                <p className="text-white/40 text-xs mt-0.5">
+                  Your agent has been paused. Re-subscribe to resume.
+                </p>
+              </div>
+              <a
+                href="/pricing"
+                className="text-sm bg-red-500/20 hover:bg-red-500/30 text-red-300 px-4 py-2 rounded-lg transition-colors whitespace-nowrap"
+              >
+                Re-subscribe
+              </a>
+            </div>
+          </div>
+        )}
 
         <h1 className="font-display text-4xl md:text-5xl text-white uppercase leading-none mb-2">
           HEY {displayName.toUpperCase()}

--- a/web/app/api/stripe/webhook/route.ts
+++ b/web/app/api/stripe/webhook/route.ts
@@ -2,6 +2,8 @@ import type Stripe from 'stripe'
 import { NextRequest, NextResponse } from 'next/server'
 import { stripe } from '@/lib/stripe'
 import { createClient } from '@supabase/supabase-js'
+import { sendEmail } from '@/lib/email'
+import { paymentFailedEmail, subscriptionCanceledEmail } from '@/lib/dunning-emails'
 
 export const runtime = 'nodejs'
 
@@ -104,12 +106,28 @@ export async function POST(request: NextRequest) {
     case 'customer.subscription.deleted': {
       const subscription = event.data.object as Stripe.Subscription
       const customerId = subscription.customer as string
+
+      const { data: canceledProfile } = await supabaseAdmin
+        .from('profiles')
+        .select('id, email')
+        .eq('stripe_customer_id', customerId)
+        .single()
+
       await supabaseAdmin.from('profiles').update({
         subscription_status: 'canceled',
         subscription_tier: 'free',
         access_expires_at: null,
         trial_end: null,
       }).eq('stripe_customer_id', customerId)
+
+      // Send cancellation email
+      if (canceledProfile?.email) {
+        const tpl = subscriptionCanceledEmail()
+        await sendEmail({ to: canceledProfile.email, subject: tpl.subject, html: tpl.html })
+          .catch((err: unknown) => console.error('[BILLING] Failed to send cancellation email:', err))
+      }
+
+      console.log(`[BILLING] Subscription canceled for ${canceledProfile?.email || customerId}`)
       break
     }
 
@@ -133,7 +151,15 @@ export async function POST(request: NextRequest) {
           access_expires_at: graceExpiry.toISOString(),
         }).eq('id', failedProfile.id)
 
-        console.log(`[BILLING] Payment failed for ${failedProfile.email} — access expires ${graceExpiry.toISOString()}`)
+        // Send dunning email with attempt number
+        const attempt = invoice.attempt_count ?? 1
+        if (failedProfile.email) {
+          const tpl = paymentFailedEmail(attempt)
+          await sendEmail({ to: failedProfile.email, subject: tpl.subject, html: tpl.html })
+            .catch((err: unknown) => console.error('[BILLING] Failed to send dunning email:', err))
+        }
+
+        console.log(`[BILLING] Payment failed for ${failedProfile.email} (attempt ${attempt}) — access expires ${graceExpiry.toISOString()}`)
       }
       break
     }

--- a/web/components/plan-badge.tsx
+++ b/web/components/plan-badge.tsx
@@ -22,6 +22,14 @@ export default function PlanBadge({ plan, subscriptionStatus }: PlanBadgeProps) 
     )
   }
 
+  if (subscriptionStatus === 'canceled') {
+    return (
+      <span className="inline-flex items-center gap-1 bg-red-900/30 border border-red-500/40 rounded-full px-2.5 py-0.5 text-[10px] font-medium text-red-300">
+        Canceled
+      </span>
+    )
+  }
+
   if (plan === 'elite') {
     return (
       <span className="inline-flex items-center gap-1 bg-brand-900/40 border border-brand-700/40 rounded-full px-2.5 py-0.5 text-[10px] font-medium text-brand-300">

--- a/web/lib/dunning-emails.ts
+++ b/web/lib/dunning-emails.ts
@@ -1,0 +1,92 @@
+// Dunning email templates for failed payment recovery flow
+// Styled to match existing onboarding email templates (dark theme, violet accent)
+
+const VIOLET = '#8b5cf6'
+const DARK_BG = '#0f0f14'
+const CARD_BG = '#1a1a24'
+const TEXT_COLOR = '#e4e4e7'
+const MUTED = '#a1a1aa'
+const RED = '#ef4444'
+const BILLING_URL = 'https://clapcheeks.tech/billing'
+const PRICING_URL = 'https://clapcheeks.tech/pricing'
+
+function layout(content: string) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:${DARK_BG};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:${DARK_BG};padding:40px 16px;">
+<tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;">
+  <tr><td style="padding:24px 0;text-align:center;">
+    <span style="font-size:28px;font-weight:800;color:${VIOLET};letter-spacing:-0.5px;">Clap Cheeks</span>
+  </td></tr>
+  <tr><td style="background:${CARD_BG};border-radius:12px;padding:32px;color:${TEXT_COLOR};font-size:15px;line-height:1.7;">
+    ${content}
+  </td></tr>
+  <tr><td style="padding:24px 0;text-align:center;color:${MUTED};font-size:12px;">
+    Clap Cheeks &mdash; AI Dating Co-Pilot<br>
+    <a href="https://clapcheeks.tech" style="color:${MUTED};text-decoration:underline;">clapcheeks.tech</a>
+  </td></tr>
+</table>
+</td></tr>
+</table>
+</body></html>`
+}
+
+function button(text: string, href: string, color = VIOLET) {
+  return `<table cellpadding="0" cellspacing="0" style="margin:24px 0;"><tr><td>
+    <a href="${href}" style="display:inline-block;background:${color};color:#fff;font-weight:600;font-size:15px;padding:12px 28px;border-radius:8px;text-decoration:none;">${text}</a>
+  </td></tr></table>`
+}
+
+/**
+ * Email sent on each failed payment attempt.
+ * attempt: 1-based attempt number from Stripe invoice.attempt_count
+ */
+export function paymentFailedEmail(attempt: number) {
+  const isFirst = attempt <= 1
+  const isLast = attempt >= 3
+
+  const urgency = isFirst
+    ? 'We had trouble processing your payment.'
+    : isLast
+      ? 'This is the final attempt to process your payment.'
+      : `We tried to charge your card again, but it didn't go through (attempt ${attempt} of 3).`
+
+  const consequence = isLast
+    ? `<p style="color:${RED};font-weight:600;">If we can't collect payment, your subscription will be canceled and your agent will stop running.</p>`
+    : `<p style="color:${MUTED};">Your agent is still running, but if the issue isn't resolved your subscription will be canceled.</p>`
+
+  return {
+    subject: isFirst
+      ? 'Your Clap Cheeks payment failed'
+      : isLast
+        ? 'Final notice: update your payment to keep your agent running'
+        : 'Reminder: your Clap Cheeks payment is past due',
+    html: layout(`
+      <h2 style="margin:0 0 16px;color:#fff;font-size:22px;">Payment failed</h2>
+      <p style="color:${TEXT_COLOR};">${urgency}</p>
+      ${consequence}
+      <p style="color:${TEXT_COLOR};">The most common fix is to update your card on file:</p>
+      ${button('Update Payment Method', BILLING_URL)}
+      <p style="color:${MUTED};font-size:13px;">If your card details are correct, contact your bank to authorize the charge. You can also retry the payment from your <a href="${BILLING_URL}" style="color:${VIOLET};">billing page</a>.</p>
+    `),
+  }
+}
+
+/**
+ * Email sent when subscription is canceled after all retries failed.
+ */
+export function subscriptionCanceledEmail() {
+  return {
+    subject: 'Your Clap Cheeks subscription has been canceled',
+    html: layout(`
+      <h2 style="margin:0 0 16px;color:#fff;font-size:22px;">Your subscription has been canceled</h2>
+      <p style="color:${TEXT_COLOR};">After multiple payment attempts, we weren't able to process your payment. Your subscription has been canceled and your agent has been paused.</p>
+      <p style="color:${TEXT_COLOR};">Your data is safe &mdash; you can re-subscribe at any time to pick up where you left off.</p>
+      ${button('Re-subscribe', PRICING_URL)}
+      <p style="color:${MUTED};font-size:13px;">If this was a mistake or you need help, just reply to this email.</p>
+    `),
+  }
+}

--- a/web/lib/email.ts
+++ b/web/lib/email.ts
@@ -1,0 +1,27 @@
+// Minimal Resend email sender for Next.js API routes
+// Mirrors api/email/resend.js for use within the web app
+
+export async function sendEmail({
+  to,
+  subject,
+  html,
+}: {
+  to: string
+  subject: string
+  html: string
+}) {
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: 'Clap Cheeks <hello@clapcheeks.tech>',
+      to,
+      subject,
+      html,
+    }),
+  })
+  return res.json()
+}


### PR DESCRIPTION
Closes PERS-222

## Summary

- **Dunning emails on payment failure**: Webhook sends escalating emails via Resend on each `invoice.payment_failed` event (attempt 1/2/3)
- **Cancellation email**: Sends email when subscription is canceled after all retries fail (`customer.subscription.deleted`)
- **Canceled state on /billing**: Dedicated UI with re-subscribe CTA (Base/Elite buttons)
- **Grace period warning on dashboard**: Yellow banner when payment is past_due, with countdown to access expiry
- **Canceled banner on dashboard**: Red banner with re-subscribe link when subscription is canceled
- **Plan badge updated**: PlanBadge component shows "Canceled" state
- **Stripe test clock script**: `scripts/test-dunning-flow.mjs` simulates the full dunning flow

## New Files

- `web/lib/email.ts` — Resend email sender for Next.js API routes
- `web/lib/dunning-emails.ts` — Payment failed + subscription canceled email templates
- `scripts/test-dunning-flow.mjs` — Stripe test clock dunning simulation

## Fix

Previous PR #9 was created from wrong branch (`pers-215` instead of `pers-222`). This PR is from the correct branch with the actual dunning flow changes.

## Test plan

- [ ] Build compiles clean (`npx next build`)
- [ ] Set `subscription_status = 'past_due'` in profiles → verify yellow warning banner on dashboard
- [ ] Set `subscription_status = 'canceled'` → verify red canceled banner + billing re-subscribe CTA
- [ ] Run `STRIPE_SECRET_KEY=sk_test_... node scripts/test-dunning-flow.mjs` to simulate full flow

Linear: https://linear.app/ai-acrobatics/issue/PERS-222/implement-failed-payment-recovery-dunning-flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)