### PR TITLE
Phase D: /dashboard/matches grid + detail

### DIFF
--- a/web/app/(main)/dashboard/matches/[id]/page.tsx
+++ b/web/app/(main)/dashboard/matches/[id]/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from 'next'
+import { redirect, notFound } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import MatchDetail from '@/components/matches/MatchDetail'
+import {
+  ClapcheeksMatchRow,
+  ConversationMessage,
+} from '@/lib/matches/types'
+
+export const metadata: Metadata = {
+  title: 'Match Detail — Clapcheeks',
+}
+
+type RouteParams = { id: string }
+
+// Loose raw-message shape from clapcheeks_conversations.messages JSON.
+type RawMsg = {
+  id?: string
+  direction?: 'incoming' | 'outgoing'
+  from?: 'her' | 'you' | 'me' | string
+  body?: string
+  text?: string
+  message?: string
+  sent_at?: string
+  created_at?: string
+  timestamp?: string
+}
+
+function normalizeMessage(m: RawMsg, fallbackIndex: number): ConversationMessage {
+  const dir: 'incoming' | 'outgoing' =
+    m.direction === 'outgoing' || m.from === 'you' || m.from === 'me'
+      ? 'outgoing'
+      : 'incoming'
+  return {
+    id: m.id ?? `msg-${fallbackIndex}`,
+    direction: dir,
+    body: m.body ?? m.text ?? m.message ?? '',
+    sent_at: m.sent_at ?? m.created_at ?? m.timestamp ?? new Date().toISOString(),
+  }
+}
+
+export default async function MatchDetailPage({
+  params,
+}: {
+  params: Promise<RouteParams>
+}) {
+  const { id } = await params
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  let match: ClapcheeksMatchRow | null = null
+  let fetchError: string | null = null
+  try {
+    const { data, error } = await (supabase as any)
+      .from('clapcheeks_matches')
+      .select('*')
+      .eq('user_id', user.id)
+      .eq('id', id)
+      .maybeSingle()
+    if (error) fetchError = error.message
+    match = (data as ClapcheeksMatchRow) ?? null
+  } catch (e) {
+    fetchError = (e as Error).message
+  }
+
+  if (!match) {
+    if (fetchError) {
+      return (
+        <div className="min-h-screen bg-black text-white px-6 py-10">
+          <div className="max-w-2xl mx-auto bg-amber-500/10 border border-amber-500/30 rounded-lg p-5 text-sm text-amber-200 font-mono">
+            Could not load match {id}. Error: {fetchError}. The clapcheeks_matches table may not exist yet — Phase A (AI-8315) owns its migration.
+          </div>
+        </div>
+      )
+    }
+    notFound()
+  }
+
+  // Pull conversation messages if clapcheeks_conversations has a row for this match.
+  let messages: ConversationMessage[] = []
+  try {
+    if (match.external_id) {
+      const { data: conv } = await supabase
+        .from('clapcheeks_conversations')
+        .select('messages')
+        .eq('user_id', user.id)
+        .eq('match_id', match.external_id)
+        .maybeSingle()
+      const raw: RawMsg[] = Array.isArray(conv?.messages) ? (conv!.messages as RawMsg[]) : []
+      messages = raw.map(normalizeMessage)
+    }
+  } catch {
+    // optional — detail still renders without convo
+  }
+
+  // Cluster-risk detection is owned by the scoring engine — here we just surface
+  // it if match_intel.cluster_risk is set by upstream.
+  const clusterRisk =
+    typeof (match.match_intel as Record<string, unknown> | null)?.['cluster_risk'] === 'boolean'
+      ? Boolean((match.match_intel as Record<string, unknown>)['cluster_risk'])
+      : false
+
+  return <MatchDetail match={match} messages={messages} clusterRisk={clusterRisk} />
+}

--- a/web/app/(main)/dashboard/matches/page.tsx
+++ b/web/app/(main)/dashboard/matches/page.tsx
@@ -1,0 +1,120 @@
+import type { Metadata } from 'next'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { createClient } from '@/lib/supabase/server'
+import MatchGrid from '@/components/matches/MatchGrid'
+import { ClapcheeksMatchRow } from '@/lib/matches/types'
+
+export const metadata: Metadata = {
+  title: 'Matches — Clapcheeks',
+  description: 'Every match across every platform, ranked and ready to action.',
+}
+
+const PAGE_SIZE = 30
+
+// `clapcheeks_matches` may not be in the generated Database type yet —
+// use a loose cast so the page still builds while Phase A is in flight.
+type ConvoLite = {
+  match_id: string
+  last_message: string | null
+  last_message_at: string | null
+}
+
+export default async function MatchesPage() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/login')
+
+  // Fetch matches. If the table doesn't exist yet (Phase A not landed),
+  // swallow the error and render the empty state.
+  let matches: ClapcheeksMatchRow[] = []
+  let hasMore = false
+  let fetchError: string | null = null
+  try {
+    const { data, error } = await (supabase as any)
+      .from('clapcheeks_matches')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('final_score', { ascending: false, nullsFirst: false })
+      .order('last_activity_at', { ascending: false, nullsFirst: false })
+      .range(0, PAGE_SIZE - 1)
+    if (error) {
+      fetchError = error.message
+    } else if (data) {
+      matches = data as ClapcheeksMatchRow[]
+      hasMore = data.length >= PAGE_SIZE
+    }
+  } catch (e) {
+    fetchError = (e as Error).message
+  }
+
+  // Best-effort last-message pull.
+  const lastMessages: Record<string, string | null> = {}
+  if (matches.length > 0) {
+    try {
+      const matchIds = matches
+        .map((m) => m.external_id)
+        .filter((x): x is string => !!x)
+      if (matchIds.length > 0) {
+        const { data } = await supabase
+          .from('clapcheeks_conversations')
+          .select('match_id, last_message, last_message_at')
+          .eq('user_id', user.id)
+          .in('match_id', matchIds)
+        const map = new Map<string, ConvoLite>()
+        for (const row of (data ?? []) as ConvoLite[]) {
+          map.set(row.match_id, row)
+        }
+        for (const m of matches) {
+          const c = m.external_id ? map.get(m.external_id) : undefined
+          lastMessages[m.id] = c?.last_message ?? null
+        }
+      }
+    } catch {
+      // non-fatal — last-message preview is optional
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-black px-4 md:px-6 py-6 md:py-8">
+      <div className="relative max-w-7xl mx-auto">
+        <div className="flex items-center justify-between gap-3 flex-wrap mb-2">
+          <div>
+            <div className="flex items-center gap-3 mb-1">
+              <h1 className="font-display text-3xl md:text-4xl uppercase tracking-wide gold-text">
+                Matches
+              </h1>
+              <span className="font-mono text-[10px] uppercase tracking-widest text-white/30 bg-white/5 px-2 py-0.5 rounded border border-white/10">
+                phase d
+              </span>
+            </div>
+            <p className="text-white/50 text-sm">
+              Every match, ranked by score and recency. Click a card to drill in.
+            </p>
+          </div>
+          <Link
+            href="/dashboard"
+            className="text-white/40 hover:text-white/70 text-xs font-mono bg-white/5 hover:bg-white/10 border border-white/10 px-3 py-1.5 rounded-lg transition-all"
+          >
+            ← Dashboard
+          </Link>
+        </div>
+
+        {fetchError && (
+          <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-3 my-4 text-xs text-amber-300 font-mono">
+            Matches table error: {fetchError}. Phase A (match intake) may not have run its migration yet.
+          </div>
+        )}
+
+        <div className="mt-6">
+          <MatchGrid
+            initialMatches={matches}
+            initialHasMore={hasMore}
+            initialLastMessages={lastMessages}
+            pageSize={PAGE_SIZE}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/app/(main)/dashboard/page.tsx
+++ b/web/app/(main)/dashboard/page.tsx
@@ -331,6 +331,12 @@ export default async function Dashboard() {
               <span className="text-white/30 text-xs hidden sm:block">{user.email}</span>
             )}
             <Link
+              href="/dashboard/matches"
+              className="text-white/70 hover:text-white text-xs bg-yellow-500/10 hover:bg-yellow-500/20 border border-yellow-500/30 px-3 py-1.5 rounded-lg transition-all font-semibold"
+            >
+              Matches
+            </Link>
+            <Link
               href="/photos"
               className="text-white/40 hover:text-white/70 text-xs bg-white/5 hover:bg-white/10 border border-white/10 px-3 py-1.5 rounded-lg transition-all"
             >

--- a/web/app/api/agent/sync-matches/route.ts
+++ b/web/app/api/agent/sync-matches/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+/**
+ * Phase D stub — triggers the Phase A match-intake daemon.
+ *
+ * Phase A (AI-8315) owns the actual daemon wiring. Until then this endpoint
+ * 1. Verifies the user is authenticated
+ * 2. Logs the sync request
+ * 3. Returns 202 Accepted
+ *
+ * When Phase A lands, swap the console.log for the real trigger (e.g. post
+ * to the agent's command queue or publish a Supabase realtime event).
+ */
+export async function POST() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // eslint-disable-next-line no-console
+  console.log('[sync-matches] sync requested', {
+    user_id: user.id,
+    ts: new Date().toISOString(),
+  })
+
+  return NextResponse.json(
+    {
+      ok: true,
+      message: 'Sync requested. Phase A daemon will process on its next tick.',
+      phase: 'D-stub',
+    },
+    { status: 202 },
+  )
+}

--- a/web/app/dashboard-demo/page.tsx
+++ b/web/app/dashboard-demo/page.tsx
@@ -1,0 +1,264 @@
+import { notFound } from 'next/navigation'
+import MatchGrid from '@/components/matches/MatchGrid'
+import MatchDetail from '@/components/matches/MatchDetail'
+import { ClapcheeksMatchRow, ConversationMessage } from '@/lib/matches/types'
+
+/**
+ * Public demo preview for Phase D screenshots. Only renders when
+ * NEXT_PUBLIC_ENABLE_MATCH_DEMO=1. This is a dev-only preview — it does NOT
+ * hit Supabase and has no auth gate, so it must stay disabled in production.
+ */
+export const dynamic = 'force-dynamic'
+
+const DEMO_USER = '00000000-0000-0000-0000-000000000000'
+const NOW = new Date()
+
+const DEMO_MATCHES: ClapcheeksMatchRow[] = [
+  {
+    id: 'demo-1',
+    user_id: DEMO_USER,
+    platform: 'hinge',
+    external_id: 'demo-hinge-001',
+    name: 'Sofia',
+    age: 27,
+    bio: 'Barre instructor by day. Matcha enthusiast. Ask me about my dog.',
+    photos_jsonb: [
+      { url: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=800' },
+      { url: 'https://images.unsplash.com/photo-1531123897727-8f129e1688ce?w=800' },
+      { url: 'https://images.unsplash.com/photo-1517841905240-472988babdf9?w=800' },
+    ],
+    prompts_jsonb: [
+      { question: 'My simple pleasures', answer: 'Espresso, vinyl, and winning arguments.' },
+      { question: 'Two truths and a lie', answer: 'Ran a marathon; allergic to cilantro; played in a punk band.' },
+    ],
+    job: 'Pilates instructor',
+    school: 'UCSD',
+    instagram_handle: 'sofia.moves',
+    spotify_artists: ['Faye Webster', 'Phoebe Bridgers', 'Mac Demarco'],
+    birth_date: null,
+    zodiac: 'Libra',
+    match_intel: {
+      summary: 'High-energy, creative.',
+      green_flags: ['Replies within 2h consistently', 'Uses complete sentences'],
+      red_flags: [],
+    },
+    vision_summary:
+      'Balanced photo set: two portraits, one group shot, one activity. Warm outdoor lighting. Genuine smile in primary.',
+    instagram_intel: {
+      summary: 'Active (posts 3x/week). Fitness and cafe culture. Low red flags.',
+      handle: 'sofia.moves',
+    },
+    status: 'conversing',
+    last_activity_at: new Date(NOW.getTime() - 42 * 60 * 1000).toISOString(),
+    created_at: NOW.toISOString(),
+    updated_at: NOW.toISOString(),
+    final_score: 87,
+    location_score: 92,
+    criteria_score: 83,
+    scoring_reason: 'Lives within 5 miles. Hits 4 of 5 criteria: fitness, creative career, pets, non-smoker.',
+    julian_rank: 8,
+    is_demo: true,
+  },
+  {
+    id: 'demo-2',
+    user_id: DEMO_USER,
+    platform: 'tinder',
+    external_id: 'demo-tinder-002',
+    name: 'Marisol',
+    age: 24,
+    bio: 'Architect. Travel junkie.',
+    photos_jsonb: [
+      { url: 'https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=800' },
+    ],
+    prompts_jsonb: null,
+    job: 'Architect',
+    school: null,
+    instagram_handle: null,
+    spotify_artists: ['Caamp'],
+    birth_date: null,
+    zodiac: 'Gemini',
+    match_intel: null,
+    vision_summary: null,
+    instagram_intel: null,
+    status: 'new',
+    last_activity_at: new Date(NOW.getTime() - 3 * 60 * 60 * 1000).toISOString(),
+    created_at: NOW.toISOString(),
+    updated_at: NOW.toISOString(),
+    final_score: 72,
+    location_score: 85,
+    criteria_score: 60,
+    scoring_reason: 'Good location, only hits 2 of 5 criteria.',
+    julian_rank: null,
+    is_demo: true,
+  },
+  {
+    id: 'demo-3',
+    user_id: DEMO_USER,
+    platform: 'hinge',
+    external_id: 'demo-hinge-003',
+    name: 'Talia',
+    age: 29,
+    bio: 'PT. Runner. Reader of weird fiction.',
+    photos_jsonb: [
+      { url: 'https://images.unsplash.com/photo-1521146764736-56c929d59c83?w=800' },
+      { url: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?w=800' },
+    ],
+    prompts_jsonb: [
+      { question: "I'm weirdly attracted to", answer: 'People who over-explain the plot of a movie.' },
+    ],
+    job: 'Physical therapist',
+    school: 'SDSU',
+    instagram_handle: 'talia.runs',
+    spotify_artists: ['Big Thief', 'Soccer Mommy'],
+    birth_date: null,
+    zodiac: 'Virgo',
+    match_intel: {
+      summary: 'Independent, witty.',
+      green_flags: ['Outdoorsy', 'Shared music taste'],
+      red_flags: [],
+    },
+    vision_summary: 'All daytime outdoor shots. Strong eye contact in primary.',
+    instagram_intel: {
+      summary: 'Moderate (posts weekly). Running, books, beach. Consistent aesthetic.',
+      handle: 'talia.runs',
+    },
+    status: 'date_proposed',
+    last_activity_at: new Date(NOW.getTime() - 18 * 60 * 60 * 1000).toISOString(),
+    created_at: NOW.toISOString(),
+    updated_at: NOW.toISOString(),
+    final_score: 91,
+    location_score: 95,
+    criteria_score: 88,
+    scoring_reason: 'Top match. Lives 2 miles away, hits 5 of 5 criteria.',
+    julian_rank: 9,
+    is_demo: true,
+  },
+  {
+    id: 'demo-4',
+    user_id: DEMO_USER,
+    platform: 'bumble',
+    external_id: 'demo-bumble-004',
+    name: 'Priya',
+    age: 26,
+    bio: 'Grad student. Climbing. Slow mornings.',
+    photos_jsonb: [
+      { url: 'https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?w=800' },
+    ],
+    prompts_jsonb: null,
+    job: 'PhD student',
+    school: 'UCSD',
+    instagram_handle: null,
+    spotify_artists: [],
+    birth_date: null,
+    zodiac: null,
+    match_intel: null,
+    vision_summary: null,
+    instagram_intel: null,
+    status: 'stalled',
+    last_activity_at: new Date(NOW.getTime() - 6 * 24 * 60 * 60 * 1000).toISOString(),
+    created_at: NOW.toISOString(),
+    updated_at: NOW.toISOString(),
+    final_score: 54,
+    location_score: 70,
+    criteria_score: 45,
+    scoring_reason: 'Minimal bio. Stalled after 3 exchanges.',
+    julian_rank: null,
+    is_demo: true,
+  },
+  {
+    id: 'demo-5',
+    user_id: DEMO_USER,
+    platform: 'offline',
+    external_id: 'demo-offline-005',
+    name: 'Elena',
+    age: 28,
+    bio: 'Met at the Mission Beach Pilates studio.',
+    photos_jsonb: [
+      { url: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?w=800' },
+      { url: 'https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=800' },
+    ],
+    prompts_jsonb: null,
+    job: 'Pilates instructor',
+    school: null,
+    instagram_handle: 'elena.flows',
+    spotify_artists: [],
+    birth_date: null,
+    zodiac: 'Taurus',
+    match_intel: {
+      summary: 'In-person intro; highest trust signal.',
+      green_flags: ['Met IRL', 'Gave number unprompted'],
+      red_flags: [],
+    },
+    vision_summary: 'Two photos total, both candid. High authenticity signal.',
+    instagram_intel: { summary: 'Private account.' },
+    status: 'date_booked',
+    last_activity_at: new Date(NOW.getTime() - 8 * 60 * 1000).toISOString(),
+    created_at: NOW.toISOString(),
+    updated_at: NOW.toISOString(),
+    final_score: 95,
+    location_score: 100,
+    criteria_score: 93,
+    scoring_reason: 'Met offline — highest-trust channel. Top criteria match. Booked for Thursday.',
+    julian_rank: 10,
+    is_demo: true,
+  },
+]
+
+const DEMO_MESSAGES: ConversationMessage[] = [
+  { id: 'm1', direction: 'outgoing', body: 'Espresso, vinyl, or winning arguments — which one do we start with?', sent_at: new Date(NOW.getTime() - 5 * 60 * 60 * 1000).toISOString() },
+  { id: 'm2', direction: 'incoming', body: 'Haha okay I respect the callback. Espresso first, arguments after caffeine lands.', sent_at: new Date(NOW.getTime() - 4 * 60 * 60 * 1000).toISOString() },
+  { id: 'm3', direction: 'outgoing', body: 'Deal. You have a favorite spot or should I pick?', sent_at: new Date(NOW.getTime() - 42 * 60 * 1000).toISOString() },
+]
+
+export default async function DashboardDemo({ searchParams }: { searchParams: Promise<{ view?: string; id?: string }> }) {
+  if (process.env.NEXT_PUBLIC_ENABLE_MATCH_DEMO !== '1') notFound()
+  const sp = await searchParams
+  const view = sp.view ?? 'grid'
+  const id = sp.id ?? 'demo-1'
+
+  if (view === 'detail') {
+    const match = DEMO_MATCHES.find((m) => m.id === id) ?? DEMO_MATCHES[0]
+    return <MatchDetail match={match} messages={DEMO_MESSAGES} clusterRisk={false} />
+  }
+  if (view === 'empty') {
+    return (
+      <div className="min-h-screen bg-black px-4 md:px-6 py-6 md:py-8">
+        <div className="relative max-w-7xl mx-auto">
+          <h1 className="font-display text-3xl md:text-4xl uppercase tracking-wide gold-text mb-2">
+            Matches
+          </h1>
+          <p className="text-white/50 text-sm mb-6">Every match, ranked by score and recency.</p>
+          <MatchGrid
+            initialMatches={[]}
+            initialHasMore={false}
+            initialLastMessages={{}}
+            pageSize={30}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-black px-4 md:px-6 py-6 md:py-8">
+      <div className="relative max-w-7xl mx-auto">
+        <h1 className="font-display text-3xl md:text-4xl uppercase tracking-wide gold-text mb-2">
+          Matches (demo)
+        </h1>
+        <p className="text-white/50 text-sm mb-6">
+          Public preview for Phase D screenshots — real data lives at /dashboard/matches.
+        </p>
+        <MatchGrid
+          initialMatches={DEMO_MATCHES}
+          initialHasMore={false}
+          initialLastMessages={{
+            'demo-1': 'Haha okay I respect the callback. Espresso first, arguments after caffeine lands.',
+            'demo-3': 'Thursday works. 7pm? The place on Adams?',
+            'demo-5': 'See you Thursday!',
+          }}
+          pageSize={30}
+        />
+      </div>
+    </div>
+  )
+}

--- a/web/components/layout/app-sidebar.tsx
+++ b/web/components/layout/app-sidebar.tsx
@@ -15,6 +15,7 @@ type NavItem = {
 
 const PRIMARY: NavItem[] = [
   { href: '/dashboard', label: 'Dashboard', icon: <HomeIcon /> },
+  { href: '/dashboard/matches', label: 'Matches', icon: <HeartIcon /> },
   { href: '/leads', label: 'Leads', icon: <PipelineIcon /> },
   { href: '/conversation', label: 'Conversations', icon: <ChatIcon /> },
   { href: '/intelligence', label: 'Intelligence', icon: <SparkIcon /> },
@@ -44,6 +45,9 @@ export default function AppSidebar() {
 
   function isActive(href: string) {
     if (href === '/') return pathname === '/'
+    // Exact dashboard match only — otherwise /dashboard/matches would also
+    // activate the Dashboard nav item.
+    if (href === '/dashboard') return pathname === '/dashboard'
     return pathname === href || pathname.startsWith(`${href}/`)
   }
 
@@ -203,6 +207,7 @@ const IconBase = (d: string) => (
   </svg>
 )
 function HomeIcon()     { return IconBase('M3 10l9-7 9 7v11a2 2 0 0 1-2 2h-4v-7h-6v7H5a2 2 0 0 1-2-2V10z') }
+function HeartIcon()    { return IconBase('M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z') }
 function PipelineIcon() { return IconBase('M3 6h6v4H3zM9 12h6v4H9zM15 18h6v-4h-6z M9 10v2 M15 16v-2') }
 function ChatIcon()     { return IconBase('M21 11.5a8.38 8.38 0 0 1-8.5 8.5 8.5 8.5 0 0 1-3.6-.8L3 21l1.9-5.6A8.5 8.5 0 1 1 21 11.5z') }
 function SparkIcon()    { return IconBase('M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83') }

--- a/web/components/matches/ConversationThread.tsx
+++ b/web/components/matches/ConversationThread.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { ConversationMessage, formatTimeAgo } from '@/lib/matches/types'
+
+type Props = {
+  messages: ConversationMessage[]
+  matchName?: string | null
+}
+
+export default function ConversationThread({ messages, matchName }: Props) {
+  if (!messages || messages.length === 0) {
+    return (
+      <div className="bg-white/[0.03] border border-white/10 rounded-xl p-6 text-center">
+        <p className="text-white/40 text-sm">No conversation yet.</p>
+        <p className="text-white/25 text-xs mt-1">
+          Messages will appear here once the agent logs outbound or incoming replies.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white/[0.03] border border-white/10 rounded-xl p-4 space-y-3 max-h-[600px] overflow-y-auto">
+      {messages.map((msg, i) => {
+        const isOut = msg.direction === 'outgoing'
+        return (
+          <div
+            key={msg.id ?? i}
+            className={`flex ${isOut ? 'justify-end' : 'justify-start'}`}
+          >
+            <div
+              className={`max-w-[80%] rounded-2xl px-3.5 py-2 text-sm ${
+                isOut
+                  ? 'bg-gradient-to-br from-yellow-500/90 to-red-600/80 text-black font-medium rounded-br-sm'
+                  : 'bg-white/10 text-white/90 rounded-bl-sm'
+              }`}
+            >
+              <div className="whitespace-pre-wrap break-words">{msg.body}</div>
+              <div
+                className={`text-[10px] mt-1 font-mono ${
+                  isOut ? 'text-black/50' : 'text-white/40'
+                }`}
+              >
+                {isOut ? 'You' : matchName ?? 'Her'} · {formatTimeAgo(msg.sent_at)}
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/web/components/matches/FilterBar.tsx
+++ b/web/components/matches/FilterBar.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import {
+  MatchListFilters,
+  PLATFORM_OPTIONS,
+  STATUS_OPTIONS,
+} from '@/lib/matches/types'
+
+type Props = {
+  filters: MatchListFilters
+  onChange: (next: MatchListFilters) => void
+  total: number
+  filteredCount: number
+}
+
+export default function FilterBar({ filters, onChange, total, filteredCount }: Props) {
+  return (
+    <div className="bg-white/[0.03] border border-white/10 rounded-xl p-4 mb-6">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 flex-1">
+          <div className="flex flex-col gap-1">
+            <label className="text-[10px] uppercase tracking-wider font-mono text-white/40">
+              Platform
+            </label>
+            <div className="flex gap-1 flex-wrap">
+              {PLATFORM_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => onChange({ ...filters, platform: opt.value })}
+                  className={`text-xs px-2.5 py-1 rounded border transition-all ${
+                    filters.platform === opt.value
+                      ? 'bg-yellow-500/20 text-yellow-300 border-yellow-500/40'
+                      : 'bg-white/5 text-white/60 border-white/10 hover:bg-white/10'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex flex-col gap-1 flex-1">
+            <label className="text-[10px] uppercase tracking-wider font-mono text-white/40">
+              Status
+            </label>
+            <div className="flex gap-1 flex-wrap">
+              {STATUS_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => onChange({ ...filters, status: opt.value })}
+                  className={`text-xs px-2.5 py-1 rounded border transition-all ${
+                    filters.status === opt.value
+                      ? 'bg-yellow-500/20 text-yellow-300 border-yellow-500/40'
+                      : 'bg-white/5 text-white/60 border-white/10 hover:bg-white/10'
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col gap-1 min-w-[200px]">
+          <label className="text-[10px] uppercase tracking-wider font-mono text-white/40 flex justify-between">
+            <span>Min score</span>
+            <span className="text-yellow-400 font-bold">{filters.minScore}</span>
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={filters.minScore}
+            onChange={(e) =>
+              onChange({ ...filters, minScore: Number(e.target.value) })
+            }
+            className="w-full accent-yellow-500"
+          />
+        </div>
+      </div>
+      <div className="mt-3 flex items-center justify-between text-[11px] text-white/40 font-mono">
+        <span>
+          Showing <span className="text-white/70">{filteredCount}</span> of {total}
+        </span>
+        {(filters.platform !== 'all' ||
+          filters.status !== 'all' ||
+          filters.minScore > 0) && (
+          <button
+            type="button"
+            onClick={() =>
+              onChange({ platform: 'all', status: 'all', minScore: 0 })
+            }
+            className="text-yellow-400/80 hover:text-yellow-300 underline underline-offset-2"
+          >
+            Reset
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/components/matches/MatchCard.tsx
+++ b/web/components/matches/MatchCard.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import Link from 'next/link'
+import {
+  ClapcheeksMatchRow,
+  PLATFORM_COLORS,
+  STATUS_COLORS,
+  formatTimeAgo,
+} from '@/lib/matches/types'
+
+type Props = {
+  match: ClapcheeksMatchRow
+  lastMessage?: string | null
+}
+
+export default function MatchCard({ match, lastMessage }: Props) {
+  const primaryPhoto = match.photos_jsonb?.[0]?.url ?? null
+  const initials = (match.name ?? '?').slice(0, 1).toUpperCase()
+  const score = typeof match.final_score === 'number' ? Math.round(match.final_score) : null
+
+  return (
+    <Link
+      href={`/dashboard/matches/${match.id}`}
+      className="group block bg-white/[0.03] border border-white/10 rounded-xl overflow-hidden hover:border-yellow-500/40 hover:bg-white/[0.05] transition-all"
+    >
+      <div className="relative aspect-[3/4] w-full bg-gradient-to-br from-zinc-800 to-zinc-900 overflow-hidden">
+        {primaryPhoto ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={primaryPhoto}
+            alt={match.name ?? 'Match'}
+            className="w-full h-full object-cover group-hover:scale-[1.02] transition-transform"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-white/30 text-5xl font-bold">
+            {initials}
+          </div>
+        )}
+        {score !== null && (
+          <div className="absolute top-2 left-2 bg-black/70 backdrop-blur border border-yellow-500/40 rounded-md px-2 py-0.5 text-[11px] font-mono font-bold text-yellow-400">
+            {score}
+          </div>
+        )}
+        <div className="absolute top-2 right-2 flex flex-col items-end gap-1">
+          <span
+            className={`text-[10px] uppercase tracking-wider font-mono font-bold px-2 py-0.5 rounded border ${PLATFORM_COLORS[match.platform]}`}
+          >
+            {match.platform}
+          </span>
+        </div>
+        <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/90 to-transparent p-3">
+          <div className="flex items-baseline gap-1.5">
+            <span className="text-white font-semibold text-sm truncate">
+              {match.name ?? 'Unknown'}
+            </span>
+            {match.age && <span className="text-white/70 text-sm">{match.age}</span>}
+          </div>
+        </div>
+      </div>
+      <div className="p-3">
+        <div className="flex items-center justify-between gap-2 mb-2">
+          <span
+            className={`text-[10px] uppercase tracking-wider font-mono font-semibold px-2 py-0.5 rounded border ${STATUS_COLORS[match.status] ?? STATUS_COLORS.new}`}
+          >
+            {match.status.replace('_', ' ')}
+          </span>
+          <span className="text-[10px] text-white/40 font-mono">
+            {formatTimeAgo(match.last_activity_at ?? match.updated_at)}
+          </span>
+        </div>
+        {lastMessage ? (
+          <p className="text-xs text-white/50 line-clamp-2 leading-snug">{lastMessage}</p>
+        ) : (
+          <p className="text-xs text-white/25 italic">No conversation yet</p>
+        )}
+      </div>
+    </Link>
+  )
+}

--- a/web/components/matches/MatchDetail.tsx
+++ b/web/components/matches/MatchDetail.tsx
@@ -1,0 +1,363 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { createClient } from '@/lib/supabase/client'
+import {
+  ClapcheeksMatchRow,
+  ConversationMessage,
+  MatchStatus,
+  PLATFORM_COLORS,
+  STATUS_COLORS,
+  formatTimeAgo,
+} from '@/lib/matches/types'
+import PhotoGallery from './PhotoGallery'
+import ScoringPanel from './ScoringPanel'
+import ConversationThread from './ConversationThread'
+
+type Props = {
+  match: ClapcheeksMatchRow
+  messages: ConversationMessage[]
+  clusterRisk?: boolean
+}
+
+const ACTIONABLE_STATUSES: Array<{ key: MatchStatus; label: string }> = [
+  { key: 'date_booked', label: 'Schedule date' },
+  { key: 'dated', label: 'Mark dated' },
+  { key: 'stalled', label: 'Send re-engage' },
+  { key: 'ghosted', label: 'Archive' },
+]
+
+export default function MatchDetail({ match, messages, clusterRisk }: Props) {
+  const [current, setCurrent] = useState(match)
+  const [rank, setRank] = useState<number>(match.julian_rank ?? 5)
+  const [rankSaving, setRankSaving] = useState(false)
+  const [rankError, setRankError] = useState<string | null>(null)
+  const [proceedRisk, setProceedRisk] = useState(false)
+  const [statusBusy, setStatusBusy] = useState<MatchStatus | null>(null)
+
+  const visionSummary = match.vision_summary ?? null
+  const instagramSummary = match.instagram_intel?.summary ?? null
+
+  async function updateStatus(next: MatchStatus) {
+    setStatusBusy(next)
+    try {
+      const supabase = createClient()
+      const { error } = await supabase
+        .from('clapcheeks_matches')
+        .update({ status: next, updated_at: new Date().toISOString() })
+        .eq('id', current.id)
+      if (!error) {
+        setCurrent((prev) => ({ ...prev, status: next }))
+      } else {
+        console.warn('[MatchDetail] status update failed:', error.message)
+      }
+    } finally {
+      setStatusBusy(null)
+    }
+  }
+
+  async function saveRank(newRank: number) {
+    setRankSaving(true)
+    setRankError(null)
+    try {
+      const supabase = createClient()
+      // julian_rank column may not exist yet — handle gracefully.
+      const { error } = await supabase
+        .from('clapcheeks_matches')
+        .update({ julian_rank: newRank })
+        .eq('id', current.id)
+      if (error) {
+        setRankError('julian_rank column not yet deployed — Phase A will add it.')
+      }
+    } catch (e) {
+      setRankError('Network error saving rank.')
+    } finally {
+      setRankSaving(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-black text-white px-4 md:px-6 py-6 md:py-8">
+      <div className="max-w-6xl mx-auto">
+        {/* Back link */}
+        <div className="mb-4">
+          <Link
+            href="/dashboard/matches"
+            className="inline-flex items-center gap-2 text-xs text-white/50 hover:text-white font-mono"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M15 18l-6-6 6-6" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            Back to matches
+          </Link>
+        </div>
+
+        {/* Header */}
+        <div className="mb-6 flex flex-col md:flex-row md:items-end md:justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2 flex-wrap mb-1">
+              <span
+                className={`text-[10px] uppercase tracking-wider font-mono font-bold px-2 py-0.5 rounded border ${PLATFORM_COLORS[current.platform]}`}
+              >
+                {current.platform}
+              </span>
+              <span
+                className={`text-[10px] uppercase tracking-wider font-mono font-semibold px-2 py-0.5 rounded border ${STATUS_COLORS[current.status] ?? STATUS_COLORS.new}`}
+              >
+                {current.status.replace('_', ' ')}
+              </span>
+              <span className="text-[10px] font-mono text-white/40">
+                Last activity {formatTimeAgo(current.last_activity_at ?? current.updated_at)}
+              </span>
+            </div>
+            <h1 className="font-display text-4xl md:text-5xl uppercase leading-none">
+              {current.name ?? 'Unknown'}
+              {current.age && (
+                <span className="text-white/60 font-body text-2xl md:text-3xl ml-3">{current.age}</span>
+              )}
+            </h1>
+            <div className="mt-2 text-sm text-white/50 flex gap-3 flex-wrap font-mono">
+              {current.job && <span>{current.job}</span>}
+              {current.school && <span>· {current.school}</span>}
+              {current.zodiac && <span>· {current.zodiac}</span>}
+            </div>
+          </div>
+
+          {/* Action bar */}
+          <div className="flex gap-2 flex-wrap">
+            {ACTIONABLE_STATUSES.map((s) => (
+              <button
+                key={s.key}
+                type="button"
+                onClick={() => updateStatus(s.key)}
+                disabled={statusBusy !== null}
+                className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
+                  current.status === s.key
+                    ? 'bg-yellow-500/25 text-yellow-200 border-yellow-500/50'
+                    : 'bg-white/5 text-white/70 border-white/10 hover:bg-white/10'
+                } disabled:opacity-50`}
+              >
+                {statusBusy === s.key ? '...' : s.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Grid */}
+        <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,360px)_minmax(0,1fr)] gap-6">
+          {/* Left col: photos + scoring */}
+          <div className="space-y-6">
+            <PhotoGallery photos={current.photos_jsonb ?? []} name={current.name} />
+            <ScoringPanel match={current} />
+
+            {/* Julian rank */}
+            <div className="bg-white/[0.03] border border-white/10 rounded-xl p-5">
+              <div className="flex justify-between items-baseline mb-2">
+                <h3 className="text-xs uppercase tracking-widest font-mono text-white/40">
+                  Julian rank
+                </h3>
+                <span className="font-mono text-2xl text-yellow-400 font-bold">{rank}</span>
+              </div>
+              <input
+                type="range"
+                min={1}
+                max={10}
+                step={1}
+                value={rank}
+                onChange={(e) => setRank(Number(e.target.value))}
+                onMouseUp={(e) => saveRank(Number((e.target as HTMLInputElement).value))}
+                onTouchEnd={(e) => saveRank(Number((e.target as HTMLInputElement).value))}
+                className="w-full accent-yellow-500"
+              />
+              <div className="flex justify-between text-[10px] text-white/30 font-mono mt-1">
+                <span>1</span>
+                <span>10</span>
+              </div>
+              {rankSaving && <p className="text-[10px] text-white/40 mt-2">Saving...</p>}
+              {rankError && <p className="text-[10px] text-amber-400 mt-2">{rankError}</p>}
+            </div>
+
+            {/* Cluster risk toggle */}
+            {clusterRisk && (
+              <div className="bg-red-500/10 border border-red-500/30 rounded-xl p-4">
+                <div className="flex items-start gap-2">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-red-400 mt-0.5">
+                    <path d="M12 9v2m0 4h.01M5 19h14a2 2 0 001.84-2.75L13.74 4a2 2 0 00-3.48 0l-7.1 12.25A2 2 0 005 19z" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                  <div>
+                    <p className="text-xs text-red-300 font-semibold mb-1">Cluster risk detected</p>
+                    <p className="text-[11px] text-red-200/70 leading-snug">
+                      This match shares signals with profiles that previously stalled. Proceed with caution.
+                    </p>
+                    <label className="flex items-center gap-2 mt-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={proceedRisk}
+                        onChange={(e) => setProceedRisk(e.target.checked)}
+                        className="accent-red-400"
+                      />
+                      <span className="text-[11px] text-red-200">Proceed despite cluster risk</span>
+                    </label>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Right col: bio, prompts, AI insights, convo */}
+          <div className="space-y-6 min-w-0">
+            {/* Bio */}
+            {current.bio && (
+              <div className="bg-white/[0.03] border border-white/10 rounded-xl p-5">
+                <h3 className="text-xs uppercase tracking-widest font-mono text-white/40 mb-2">Bio</h3>
+                <p className="text-white/80 text-sm leading-relaxed whitespace-pre-wrap">
+                  {current.bio}
+                </p>
+              </div>
+            )}
+
+            {/* Prompts (Hinge) */}
+            {current.prompts_jsonb && current.prompts_jsonb.length > 0 && (
+              <div className="bg-white/[0.03] border border-white/10 rounded-xl p-5">
+                <h3 className="text-xs uppercase tracking-widest font-mono text-white/40 mb-3">
+                  Prompts
+                </h3>
+                <div className="space-y-3">
+                  {current.prompts_jsonb.map((p, i) => (
+                    <div key={i}>
+                      <p className="text-[11px] text-white/40 uppercase tracking-wide font-mono">
+                        {p.question}
+                      </p>
+                      <p className="text-white/80 text-sm mt-0.5">{p.answer}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Spotify + IG */}
+            {(current.spotify_artists && current.spotify_artists.length > 0) || current.instagram_handle ? (
+              <div className="bg-white/[0.03] border border-white/10 rounded-xl p-5">
+                <h3 className="text-xs uppercase tracking-widest font-mono text-white/40 mb-3">Signals</h3>
+                {current.instagram_handle && (
+                  <div className="mb-3">
+                    <p className="text-[11px] text-white/40 font-mono">Instagram</p>
+                    <p className="text-white/80 text-sm">@{current.instagram_handle}</p>
+                  </div>
+                )}
+                {current.spotify_artists && current.spotify_artists.length > 0 && (
+                  <div>
+                    <p className="text-[11px] text-white/40 font-mono mb-1">Spotify top artists</p>
+                    <div className="flex gap-1.5 flex-wrap">
+                      {current.spotify_artists.map((a) => (
+                        <span
+                          key={a}
+                          className="text-[11px] bg-white/5 border border-white/10 rounded px-2 py-0.5 text-white/70"
+                        >
+                          {a}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : null}
+
+            {/* AI insights */}
+            <div>
+              <h3 className="text-xs uppercase tracking-widest font-mono text-white/40 mb-3 px-1">
+                AI Insights
+              </h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="bg-white/[0.03] border border-white/10 rounded-xl p-5">
+                  <div className="flex items-center gap-2 mb-2">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="text-purple-400">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z M12 16a4 4 0 1 0 0-8 4 4 0 0 0 0 8z" />
+                    </svg>
+                    <span className="text-xs uppercase tracking-wider text-purple-300 font-mono font-semibold">
+                      Vision
+                    </span>
+                  </div>
+                  {visionSummary ? (
+                    <p className="text-sm text-white/80 leading-relaxed">{visionSummary}</p>
+                  ) : (
+                    <p className="text-xs text-white/30 italic">
+                      Pending analysis. The vision model analyzes photos and returns a summary once images have been processed.
+                    </p>
+                  )}
+                </div>
+                <div className="bg-white/[0.03] border border-white/10 rounded-xl p-5">
+                  <div className="flex items-center gap-2 mb-2">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className="text-pink-400">
+                      <rect x="3" y="3" width="18" height="18" rx="4" />
+                      <circle cx="12" cy="12" r="4" />
+                      <circle cx="17" cy="7" r="1" fill="currentColor" />
+                    </svg>
+                    <span className="text-xs uppercase tracking-wider text-pink-300 font-mono font-semibold">
+                      Instagram
+                    </span>
+                  </div>
+                  {instagramSummary ? (
+                    <p className="text-sm text-white/80 leading-relaxed">{instagramSummary}</p>
+                  ) : (
+                    <p className="text-xs text-white/30 italic">
+                      Pending analysis. Instagram intel runs after the handle is linked and the agent pulls recent posts.
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Match intel badges */}
+            {current.match_intel && (current.match_intel.green_flags?.length || current.match_intel.red_flags?.length) ? (
+              <div className="bg-white/[0.03] border border-white/10 rounded-xl p-5">
+                <h3 className="text-xs uppercase tracking-widest font-mono text-white/40 mb-3">
+                  Flags
+                </h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <p className="text-[11px] text-emerald-400 font-mono uppercase tracking-wide mb-1">
+                      Green flags
+                    </p>
+                    {current.match_intel.green_flags?.length ? (
+                      <ul className="text-sm text-white/80 space-y-1">
+                        {current.match_intel.green_flags.map((f, i) => (
+                          <li key={i}>· {f}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="text-[11px] text-white/30 italic">None noted.</p>
+                    )}
+                  </div>
+                  <div>
+                    <p className="text-[11px] text-amber-400 font-mono uppercase tracking-wide mb-1">
+                      Red flags
+                    </p>
+                    {current.match_intel.red_flags?.length ? (
+                      <ul className="text-sm text-white/80 space-y-1">
+                        {current.match_intel.red_flags.map((f, i) => (
+                          <li key={i}>· {f}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="text-[11px] text-white/30 italic">None noted.</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ) : null}
+
+            {/* Conversation */}
+            <div>
+              <h3 className="text-xs uppercase tracking-widest font-mono text-white/40 mb-3 px-1">
+                Conversation
+              </h3>
+              <ConversationThread messages={messages} matchName={current.name} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/components/matches/MatchGrid.tsx
+++ b/web/components/matches/MatchGrid.tsx
@@ -1,0 +1,189 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import MatchCard from './MatchCard'
+import FilterBar from './FilterBar'
+import {
+  ClapcheeksMatchRow,
+  MatchListFilters,
+} from '@/lib/matches/types'
+
+type LastMessageMap = Record<string, string | null>
+
+type Props = {
+  initialMatches: ClapcheeksMatchRow[]
+  initialHasMore: boolean
+  initialLastMessages: LastMessageMap
+  pageSize: number
+}
+
+const DEFAULT_FILTERS: MatchListFilters = {
+  platform: 'all',
+  status: 'all',
+  minScore: 0,
+}
+
+export default function MatchGrid({
+  initialMatches,
+  initialHasMore,
+  initialLastMessages,
+  pageSize,
+}: Props) {
+  const [matches, setMatches] = useState<ClapcheeksMatchRow[]>(initialMatches)
+  const [lastMessages] = useState<LastMessageMap>(initialLastMessages)
+  const [hasMore, setHasMore] = useState(initialHasMore)
+  const [loading, setLoading] = useState(false)
+  const [filters, setFilters] = useState<MatchListFilters>(DEFAULT_FILTERS)
+  const [syncing, setSyncing] = useState(false)
+  const [syncMsg, setSyncMsg] = useState<string | null>(null)
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+
+  const filtered = useMemo(() => {
+    return matches.filter((m) => {
+      if (filters.platform !== 'all' && m.platform !== filters.platform) return false
+      if (filters.status !== 'all' && m.status !== filters.status) return false
+      if (filters.minScore > 0) {
+        const s = typeof m.final_score === 'number' ? m.final_score : 0
+        if (s < filters.minScore) return false
+      }
+      return true
+    })
+  }, [matches, filters])
+
+  const fetchMore = useCallback(async () => {
+    if (!hasMore || loading) return
+    setLoading(true)
+    try {
+      const supabase = createClient()
+      const from = matches.length
+      const to = from + pageSize - 1
+      const { data, error } = await supabase
+        .from('clapcheeks_matches')
+        .select('*')
+        .order('final_score', { ascending: false, nullsFirst: false })
+        .order('last_activity_at', { ascending: false, nullsFirst: false })
+        .range(from, to)
+      if (error) {
+        console.warn('[MatchGrid] fetchMore error:', error.message)
+        setHasMore(false)
+      } else if (data && data.length > 0) {
+        setMatches((prev) => [...prev, ...(data as unknown as ClapcheeksMatchRow[])])
+        if (data.length < pageSize) setHasMore(false)
+      } else {
+        setHasMore(false)
+      }
+    } finally {
+      setLoading(false)
+    }
+  }, [hasMore, loading, matches.length, pageSize])
+
+  useEffect(() => {
+    if (!sentinelRef.current || !hasMore) return
+    const el = sentinelRef.current
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) fetchMore()
+      },
+      { rootMargin: '400px' },
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [fetchMore, hasMore])
+
+  async function triggerSync() {
+    setSyncing(true)
+    setSyncMsg(null)
+    try {
+      const res = await fetch('/api/agent/sync-matches', { method: 'POST' })
+      if (res.ok) {
+        setSyncMsg('Sync requested. Check back in a minute.')
+      } else {
+        setSyncMsg('Sync failed. Make sure the agent is installed.')
+      }
+    } catch {
+      setSyncMsg('Network error. Try again.')
+    } finally {
+      setSyncing(false)
+    }
+  }
+
+  if (matches.length === 0) {
+    return (
+      <div className="bg-white/[0.03] border border-white/10 rounded-xl p-10 text-center">
+        <div className="w-16 h-16 rounded-2xl bg-yellow-500/10 border border-yellow-500/30 mx-auto mb-4 flex items-center justify-center">
+          <svg
+            width="28"
+            height="28"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            className="text-yellow-400"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+        </div>
+        <h3 className="text-white font-semibold text-lg mb-2">No matches yet</h3>
+        <p className="text-white/40 text-sm max-w-md mx-auto mb-4">
+          Match intake is running — the Clapcheeks agent pulls your matches every 10 minutes. Check
+          back soon, or kick off a manual sync now.
+        </p>
+        <button
+          type="button"
+          onClick={triggerSync}
+          disabled={syncing}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-gradient-to-r from-yellow-500 to-red-600 text-black text-sm font-bold hover:opacity-90 transition-opacity disabled:opacity-50"
+        >
+          {syncing ? 'Requesting...' : 'Run sync now'}
+        </button>
+        {syncMsg && (
+          <p className="mt-3 text-xs font-mono text-yellow-400/80">{syncMsg}</p>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <FilterBar
+        filters={filters}
+        onChange={setFilters}
+        total={matches.length}
+        filteredCount={filtered.length}
+      />
+      {filtered.length === 0 ? (
+        <div className="bg-white/[0.03] border border-white/10 rounded-xl p-10 text-center">
+          <p className="text-white/50 text-sm">
+            No matches match these filters. Adjust the platform, status, or score slider.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+          {filtered.map((m) => (
+            <MatchCard key={m.id} match={m} lastMessage={lastMessages[m.id]} />
+          ))}
+        </div>
+      )}
+      {hasMore && (
+        <div ref={sentinelRef} className="h-20 flex items-center justify-center">
+          {loading ? (
+            <div className="text-white/40 text-xs font-mono">Loading more...</div>
+          ) : (
+            <div className="text-white/20 text-xs font-mono">Scroll for more</div>
+          )}
+        </div>
+      )}
+      {!hasMore && matches.length > 0 && (
+        <div className="h-20 flex items-center justify-center text-white/20 text-xs font-mono">
+          End of matches
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/web/components/matches/PhotoGallery.tsx
+++ b/web/components/matches/PhotoGallery.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import useEmblaCarousel from 'embla-carousel-react'
+import { MatchPhoto } from '@/lib/matches/types'
+
+type Props = {
+  photos: MatchPhoto[]
+  name?: string | null
+}
+
+export default function PhotoGallery({ photos, name }: Props) {
+  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: photos.length > 1, dragFree: false })
+  const [index, setIndex] = useState(0)
+  const touch = useRef({ x: 0 })
+
+  useEffect(() => {
+    if (!emblaApi) return
+    const onSelect = () => setIndex(emblaApi.selectedScrollSnap())
+    emblaApi.on('select', onSelect)
+    return () => {
+      emblaApi.off('select', onSelect)
+    }
+  }, [emblaApi])
+
+  if (!photos || photos.length === 0) {
+    return (
+      <div className="relative w-full aspect-[3/4] bg-gradient-to-br from-zinc-800 to-zinc-900 rounded-xl border border-white/10 flex items-center justify-center">
+        <div className="text-white/30 text-6xl font-bold">
+          {(name ?? '?').slice(0, 1).toUpperCase()}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative">
+      <div
+        className="overflow-hidden rounded-xl border border-white/10 bg-zinc-900"
+        ref={emblaRef}
+        onTouchStart={(e) => {
+          touch.current.x = e.touches[0]?.clientX ?? 0
+        }}
+      >
+        <div className="flex">
+          {photos.map((p, i) => (
+            <div
+              key={i}
+              className="relative flex-[0_0_100%] aspect-[3/4] bg-zinc-900"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={p.url}
+                alt={name ? `${name} photo ${i + 1}` : `Photo ${i + 1}`}
+                className="w-full h-full object-cover"
+                loading={i === 0 ? 'eager' : 'lazy'}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+      {photos.length > 1 && (
+        <>
+          <div className="absolute top-2 left-0 right-0 flex gap-1 px-2">
+            {photos.map((_, i) => (
+              <div
+                key={i}
+                className={`h-1 flex-1 rounded-full transition-all ${
+                  i === index ? 'bg-white' : 'bg-white/30'
+                }`}
+              />
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={() => emblaApi?.scrollPrev()}
+            className="absolute left-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/50 backdrop-blur border border-white/20 text-white hover:bg-black/70 flex items-center justify-center"
+            aria-label="Previous photo"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M15 18l-6-6 6-6" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            onClick={() => emblaApi?.scrollNext()}
+            className="absolute right-2 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-black/50 backdrop-blur border border-white/20 text-white hover:bg-black/70 flex items-center justify-center"
+            aria-label="Next photo"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M9 6l6 6-6 6" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+          <div className="absolute bottom-2 right-2 bg-black/60 backdrop-blur border border-white/10 text-white/80 text-[10px] font-mono px-2 py-0.5 rounded">
+            {index + 1} / {photos.length}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/web/components/matches/ScoringPanel.tsx
+++ b/web/components/matches/ScoringPanel.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { ClapcheeksMatchRow } from '@/lib/matches/types'
+
+type Props = {
+  match: ClapcheeksMatchRow
+}
+
+function ScoreBar({
+  label,
+  value,
+  color,
+}: {
+  label: string
+  value: number | null
+  color: string
+}) {
+  if (value === null || value === undefined) {
+    return (
+      <div>
+        <div className="flex items-baseline justify-between mb-1">
+          <span className="text-xs text-white/60 uppercase tracking-wider font-mono">{label}</span>
+          <span className="text-xs text-white/30 font-mono">pending</span>
+        </div>
+        <div className="h-1.5 bg-white/5 rounded-full overflow-hidden">
+          <div className="h-full bg-white/10 w-0" />
+        </div>
+      </div>
+    )
+  }
+  const pct = Math.max(0, Math.min(100, value))
+  return (
+    <div>
+      <div className="flex items-baseline justify-between mb-1">
+        <span className="text-xs text-white/60 uppercase tracking-wider font-mono">{label}</span>
+        <span className="text-xs text-white font-mono font-bold">{Math.round(pct)}</span>
+      </div>
+      <div className="h-1.5 bg-white/5 rounded-full overflow-hidden">
+        <div
+          className={`h-full ${color} transition-all`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default function ScoringPanel({ match }: Props) {
+  const hasScore = typeof match.final_score === 'number' && !Number.isNaN(match.final_score)
+  const score = hasScore ? Math.round(match.final_score!) : null
+
+  return (
+    <div className="bg-white/[0.03] border border-white/10 rounded-xl p-5">
+      <h3 className="text-xs uppercase tracking-widest font-mono text-white/40 mb-4">Scoring</h3>
+      <div className="flex items-baseline gap-2 mb-1">
+        {score !== null ? (
+          <>
+            <span className="font-display text-5xl gold-text font-bold">{score}</span>
+            <span className="text-white/40 text-sm font-mono">/ 100</span>
+          </>
+        ) : (
+          <>
+            <span className="font-display text-5xl text-white/20 font-bold">--</span>
+            <span className="text-white/30 text-xs font-mono">scoring pending</span>
+          </>
+        )}
+      </div>
+      {match.scoring_reason ? (
+        <p className="text-sm text-white/70 mt-2 mb-4 leading-relaxed">
+          {match.scoring_reason}
+        </p>
+      ) : (
+        <p className="text-xs text-white/30 italic mt-2 mb-4">
+          Scoring explanation will appear here once Phase A + the scoring engine populate it.
+        </p>
+      )}
+      <div className="space-y-3">
+        <ScoreBar label="Location" value={match.location_score} color="bg-blue-400" />
+        <ScoreBar label="Criteria" value={match.criteria_score} color="bg-emerald-400" />
+      </div>
+    </div>
+  )
+}

--- a/web/lib/matches/types.ts
+++ b/web/lib/matches/types.ts
@@ -1,0 +1,147 @@
+// Type definitions for Phase D match views.
+// Aligns with the clapcheeks_matches schema that Phase A (AI-8315) will create.
+// Columns marked "future" may not exist yet — read with try/catch or optional chaining.
+
+export type MatchPlatform = 'tinder' | 'hinge' | 'bumble' | 'offline'
+
+export type MatchStatus =
+  | 'new'
+  | 'opened'
+  | 'conversing'
+  | 'stalled'
+  | 'date_proposed'
+  | 'date_booked'
+  | 'dated'
+  | 'ghosted'
+
+export type MatchPhoto = {
+  url: string
+  supabase_path?: string | null
+  width?: number | null
+  height?: number | null
+}
+
+export type MatchPrompt = {
+  question: string
+  answer: string
+}
+
+export type MatchIntel = {
+  summary?: string | null
+  red_flags?: string[]
+  green_flags?: string[]
+  vibe?: string | null
+  compatibility?: number | null
+  [k: string]: unknown
+}
+
+export type InstagramIntel = {
+  summary?: string | null
+  handle?: string | null
+  follower_count?: number | null
+  vibes?: string[]
+  [k: string]: unknown
+}
+
+export type ClapcheeksMatchRow = {
+  id: string
+  user_id: string
+  platform: MatchPlatform
+  external_id: string | null
+  name: string | null
+  age: number | null
+  bio: string | null
+  photos_jsonb: MatchPhoto[] | null
+  prompts_jsonb: MatchPrompt[] | null
+  job: string | null
+  school: string | null
+  instagram_handle: string | null
+  spotify_artists: string[] | null
+  birth_date: string | null
+  zodiac: string | null
+  match_intel: MatchIntel | null
+  vision_summary: string | null
+  instagram_intel: InstagramIntel | null
+  status: MatchStatus
+  last_activity_at: string | null
+  created_at: string
+  updated_at: string
+  // future scoring columns (may not exist yet)
+  final_score: number | null
+  location_score: number | null
+  criteria_score: number | null
+  scoring_reason: string | null
+  // future agent override (may not exist yet)
+  julian_rank: number | null
+  // demo / dev flag for seeded data
+  is_demo?: boolean | null
+}
+
+export type MatchListFilters = {
+  platform: 'all' | MatchPlatform
+  status: 'all' | 'new' | 'conversing' | 'date_proposed' | 'date_booked' | 'dated' | 'stalled' | 'ghosted'
+  minScore: number
+}
+
+export type ConversationMessage = {
+  id?: string
+  direction: 'incoming' | 'outgoing'
+  body: string
+  sent_at: string
+  platform?: string
+}
+
+export const PLATFORM_OPTIONS: Array<{ value: 'all' | MatchPlatform; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'tinder', label: 'Tinder' },
+  { value: 'hinge', label: 'Hinge' },
+  { value: 'bumble', label: 'Bumble' },
+  { value: 'offline', label: 'Offline' },
+]
+
+export const STATUS_OPTIONS: Array<{ value: MatchListFilters['status']; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'new', label: 'New' },
+  { value: 'conversing', label: 'Conversing' },
+  { value: 'date_proposed', label: 'Date proposed' },
+  { value: 'date_booked', label: 'Date booked' },
+  { value: 'dated', label: 'Dated' },
+  { value: 'stalled', label: 'Stalled' },
+  { value: 'ghosted', label: 'Ghosted' },
+]
+
+export const STATUS_COLORS: Record<MatchStatus, string> = {
+  new:            'bg-blue-500/15 text-blue-300 border-blue-500/30',
+  opened:         'bg-indigo-500/15 text-indigo-300 border-indigo-500/30',
+  conversing:     'bg-emerald-500/15 text-emerald-300 border-emerald-500/30',
+  stalled:        'bg-amber-500/15 text-amber-300 border-amber-500/30',
+  date_proposed:  'bg-fuchsia-500/15 text-fuchsia-300 border-fuchsia-500/30',
+  date_booked:    'bg-pink-500/15 text-pink-300 border-pink-500/30',
+  dated:          'bg-yellow-500/15 text-yellow-300 border-yellow-500/30',
+  ghosted:        'bg-white/10 text-white/50 border-white/15',
+}
+
+export const PLATFORM_COLORS: Record<MatchPlatform, string> = {
+  tinder:  'bg-rose-500/15 text-rose-300 border-rose-500/30',
+  hinge:   'bg-violet-500/15 text-violet-300 border-violet-500/30',
+  bumble:  'bg-amber-500/15 text-amber-300 border-amber-500/30',
+  offline: 'bg-slate-500/20 text-slate-300 border-slate-500/30',
+}
+
+export function formatTimeAgo(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const then = new Date(iso).getTime()
+  const now = Date.now()
+  const diff = Math.max(0, now - then)
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  const days = Math.floor(hrs / 24)
+  if (days < 7) return `${days}d ago`
+  const weeks = Math.floor(days / 7)
+  if (weeks < 5) return `${weeks}w ago`
+  const months = Math.floor(days / 30)
+  return `${months}mo ago`
+}

--- a/web/scripts/seed-demo-matches.ts
+++ b/web/scripts/seed-demo-matches.ts
@@ -1,0 +1,230 @@
+#!/usr/bin/env tsx
+/**
+ * Seed 5 demo matches into clapcheeks_matches for local/dev usage.
+ *
+ * Usage:
+ *   cd web && npx tsx scripts/seed-demo-matches.ts <user_id>
+ *
+ * Requires env vars:
+ *   NEXT_PUBLIC_SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY
+ *
+ * All rows are inserted with is_demo=true so they can be nuked later via:
+ *   DELETE FROM clapcheeks_matches WHERE is_demo = true;
+ *
+ * Phase A (AI-8315) owns the schema. If this script fails with
+ * "relation clapcheeks_matches does not exist", wait for Phase A to land.
+ */
+
+import { createClient } from '@supabase/supabase-js'
+
+const DEMO_MATCHES = [
+  {
+    external_id: 'demo-hinge-001',
+    platform: 'hinge',
+    name: 'Sofia',
+    age: 27,
+    bio: 'Barre instructor by day. Matcha enthusiast. Ask me about my dog.',
+    photos_jsonb: [
+      { url: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=800' },
+      { url: 'https://images.unsplash.com/photo-1531123897727-8f129e1688ce?w=800' },
+      { url: 'https://images.unsplash.com/photo-1517841905240-472988babdf9?w=800' },
+    ],
+    prompts_jsonb: [
+      { question: 'My simple pleasures', answer: 'Espresso, vinyl, and winning arguments.' },
+      { question: 'Two truths and a lie', answer: 'Ran a marathon; allergic to cilantro; played in a punk band.' },
+    ],
+    job: 'Pilates instructor',
+    school: 'UCSD',
+    instagram_handle: 'sofia.moves',
+    spotify_artists: ['Faye Webster', 'Phoebe Bridgers', 'Mac Demarco'],
+    zodiac: 'Libra',
+    match_intel: {
+      summary: 'High-energy, creative. Asks thoughtful questions.',
+      green_flags: ['Replies within 2h consistently', 'Uses complete sentences'],
+      red_flags: [],
+    },
+    vision_summary:
+      'Balanced photo set: two portraits, one group shot, one activity. Warm outdoor lighting in 3 of 5. Genuine smile in primary.',
+    instagram_intel: {
+      summary: 'Active (posts 3x/week). Fitness and cafe culture. Low red flags.',
+      handle: 'sofia.moves',
+    },
+    status: 'conversing',
+    final_score: 87,
+    location_score: 92,
+    criteria_score: 83,
+    scoring_reason: 'Lives within 5 miles. Hits 4 of 5 criteria: fitness, creative career, pets, non-smoker.',
+    last_activity_at: new Date(Date.now() - 1000 * 60 * 42).toISOString(),
+  },
+  {
+    external_id: 'demo-tinder-002',
+    platform: 'tinder',
+    name: 'Marisol',
+    age: 24,
+    bio: 'Architect. Travel junkie. Sunday pancakes.',
+    photos_jsonb: [
+      { url: 'https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=800' },
+      { url: 'https://images.unsplash.com/photo-1488426862026-3ee34a7d66df?w=800' },
+    ],
+    prompts_jsonb: [],
+    job: 'Architect',
+    school: null,
+    instagram_handle: null,
+    spotify_artists: ['Caamp', 'Noah Kahan'],
+    zodiac: 'Gemini',
+    match_intel: {
+      summary: 'Jet-setter lifestyle. Likely busy.',
+      green_flags: ['Career-driven'],
+      red_flags: ['Traveling next 2 weeks per bio'],
+    },
+    vision_summary: null,
+    instagram_intel: null,
+    status: 'new',
+    final_score: 72,
+    location_score: 85,
+    criteria_score: 60,
+    scoring_reason: 'Good location match but only hits 2 of 5 criteria. Travel schedule may slow down replies.',
+    last_activity_at: new Date(Date.now() - 1000 * 60 * 60 * 3).toISOString(),
+  },
+  {
+    external_id: 'demo-hinge-003',
+    platform: 'hinge',
+    name: 'Talia',
+    age: 29,
+    bio: 'PT. Runner. Reader of weird fiction.',
+    photos_jsonb: [
+      { url: 'https://images.unsplash.com/photo-1521146764736-56c929d59c83?w=800' },
+      { url: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?w=800' },
+      { url: 'https://images.unsplash.com/photo-1539571696357-5a69c17a67c6?w=800' },
+      { url: 'https://images.unsplash.com/photo-1502823403499-6ccfcf4fb453?w=800' },
+    ],
+    prompts_jsonb: [
+      { question: "I'm weirdly attracted to", answer: 'People who over-explain the plot of a movie.' },
+    ],
+    job: 'Physical therapist',
+    school: 'SDSU',
+    instagram_handle: 'talia.runs',
+    spotify_artists: ['Big Thief', 'Soccer Mommy'],
+    zodiac: 'Virgo',
+    match_intel: {
+      summary: 'Independent, witty. Low overlap with prior stalls.',
+      green_flags: ['Outdoorsy', 'Shares music taste overlap'],
+      red_flags: [],
+    },
+    vision_summary:
+      'All daytime outdoor shots. Strong eye contact in primary. No red flags on photo composition.',
+    instagram_intel: {
+      summary: 'Moderate (posts weekly). Running, books, beach. Consistent aesthetic.',
+      handle: 'talia.runs',
+    },
+    status: 'date_proposed',
+    final_score: 91,
+    location_score: 95,
+    criteria_score: 88,
+    scoring_reason:
+      'Top match. Lives 2 miles away, hits 5 of 5 criteria, shared taste in music and outdoor activity.',
+    last_activity_at: new Date(Date.now() - 1000 * 60 * 60 * 18).toISOString(),
+  },
+  {
+    external_id: 'demo-bumble-004',
+    platform: 'bumble',
+    name: 'Priya',
+    age: 26,
+    bio: 'Grad student. Climbing. Slow mornings.',
+    photos_jsonb: [
+      { url: 'https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?w=800' },
+    ],
+    prompts_jsonb: [],
+    job: 'PhD student',
+    school: 'UCSD',
+    instagram_handle: null,
+    spotify_artists: [],
+    zodiac: null,
+    match_intel: null,
+    vision_summary: null,
+    instagram_intel: null,
+    status: 'stalled',
+    final_score: 54,
+    location_score: 70,
+    criteria_score: 45,
+    scoring_reason: 'Minimal bio data. Stalled after 3 exchanges.',
+    last_activity_at: new Date(Date.now() - 1000 * 60 * 60 * 24 * 6).toISOString(),
+  },
+  {
+    external_id: 'demo-offline-005',
+    platform: 'offline',
+    name: 'Elena',
+    age: 28,
+    bio: 'Met at the Mission Beach Pilates studio. Gave me her number after 4 visits.',
+    photos_jsonb: [
+      { url: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?w=800' },
+      { url: 'https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=800' },
+    ],
+    prompts_jsonb: [],
+    job: 'Pilates instructor',
+    school: null,
+    instagram_handle: 'elena.flows',
+    spotify_artists: [],
+    zodiac: 'Taurus',
+    match_intel: {
+      summary: 'In-person intro; highest trust signal of the cohort.',
+      green_flags: ['Met IRL', 'Gave number unprompted'],
+      red_flags: [],
+      cluster_risk: false,
+    },
+    vision_summary:
+      'Two photos total, both candid. High authenticity signal — no filter abuse.',
+    instagram_intel: {
+      summary: 'Private account. Limited intel until follow request accepted.',
+    },
+    status: 'date_booked',
+    final_score: 95,
+    location_score: 100,
+    criteria_score: 93,
+    scoring_reason:
+      'Met offline — highest-trust channel. Top criteria match. Already booked for Thursday.',
+    last_activity_at: new Date(Date.now() - 1000 * 60 * 8).toISOString(),
+  },
+] as const
+
+async function main() {
+  const userId = process.argv[2]
+  if (!userId) {
+    console.error('Usage: npx tsx scripts/seed-demo-matches.ts <user_id>')
+    process.exit(1)
+  }
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) {
+    console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY env var.')
+    process.exit(1)
+  }
+  const supabase = createClient(url, key)
+
+  const rows = DEMO_MATCHES.map((m) => ({
+    user_id: userId,
+    ...m,
+    is_demo: true,
+    julian_rank: null,
+    birth_date: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }))
+
+  const { data, error } = await supabase
+    .from('clapcheeks_matches')
+    .upsert(rows, { onConflict: 'user_id,external_id', ignoreDuplicates: false })
+    .select('id, name')
+  if (error) {
+    console.error('Seed failed:', error.message)
+    process.exit(1)
+  }
+  console.log('Seeded matches:')
+  for (const r of data ?? []) console.log(`  - ${r.name ?? '(unknown)'} [${r.id}]`)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Phase D (Linear AI-8318) — dashboard match surface for Clapcheeks.

- Grid at `/dashboard/matches` with filters (platform / status / min score), infinite scroll, responsive columns
- Detail at `/dashboard/matches/[id]` with photo gallery, scoring panel, AI insights (vision + instagram), conversation thread, action bar, Julian rank slider
- Stub POST `/api/agent/sync-matches` that Phase A (AI-8315) will wire to the match-intake daemon

Reads align with the `clapcheeks_matches` schema documented in AI-8315. Server reads are wrapped in `try/catch` + loose casts so the pages degrade to an empty state if the Phase A migration or future scoring columns (`final_score`, `julian_rank`, etc.) haven't deployed.

A dev-only `/dashboard-demo` route renders the same components with hardcoded data (gated on `NEXT_PUBLIC_ENABLE_MATCH_DEMO=1`) — used for the screenshots below. It 404s in production.

## Screenshots

Desktop grid (5 demo matches, filters + score slider):
![grid](https://github.com/Julianb233/clapcheeks.tech/blob/phase-d-dashboard-matches/.placeholder-grid-screenshot.png)

Detail (Talia, final_score 91, date_proposed, full insights panel, Julian rank):
![detail](https://github.com/Julianb233/clapcheeks.tech/blob/phase-d-dashboard-matches/.placeholder-detail-screenshot.png)

Empty state (before Phase A runs):
![empty](https://github.com/Julianb233/clapcheeks.tech/blob/phase-d-dashboard-matches/.placeholder-empty-screenshot.png)

Local screenshots captured at:
- `tmp-screens/01-grid.png`
- `tmp-screens/02-detail.png`
- `tmp-screens/03-empty.png`
- `tmp-screens/04-grid-mobile.png`
- `tmp-screens/05-detail-mobile.png`

## Components created

- `web/lib/matches/types.ts`
- `web/components/matches/MatchCard.tsx`
- `web/components/matches/MatchGrid.tsx`
- `web/components/matches/FilterBar.tsx`
- `web/components/matches/MatchDetail.tsx`
- `web/components/matches/PhotoGallery.tsx`
- `web/components/matches/ScoringPanel.tsx`
- `web/components/matches/ConversationThread.tsx`
- `web/scripts/seed-demo-matches.ts`

## Nav changes

- `components/layout/app-sidebar.tsx` — Matches item added with heart icon; `isActive()` tweaked so Dashboard no longer stays active on the matches subpath
- `app/(main)/dashboard/page.tsx` — adds a gold "Matches" pill to the dashboard header links

## Build

`cd web && npm run build` -> PASS (73 routes, including `/dashboard/matches`, `/dashboard/matches/[id]`, `/api/agent/sync-matches`).

## Test plan

- [ ] Merge Phase A (AI-8315) migration for `clapcheeks_matches`
- [ ] Run `cd web && npx tsx scripts/seed-demo-matches.ts <user_id>` against staging
- [ ] Log in to `/dashboard/matches`, verify 5 demo rows render
- [ ] Click Talia → detail page opens, photo gallery swipes, scoring panel shows 91
- [ ] Click a status pill ("Mark dated") → status updates optimistically
- [ ] Drag Julian rank slider → saves on mouseup (gracefully warns if `julian_rank` column missing)
- [ ] Delete demo data: `DELETE FROM clapcheeks_matches WHERE is_demo = true`

## Stubbed / waiting on other phases

- `/api/agent/sync-matches` returns 202 but doesn't actually trigger the daemon — Phase A owns that wiring
- `julian_rank` column is optional; save is wrapped in try/catch and shows a friendly warning if it doesn't exist
- `vision_summary` / `instagram_intel.summary` / `final_score` / `scoring_reason` all render placeholders when null

🤖 Generated with [Claude Code](https://claude.com/claude-code)