### PR TITLE
AI-8339: Phase K social graph collision detector

### DIFF
--- a/agent/clapcheeks/daemon.py
+++ b/agent/clapcheeks/daemon.py
@@ -889,6 +889,235 @@ def _vision_worker(interval_seconds: int = 600) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Phase K: social graph collision detector (AI-8339)                # PHASE-K
+# ---------------------------------------------------------------------------
+
+def _social_graph_worker(config: dict, interval_seconds: int = 3600) -> None:
+    """Phase K worker - detect mutual friends + manage clusters.       # PHASE-K
+
+    Every ``interval_seconds`` (default 1h), scan clapcheeks_matches rows
+    that have ``social_graph_scanned_at IS NULL`` OR have been updated
+    since the last scan. For each:
+
+      1. Run ``scan_match`` to compute mutual-friend count, risk band,
+         confidence, and source list.
+      2. PATCH the row.
+      3. If the row now shares >=2 female friends with another ACTIVE
+         match for the same user, assign a cluster_id + recompute ranks.
+      4. If the row landed in ``high_risk`` or ``auto_flag``, iMessage
+         Julian and pause Phase G openers for that match (by flipping
+         status -> 'stalled' with a reason tag).
+
+    No direct IG scrape from the VPS - we read whatever
+    ``instagram_intel`` Phase M has already persisted. If Julian's IG
+    follower snapshot is missing from persona, the IG overlap tier just
+    returns empty.
+    """
+    from clapcheeks.scoring import _supabase_creds, load_persona
+    from clapcheeks.social.clusters import (
+        assign_to_cluster,
+        find_cluster_candidates,
+    )
+    from clapcheeks.social.graph import scan_match
+    import requests
+
+    user_id = (
+        config.get("user_id")
+        or config.get("clapcheeks_user_id")
+        or os.environ.get("CLAPCHEEKS_USER_ID")
+    )
+    if not user_id:
+        log.warning("social-graph worker: no user_id in config/env, disabled")
+        return
+
+    log.info("social-graph worker started (interval=%ds)", interval_seconds)
+
+    while not _shutdown.is_set():
+        try:
+            try:
+                url, key = _supabase_creds()
+            except Exception as exc:
+                log.debug("social-graph: creds unavailable (%s)", exc)
+                _shutdown.wait(interval_seconds)
+                continue
+
+            # Refresh persona each tick (cheap enough at 1 hour cadence).
+            try:
+                persona = load_persona(user_id)
+            except Exception as exc:
+                log.warning("social-graph: persona load failed (%s)", exc)
+                persona = {}
+            persona_rules = (persona or {}).get("social_graph_rules") or {}
+            julian_ig_session = (persona or {}).get("julian_ig_session")
+            julian_contacts = (persona or {}).get("julian_contacts") or []
+
+            # Unscanned matches first, up to 50 per tick.
+            resp = requests.get(
+                f"{url}/rest/v1/clapcheeks_matches",
+                params={
+                    "user_id": f"eq.{user_id}",
+                    "social_graph_scanned_at": "is.null",
+                    "select": (
+                        "id,user_id,platform,name,match_name,match_intel,"
+                        "instagram_intel,mutual_friends_list,status,"
+                        "shared_female_friends,friend_cluster_id,final_score,"
+                        "phone,phone_number"
+                    ),
+                    "order": "created_at.desc",
+                    "limit": "50",
+                },
+                headers={"apikey": key, "Authorization": f"Bearer {key}"},
+                timeout=30,
+            )
+            if resp.status_code >= 300:
+                log.warning("social-graph: fetch %s", resp.status_code)
+                _shutdown.wait(interval_seconds)
+                continue
+
+            matches = resp.json() or []
+            if not matches:
+                _shutdown.wait(interval_seconds)
+                continue
+
+            # Active roster for cluster candidacy (other matches for this
+            # user that aren't ghosted / archived).
+            active_resp = requests.get(
+                f"{url}/rest/v1/clapcheeks_matches",
+                params={
+                    "user_id": f"eq.{user_id}",
+                    "status": "in.(new,opened,conversing,stalled,"
+                              "date_proposed,date_booked,dated)",
+                    "select": (
+                        "id,status,final_score,friend_cluster_id,"
+                        "mutual_friends_list,shared_female_friends"
+                    ),
+                    "limit": "500",
+                },
+                headers={"apikey": key, "Authorization": f"Bearer {key}"},
+                timeout=30,
+            )
+            active_rows = (
+                active_resp.json() if active_resp.status_code < 300 else []
+            )
+
+            headers = {
+                "apikey": key,
+                "Authorization": f"Bearer {key}",
+                "Content-Type": "application/json",
+                "Prefer": "return=minimal",
+            }
+
+            scanned = flagged = clustered = 0
+            for m in matches:
+                if _shutdown.is_set():
+                    break
+                try:
+                    result = scan_match(
+                        m,
+                        persona_rules=persona_rules,
+                        julian_ig_session=julian_ig_session,
+                        julian_contacts=julian_contacts,
+                    )
+                    # shared_female_friends is the subset of mutual_friends
+                    # that overlaps with another match - for now, we store
+                    # the full mutual list and let the cluster logic filter.
+                    patch = {
+                        **result,
+                        "shared_female_friends": result["mutual_friends_list"],
+                        "social_graph_scanned_at": datetime.utcnow()
+                        .replace(microsecond=0)
+                        .isoformat() + "Z",
+                    }
+                    p = requests.patch(
+                        f"{url}/rest/v1/clapcheeks_matches",
+                        params={"id": f"eq.{m['id']}"},
+                        headers=headers,
+                        json=patch,
+                        timeout=15,
+                    )
+                    if p.status_code >= 300:
+                        log.warning(
+                            "social-graph PATCH %s: %s",
+                            p.status_code, p.text[:200],
+                        )
+                        continue
+                    scanned += 1
+
+                    # Cluster detection against other active matches.
+                    m_with_friends = dict(m, **{
+                        "mutual_friends_list": result["mutual_friends_list"],
+                        "shared_female_friends": result["mutual_friends_list"],
+                    })
+                    candidates = find_cluster_candidates(
+                        m_with_friends, active_rows
+                    )
+                    if candidates:
+                        cid = assign_to_cluster(m["id"], candidates)
+                        if cid:
+                            clustered += 1
+
+                    # HIGH_RISK / auto_flag side-effects: pause Phase G
+                    # opener + iMessage Julian.
+                    band = result["social_risk_band"]
+                    if band in ("high_risk", "auto_flag"):
+                        flagged += 1
+                        _phase_k_high_risk_alert(m, band, result, headers, url)
+                except Exception as exc:
+                    log.error(
+                        "social-graph: match %s failed (%s)",
+                        m.get("id"), exc,
+                    )
+            log.info(
+                "social-graph tick: scanned=%d flagged=%d clustered=%d",
+                scanned, flagged, clustered,
+            )
+        except Exception as exc:
+            log.error("social-graph tick failed: %s", exc)
+
+        _shutdown.wait(interval_seconds)
+
+
+def _phase_k_high_risk_alert(
+    match: dict,
+    band: str,
+    result: dict,
+    headers: dict,
+    url: str,
+) -> None:                                                              # PHASE-K
+    """Pause openers + ping Julian when Phase K flags a high-risk match."""
+    import requests
+    # 1) Flip status to 'stalled' so Phase G drip skips it until Julian
+    #    clears the flag (the drip scanner treats stalled as terminal
+    #    for net-new openers but still allows re-engage nudges).
+    try:
+        requests.patch(
+            f"{url}/rest/v1/clapcheeks_matches",
+            params={"id": f"eq.{match['id']}"},
+            headers=headers,
+            json={"status": "stalled"},
+            timeout=15,
+        )
+    except Exception as exc:
+        log.warning("phase-k pause status patch failed: %s", exc)
+
+    # 2) iMessage Julian.
+    try:
+        import subprocess
+        name = match.get("name") or match.get("match_name") or "unknown"
+        msg = (
+            f"Clapcheeks Phase K alert: {name} has {result['count']} mutual "
+            f"friends (band={band}). Opener paused. Review in dashboard."
+        )
+        julian_number = os.environ.get("JULIAN_PHONE", "+16195090699")
+        subprocess.run(
+            ["god", "mac", "send", julian_number, msg],
+            timeout=30, capture_output=True, text=True,
+        )
+    except Exception as exc:
+        log.debug("phase-k iMessage failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
 # Phase L: content scheduler + publisher worker (AI-8340)
 # ---------------------------------------------------------------------------
 
@@ -1221,6 +1450,19 @@ def run_daemon() -> None:
         target=_ig_enrich_worker_thread,
         args=(ig_enrich_interval,),
         name="ig-enrich",
+        daemon=True,
+    )
+    t.start()
+    threads.append(t)
+
+    # PHASE-K - AI-8339 - Social graph collision detector + cluster dedupe.
+    social_graph_interval = int(
+        daemon_cfg.get("social_graph_interval_seconds", 3600)
+    )
+    t = threading.Thread(
+        target=_social_graph_worker,
+        args=(config, social_graph_interval),
+        name="social-graph",
         daemon=True,
     )
     t.start()

--- a/agent/clapcheeks/social/__init__.py
+++ b/agent/clapcheeks/social/__init__.py
@@ -1,12 +1,30 @@
-"""Social-signal helpers (Phase C - AI-8317).
+"""Social-signal helpers (Phase C - AI-8317, Phase K - AI-8339).
 
 Public surface:
     - ig_handle.extract_ig_handles(text) -> list[str]
     - ig_parser.parse_ig_user_feed(raw) -> dict
     - ig_parser.aggregate_ig_intel(parsed) -> str
+    - graph.detect_mutual_friends(match, julian_ig_session, julian_contacts)
+    - graph.compute_risk_band(count, persona_rules)
+    - graph.scan_match(match, persona_rules, ...)
+    - clusters.find_cluster_candidates(match_row, active_matches, threshold)
+    - clusters.assign_to_cluster(match_id, candidate_ids)
+    - clusters.update_cluster_ranks(cluster_id)
+    - clusters.on_cluster_locked(cluster_id, triggering_match_id)
 """
 from clapcheeks.social.ig_handle import extract_ig_handles  # noqa: F401
 from clapcheeks.social.ig_parser import (  # noqa: F401
     aggregate_ig_intel,
     parse_ig_user_feed,
+)
+from clapcheeks.social.graph import (  # noqa: F401
+    compute_risk_band,
+    detect_mutual_friends,
+    scan_match,
+)
+from clapcheeks.social.clusters import (  # noqa: F401
+    assign_to_cluster,
+    find_cluster_candidates,
+    on_cluster_locked,
+    update_cluster_ranks,
 )

--- a/agent/clapcheeks/social/clusters.py
+++ b/agent/clapcheeks/social/clusters.py
@@ -1,0 +1,328 @@
+"""Phase K (AI-8339): Friend-cluster manager.
+
+When a new match shares >= 2 female friends with an existing active
+match, they belong to the same "friend cluster". We surface only the
+highest-scoring match per cluster on the dashboard; the rest stay in
+the DB but are marked with cluster_rank >= 2 so the UI can dedupe.
+
+Rules (from persona.social_graph_rules.cluster_management_rules):
+- On a new match joining a cluster: recompute ranks by final_score.
+  If the new match outranks the current leader, iMessage Julian with
+  "swap focus?" context.
+- When the cluster leader reaches status = 'dated' (date attended):
+  LOCK the cluster permanently. Every other member is archived.
+- When a leader fades (30d silence): UNLOCK and let the next-highest
+  surface at a 'high_risk' band because word has traveled.
+
+This module only handles the Supabase state. Actual opener-pause +
+iMessage side-effects live in the daemon worker.
+
+Public API:
+    assign_to_cluster(match_id, candidate_ids) -> cluster_id | None
+    update_cluster_ranks(cluster_id) -> None
+    on_cluster_locked(cluster_id, triggering_match_id) -> None
+    find_cluster_candidates(match_row, active_matches) -> list[str]
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Iterable
+
+from clapcheeks.social.graph import _normalize_handle, _normalize_name
+
+logger = logging.getLogger("clapcheeks.social.clusters")
+
+# Minimum shared female-friend overlap to trigger cluster assignment.
+DEFAULT_CLUSTER_THRESHOLD = 2
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _handles_set(entries: Iterable[dict] | None) -> set[str]:
+    """Extract the canonical key (handle, falling back to name) per entry."""
+    if not entries:
+        return set()
+    out: set[str] = set()
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        key = _normalize_handle(e.get("handle")) or _normalize_name(e.get("name"))
+        if key:
+            out.add(key)
+    return out
+
+
+def _supabase_rest():
+    """Import lazily so the module is test-friendly without Supabase creds."""
+    from clapcheeks.scoring import _supabase_creds
+    import requests
+    url, key = _supabase_creds()
+    return url, key, requests
+
+
+# ---------------------------------------------------------------------------
+# Candidate discovery
+# ---------------------------------------------------------------------------
+
+def find_cluster_candidates(
+    match_row: dict,
+    active_matches: Iterable[dict],
+    threshold: int = DEFAULT_CLUSTER_THRESHOLD,
+) -> list[str]:
+    """Given a new match + the list of other active matches for this user,
+    return the ids of matches that share >= ``threshold`` female friends
+    with ``match_row``.
+
+    ``active_matches`` rows must carry ``id`` + ``mutual_friends_list`` +
+    optionally ``shared_female_friends`` + ``friend_cluster_id`` +
+    ``status``. Matches that have stage = 'dated' or status = 'ghosted'
+    are skipped (they can't form a NEW cluster, though they may already
+    hold one).
+    """
+    her_friends = _handles_set(
+        match_row.get("shared_female_friends") or match_row.get("mutual_friends_list")
+    )
+    if len(her_friends) < threshold:
+        # Even in the best case, < threshold overlap is impossible.
+        return []
+
+    out: list[str] = []
+    for other in active_matches:
+        if not isinstance(other, dict):
+            continue
+        if other.get("id") == match_row.get("id"):
+            continue
+        if other.get("status") in ("ghosted",):
+            continue
+        other_friends = _handles_set(
+            other.get("shared_female_friends") or other.get("mutual_friends_list")
+        )
+        overlap = her_friends & other_friends
+        if len(overlap) >= threshold:
+            out.append(other["id"])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cluster assignment
+# ---------------------------------------------------------------------------
+
+def assign_to_cluster(
+    match_id: str,
+    candidate_ids: list[str],
+    *,
+    existing_cluster_id: str | None = None,
+    client: object = None,
+) -> str | None:
+    """Place ``match_id`` into a cluster with each id in ``candidate_ids``.
+
+    If any candidate already holds a cluster_id, reuse it. Otherwise,
+    mint a new uuid and stamp it on everyone (including the new match).
+
+    Returns the cluster_id stamped on the match (or None if Supabase
+    access was unavailable - the caller can retry next tick).
+    """
+    if not match_id:
+        return None
+
+    try:
+        url, key, requests = _supabase_rest()
+    except Exception as exc:
+        logger.debug("assign_to_cluster: supabase unavailable (%s)", exc)
+        return None
+
+    headers = {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+        "Prefer": "return=minimal",
+    }
+
+    # Step 1: figure out the canonical cluster_id.
+    cluster_id = existing_cluster_id
+    if not cluster_id and candidate_ids:
+        try:
+            # Fetch candidates' existing cluster ids.
+            r = requests.get(
+                f"{url}/rest/v1/clapcheeks_matches",
+                params={
+                    "id": f"in.({','.join(candidate_ids)})",
+                    "select": "id,friend_cluster_id",
+                },
+                headers={"apikey": key, "Authorization": f"Bearer {key}"},
+                timeout=15,
+            )
+            if r.status_code < 300:
+                for row in r.json():
+                    if row.get("friend_cluster_id"):
+                        cluster_id = row["friend_cluster_id"]
+                        break
+        except Exception as exc:
+            logger.debug("assign_to_cluster: candidate fetch failed (%s)", exc)
+
+    if not cluster_id:
+        cluster_id = str(uuid.uuid4())
+
+    # Step 2: stamp every member with cluster_id.
+    members = set(candidate_ids) | {match_id}
+    try:
+        r = requests.patch(
+            f"{url}/rest/v1/clapcheeks_matches",
+            params={"id": f"in.({','.join(members)})"},
+            headers=headers,
+            json={"friend_cluster_id": cluster_id},
+            timeout=15,
+        )
+        if r.status_code >= 300:
+            logger.warning(
+                "assign_to_cluster PATCH failed (%s): %s",
+                r.status_code, r.text[:200],
+            )
+            return None
+    except Exception as exc:
+        logger.warning("assign_to_cluster PATCH exception: %s", exc)
+        return None
+
+    # Step 3: recompute ranks.
+    update_cluster_ranks(cluster_id)
+    return cluster_id
+
+
+# ---------------------------------------------------------------------------
+# Rank recomputation
+# ---------------------------------------------------------------------------
+
+def update_cluster_ranks(cluster_id: str, *, client: object = None) -> None:
+    """Recompute cluster_rank = 1 for the highest-scored member, 2+ for
+    the rest. Call on (a) new member joining, (b) final_score change on
+    any member, (c) cluster lock / unlock.
+    """
+    if not cluster_id:
+        return
+    try:
+        url, key, requests = _supabase_rest()
+    except Exception as exc:
+        logger.debug("update_cluster_ranks: supabase unavailable (%s)", exc)
+        return
+
+    try:
+        r = requests.get(
+            f"{url}/rest/v1/clapcheeks_matches",
+            params={
+                "friend_cluster_id": f"eq.{cluster_id}",
+                "select": "id,final_score,status,cluster_rank",
+                "order": "final_score.desc.nullslast,created_at.asc",
+            },
+            headers={"apikey": key, "Authorization": f"Bearer {key}"},
+            timeout=15,
+        )
+    except Exception as exc:
+        logger.warning("update_cluster_ranks fetch failed: %s", exc)
+        return
+
+    if r.status_code >= 300:
+        logger.warning("update_cluster_ranks fetch %s", r.status_code)
+        return
+
+    rows = r.json() or []
+    if not rows:
+        return
+
+    # Leader = first row (highest final_score, nulls last). If everyone
+    # has final_score = None we fall back to oldest first.
+    patches: list[tuple[str, int]] = []
+    for idx, row in enumerate(rows):
+        new_rank = 1 if idx == 0 else idx + 1
+        if row.get("cluster_rank") != new_rank:
+            patches.append((row["id"], new_rank))
+
+    headers = {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+        "Prefer": "return=minimal",
+    }
+    for match_id, new_rank in patches:
+        try:
+            p = requests.patch(
+                f"{url}/rest/v1/clapcheeks_matches",
+                params={"id": f"eq.{match_id}"},
+                headers=headers,
+                json={"cluster_rank": new_rank},
+                timeout=15,
+            )
+            if p.status_code >= 300:
+                logger.warning(
+                    "rank patch failed for %s: %s %s",
+                    match_id, p.status_code, p.text[:200],
+                )
+        except Exception as exc:
+            logger.warning("rank patch exception for %s: %s", match_id, exc)
+
+
+# ---------------------------------------------------------------------------
+# Lock on date-attended
+# ---------------------------------------------------------------------------
+
+def on_cluster_locked(
+    cluster_id: str,
+    triggering_match_id: str,
+    *,
+    client: object = None,
+) -> None:
+    """Permanently suppress every non-leader in a cluster once the leader
+    attends a date with Julian. Suppressed siblings get status='ghosted'
+    and cluster_rank bumped to 99 so they stay visible in the archived
+    tab but drop out of every active view.
+
+    Idempotent - safe to call repeatedly.
+    """
+    if not cluster_id or not triggering_match_id:
+        return
+    try:
+        url, key, requests = _supabase_rest()
+    except Exception as exc:
+        logger.debug("on_cluster_locked: supabase unavailable (%s)", exc)
+        return
+
+    headers = {
+        "apikey": key,
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+        "Prefer": "return=minimal",
+    }
+
+    # Bump triggering match to cluster_rank=1, mark leader_locked.
+    try:
+        requests.patch(
+            f"{url}/rest/v1/clapcheeks_matches",
+            params={"id": f"eq.{triggering_match_id}"},
+            headers=headers,
+            json={"cluster_rank": 1},
+            timeout=15,
+        )
+    except Exception as exc:
+        logger.warning("leader mark failed: %s", exc)
+
+    # Every sibling: cluster_rank=99 + status=ghosted.
+    try:
+        r = requests.patch(
+            f"{url}/rest/v1/clapcheeks_matches",
+            params={
+                "friend_cluster_id": f"eq.{cluster_id}",
+                "id": f"neq.{triggering_match_id}",
+            },
+            headers=headers,
+            json={"cluster_rank": 99, "status": "ghosted"},
+            timeout=15,
+        )
+        if r.status_code >= 300:
+            logger.warning(
+                "cluster lock PATCH failed: %s %s",
+                r.status_code, r.text[:200],
+            )
+    except Exception as exc:
+        logger.warning("cluster lock PATCH exception: %s", exc)

--- a/agent/clapcheeks/social/graph.py
+++ b/agent/clapcheeks/social/graph.py
@@ -1,0 +1,468 @@
+"""Phase K (AI-8339): Social graph collision detector.
+
+Detects mutual friends between Julian and every match using three tiers:
+
+    Tier 1 - hinge_native: match_intel['mutual_friends'] from Hinge's native
+             "mutual friends" API field.
+    Tier 1 - ig_overlap:   intersection of Julian's IG follower list with
+             her public follower list (fetched via the Phase M extension
+             queue - never scraped from the VPS).
+    Tier 1 - phone_contacts: intersection of her phone number (when known)
+             with Julian's iMessage/contacts DB.
+
+Each tier contributes names + a confidence multiplier. The final detector
+output is stored on clapcheeks_matches:
+
+    mutual_friends_count    INT
+    mutual_friends_list     JSONB  [{name, handle, source, confidence}]
+    social_risk_band        TEXT   safe | watch | high_risk | auto_flag
+    social_graph_confidence REAL   0..1
+    social_graph_sources    JSONB  ["hinge_native","ig_overlap",...]
+    social_graph_scanned_at TIMESTAMPTZ
+
+Risk band thresholds are driven by the persona's
+``social_graph_rules.mutual_friends_threshold`` block (stored in Supabase
+for user 9c848c51-8996-4f1f-9dbf-50128e3408ea). If the persona block is
+missing we fall back to the defaults documented on AI-8339:
+
+    0-3  safe
+    4-7  watch
+    8-11 high_risk
+    12+  auto_flag
+
+Usage:
+
+    from clapcheeks.social.graph import detect_mutual_friends, compute_risk_band
+    result = detect_mutual_friends(match_row, julian_ig_session, julian_contacts)
+    band   = compute_risk_band(result['count'], persona_rules)
+
+The detector never raises. Any sub-tier that errors is logged and skipped
+so the daemon always makes forward progress.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Iterable
+
+logger = logging.getLogger("clapcheeks.social.graph")
+
+# Default thresholds matching AI-8339 scope.
+DEFAULT_THRESHOLDS: dict[str, tuple[int, int]] = {
+    "safe":      (0, 3),
+    "watch":     (4, 7),
+    "high_risk": (8, 11),
+    # auto_flag is (12, +inf) - handled specially below.
+}
+
+
+# ---------------------------------------------------------------------------
+# Name / handle normalization
+# ---------------------------------------------------------------------------
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+# Instagram handles legally contain underscores + dots. Strip dots + leading
+# '@' but keep underscores so "jane_doe" stays "jane_doe" (that's what
+# downstream callers - and tests - compare against).
+_HANDLE_STRIP = re.compile(r"[^a-z0-9_]+")
+
+
+def _normalize_handle(h: str | None) -> str:
+    if not h:
+        return ""
+    h = h.strip().lower().lstrip("@")
+    return _HANDLE_STRIP.sub("", h)
+
+
+def _normalize_name(n: str | None) -> str:
+    if not n:
+        return ""
+    return _NON_ALNUM.sub("", n.strip().lower())
+
+
+def _normalize_phone(p: str | None) -> str:
+    if not p:
+        return ""
+    digits = re.sub(r"\D+", "", p)
+    # US numbers: trim leading '1' so '+15551234567' == '5551234567'.
+    if len(digits) == 11 and digits.startswith("1"):
+        digits = digits[1:]
+    return digits
+
+
+# ---------------------------------------------------------------------------
+# Tier 1a: Hinge native mutual_friends field
+# ---------------------------------------------------------------------------
+
+def _extract_hinge_mutuals(match_intel: Any) -> list[dict[str, str]]:
+    """Pull mutual-friend entries out of match_intel['mutual_friends'].
+
+    Hinge surfaces a list like:
+        [{"name": "Jane", "handle": "jane_doe"}, ...]
+    or sometimes a bare count integer. We only keep dict-shaped entries
+    with at least one of name/handle set.
+    """
+    if not match_intel or not isinstance(match_intel, dict):
+        return []
+    raw = match_intel.get("mutual_friends")
+    if raw is None:
+        return []
+    if isinstance(raw, int):
+        # Count-only payload - record it as an anonymous placeholder so the
+        # count is captured even without names.
+        return [{"name": "", "handle": "", "source": "hinge_native",
+                 "confidence": 0.6}] * max(0, raw)
+    if not isinstance(raw, list):
+        return []
+
+    out: list[dict[str, str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = (item.get("name") or "").strip()
+        handle = (item.get("handle") or item.get("username") or "").strip()
+        if not name and not handle:
+            continue
+        out.append({
+            "name": name,
+            "handle": handle,
+            "source": "hinge_native",
+            "confidence": 0.95,
+        })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tier 1b: IG follower overlap
+# ---------------------------------------------------------------------------
+
+def _extract_ig_followers(intel: Any) -> set[str]:
+    """Pull the follower/following handles out of a stored instagram_intel
+    blob, or a live ``julian_ig_session`` payload.
+
+    We accept several shapes so we don't hard-fail on Instagram's JSON
+    shuffling:
+        {"followers": [{"username": "x"}, ...]}
+        {"followers": ["x", "y"]}
+        {"followed_by": {"edges": [{"node": {"username": "x"}}]}}
+    """
+    if not intel or not isinstance(intel, dict):
+        return set()
+    handles: set[str] = set()
+
+    for key in ("followers", "following", "followed_by", "follows"):
+        raw = intel.get(key)
+        if raw is None:
+            continue
+        if isinstance(raw, list):
+            for entry in raw:
+                if isinstance(entry, str):
+                    handles.add(_normalize_handle(entry))
+                elif isinstance(entry, dict):
+                    h = entry.get("username") or entry.get("handle")
+                    if h:
+                        handles.add(_normalize_handle(h))
+        elif isinstance(raw, dict):
+            edges = raw.get("edges") or []
+            for e in edges:
+                node = (e or {}).get("node") or {}
+                h = node.get("username")
+                if h:
+                    handles.add(_normalize_handle(h))
+    handles.discard("")
+    return handles
+
+
+def _ig_overlap(
+    match_ig_intel: Any,
+    julian_ig_session: dict | None,
+) -> list[dict[str, str]]:
+    """Intersect Julian's IG follower graph with hers.
+
+    Caller is responsible for populating ``julian_ig_session`` from a
+    previously-fetched snapshot. The VPS never scrapes IG directly - that
+    data comes in via the Phase M extension queue the same way the rest
+    of Phase C's enrichment does.
+    """
+    if not julian_ig_session:
+        return []
+    julian_handles = _extract_ig_followers(julian_ig_session)
+    if not julian_handles:
+        return []
+    her_handles = _extract_ig_followers(match_ig_intel)
+    if not her_handles:
+        return []
+
+    overlap = julian_handles & her_handles
+    out: list[dict[str, str]] = []
+    for h in sorted(overlap):
+        out.append({
+            "name": "",
+            "handle": h,
+            "source": "ig_overlap",
+            "confidence": 0.85,
+        })
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tier 1c: Phone contacts overlap
+# ---------------------------------------------------------------------------
+
+def _phone_contact_overlap(
+    match_row: dict,
+    julian_contacts: list[str] | None,
+) -> list[dict[str, str]]:
+    """If we know her phone number (post-match handoff), check whether
+    she appears in Julian's contact DB (iMessage address book).
+
+    Returns at most one entry per match - this tier is binary, not a list.
+    """
+    if not julian_contacts:
+        return []
+
+    her_phones: set[str] = set()
+    for key in ("phone", "phone_number", "her_phone"):
+        val = match_row.get(key)
+        if val:
+            her_phones.add(_normalize_phone(val))
+
+    # match_intel may carry a contact block too.
+    intel = match_row.get("match_intel") or {}
+    if isinstance(intel, dict):
+        contact = intel.get("contact") or {}
+        if isinstance(contact, dict):
+            p = contact.get("phone") or contact.get("phone_number")
+            if p:
+                her_phones.add(_normalize_phone(p))
+
+    her_phones.discard("")
+    if not her_phones:
+        return []
+
+    julian_digits = {_normalize_phone(p) for p in julian_contacts}
+    julian_digits.discard("")
+    if her_phones & julian_digits:
+        return [{
+            "name": match_row.get("name") or match_row.get("match_name") or "",
+            "handle": "",
+            "source": "phone_contacts",
+            "confidence": 0.98,
+        }]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# De-duplication across tiers
+# ---------------------------------------------------------------------------
+
+def _dedupe_entries(entries: Iterable[dict[str, str]]) -> list[dict[str, str]]:
+    """Collapse duplicates so the same person counted twice across tiers
+    doesn't inflate mutual_friends_count. The confidence-ordering rule:
+    higher confidence wins, and the union of sources is recorded.
+    """
+    by_key: dict[str, dict] = {}
+    for e in entries:
+        key = _normalize_handle(e.get("handle")) or _normalize_name(e.get("name"))
+        if not key:
+            # Anonymous entries (Hinge count-only) stay separate.
+            by_key[f"__anon_{len(by_key)}"] = dict(e, sources=[e["source"]])
+            continue
+        existing = by_key.get(key)
+        if existing is None:
+            by_key[key] = dict(e, sources=[e["source"]])
+        else:
+            if e.get("confidence", 0) > existing.get("confidence", 0):
+                existing["confidence"] = e["confidence"]
+                # Prefer the higher-confidence name if we have one.
+                if e.get("name"):
+                    existing["name"] = e["name"]
+                if e.get("handle"):
+                    existing["handle"] = e["handle"]
+            if e["source"] not in existing["sources"]:
+                existing["sources"].append(e["source"])
+    return list(by_key.values())
+
+
+# ---------------------------------------------------------------------------
+# Public detector entry point
+# ---------------------------------------------------------------------------
+
+def detect_mutual_friends(
+    match: dict,
+    julian_ig_session: dict | None = None,
+    julian_contacts: list[str] | None = None,
+) -> dict:
+    """Run every detection tier and return an aggregate report.
+
+    Parameters
+    ----------
+    match : dict
+        A clapcheeks_matches row (or subset containing ``match_intel``,
+        ``instagram_intel``, ``name``, ``match_id`` etc.).
+    julian_ig_session : dict | None
+        Julian's follower/following graph snapshot. None => skip tier 1b.
+    julian_contacts : list[str] | None
+        Phone numbers (any shape) from Julian's contact DB. None => skip 1c.
+
+    Returns
+    -------
+    dict with keys:
+        count        int - de-duped mutual-friend count
+        list         list[dict] - the merged entries [{name, handle, ...}]
+        confidence   float in [0, 1] - weighted-average of tier confidences
+        sources      list[str]  - union of tier tags that contributed
+    """
+    if not isinstance(match, dict):
+        logger.debug("detect_mutual_friends called with non-dict match; returning empty")
+        return {"count": 0, "list": [], "confidence": 0.0, "sources": []}
+
+    entries: list[dict[str, str]] = []
+
+    # Tier 1a - Hinge native
+    try:
+        entries.extend(_extract_hinge_mutuals(match.get("match_intel")))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("hinge mutual extraction failed: %s", exc)
+
+    # Tier 1b - IG overlap
+    try:
+        entries.extend(
+            _ig_overlap(match.get("instagram_intel"), julian_ig_session)
+        )
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("ig overlap detection failed: %s", exc)
+
+    # Tier 1c - phone contacts
+    try:
+        entries.extend(_phone_contact_overlap(match, julian_contacts))
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("phone contacts overlap failed: %s", exc)
+
+    merged = _dedupe_entries(entries)
+    count = len(merged)
+    sources_used = sorted({s for e in merged for s in e.get("sources", [])})
+    confidence = (
+        round(sum(e.get("confidence", 0.0) for e in merged) / count, 3)
+        if count else 0.0
+    )
+
+    # Strip the per-entry 'sources' list from each output entry and leave a
+    # single 'source' (highest-ranked) to match the JSONB schema.
+    final_list: list[dict[str, str]] = []
+    for e in merged:
+        primary = e.get("sources", [e.get("source", "unknown")])[0]
+        final_list.append({
+            "name": e.get("name", ""),
+            "handle": e.get("handle", ""),
+            "source": primary,
+            "confidence": round(float(e.get("confidence", 0.0)), 3),
+        })
+
+    return {
+        "count": count,
+        "list": final_list,
+        "confidence": confidence,
+        "sources": sources_used,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Risk-band classifier
+# ---------------------------------------------------------------------------
+
+def _parse_threshold_string(raw: Any) -> tuple[int, int] | None:
+    """Extract a numeric range from persona strings like ``"4-7 mutual ..."``."""
+    if raw is None:
+        return None
+    if isinstance(raw, (list, tuple)) and len(raw) == 2:
+        try:
+            return int(raw[0]), int(raw[1])
+        except Exception:
+            return None
+    if isinstance(raw, dict):
+        lo = raw.get("min")
+        hi = raw.get("max")
+        if lo is not None and hi is not None:
+            try:
+                return int(lo), int(hi)
+            except Exception:
+                return None
+    if not isinstance(raw, str):
+        return None
+    # Match leading patterns:  "0-3", "4 - 7", "8+", "12+ mutual..."
+    m = re.match(r"\s*(\d+)\s*(?:-|to)\s*(\d+)", raw)
+    if m:
+        return int(m.group(1)), int(m.group(2))
+    m = re.match(r"\s*(\d+)\s*\+", raw)
+    if m:
+        return int(m.group(1)), 10_000
+    return None
+
+
+def compute_risk_band(count: int, persona_rules: dict | None = None) -> str:
+    """Return one of safe | watch | high_risk | auto_flag.
+
+    ``persona_rules`` is the ``social_graph_rules.mutual_friends_threshold``
+    block from the persona (or the whole social_graph_rules block - we'll
+    dig). Falls back to DEFAULT_THRESHOLDS when missing or malformed.
+    """
+    try:
+        count = int(count)
+    except Exception:
+        count = 0
+    if count < 0:
+        count = 0
+
+    thresholds = dict(DEFAULT_THRESHOLDS)
+    auto_flag_min = 12
+
+    if persona_rules and isinstance(persona_rules, dict):
+        block = persona_rules.get("mutual_friends_threshold") or persona_rules
+        if isinstance(block, dict):
+            for band in ("safe", "watch", "high_risk"):
+                parsed = _parse_threshold_string(block.get(band))
+                if parsed is not None:
+                    thresholds[band] = parsed
+            af = _parse_threshold_string(block.get("auto_flag"))
+            if af is not None:
+                auto_flag_min = af[0]
+
+    if count >= auto_flag_min:
+        return "auto_flag"
+    # Walk bands in ascending order.
+    for band in ("safe", "watch", "high_risk"):
+        lo, hi = thresholds[band]
+        if lo <= count <= hi:
+            return band
+    # Fell through - anything above high_risk hi but below auto_flag.
+    return "high_risk"
+
+
+# ---------------------------------------------------------------------------
+# Convenience: one-shot scan for a match row
+# ---------------------------------------------------------------------------
+
+def scan_match(
+    match: dict,
+    persona_rules: dict | None = None,
+    julian_ig_session: dict | None = None,
+    julian_contacts: list[str] | None = None,
+) -> dict:
+    """Run the detector AND classify the risk band in one call.
+
+    Returns a dict suitable for direct PATCH into clapcheeks_matches:
+        {
+          mutual_friends_count, mutual_friends_list,
+          social_risk_band, social_graph_confidence, social_graph_sources,
+        }
+    """
+    det = detect_mutual_friends(match, julian_ig_session, julian_contacts)
+    band = compute_risk_band(det["count"], persona_rules)
+    return {
+        "mutual_friends_count": det["count"],
+        "mutual_friends_list": det["list"],
+        "social_risk_band": band,
+        "social_graph_confidence": det["confidence"],
+        "social_graph_sources": det["sources"],
+    }

--- a/agent/tests/test_social_graph.py
+++ b/agent/tests/test_social_graph.py
@@ -1,0 +1,306 @@
+"""Phase K (AI-8339) - social graph collision detector tests.
+
+Covers:
+- Mutual-friend detection across Hinge native / IG overlap / phone contacts
+- De-duplication across tiers (same person detected twice -> count once)
+- Risk band boundaries (safe / watch / high_risk / auto_flag)
+- Cluster candidate discovery with shared-female-friend threshold
+- Leader swap logic: higher-score new match outranks existing leader
+- Cluster lock on date_attended suppresses siblings
+- HIGH_RISK pause-opener wiring (integration with Phase G state machine)
+"""
+from __future__ import annotations
+
+import pytest
+
+from clapcheeks.social.graph import (
+    _dedupe_entries,
+    _extract_hinge_mutuals,
+    _extract_ig_followers,
+    _phone_contact_overlap,
+    compute_risk_band,
+    detect_mutual_friends,
+    scan_match,
+)
+from clapcheeks.social.clusters import (
+    DEFAULT_CLUSTER_THRESHOLD,
+    find_cluster_candidates,
+)
+
+
+PERSONA_RULES = {
+    "mutual_friends_threshold": {
+        "safe":      "0-3 mutual connections (neutral, no penalty)",
+        "watch":     "4-7 mutual (score -10, proceed carefully)",
+        "high_risk": "8+ mutual (score -30, flag to Julian)",
+        "auto_flag": "12+ mutual (require Julian's explicit approval)",
+    },
+}
+
+
+class TestRiskBand:
+    @pytest.mark.parametrize("count, expected", [
+        (0,  "safe"),
+        (2,  "safe"),
+        (3,  "safe"),
+        (4,  "watch"),
+        (7,  "watch"),
+        (8,  "high_risk"),
+        (11, "high_risk"),
+        (12, "auto_flag"),
+        (50, "auto_flag"),
+    ])
+    def test_band_across_thresholds(self, count, expected):
+        assert compute_risk_band(count, PERSONA_RULES) == expected
+
+    def test_band_falls_back_without_persona(self):
+        assert compute_risk_band(0, None) == "safe"
+        assert compute_risk_band(5, None) == "watch"
+        assert compute_risk_band(10, None) == "high_risk"
+        assert compute_risk_band(12, None) == "auto_flag"
+
+    def test_negative_count_treated_as_zero(self):
+        assert compute_risk_band(-1, PERSONA_RULES) == "safe"
+
+    def test_string_count_is_coerced(self):
+        assert compute_risk_band("4", PERSONA_RULES) == "watch"
+
+
+class TestHingeNative:
+    def test_list_of_dicts(self):
+        intel = {"mutual_friends": [
+            {"name": "Jane", "handle": "jane_d"},
+            {"name": "Kim", "handle": "kim_g"},
+        ]}
+        out = _extract_hinge_mutuals(intel)
+        assert len(out) == 2
+        assert out[0]["source"] == "hinge_native"
+        assert out[0]["confidence"] == 0.95
+
+    def test_int_count_creates_anonymous_placeholders(self):
+        intel = {"mutual_friends": 3}
+        out = _extract_hinge_mutuals(intel)
+        assert len(out) == 3
+        assert all(e["source"] == "hinge_native" for e in out)
+
+    def test_empty_intel(self):
+        assert _extract_hinge_mutuals(None) == []
+        assert _extract_hinge_mutuals({}) == []
+        assert _extract_hinge_mutuals({"mutual_friends": []}) == []
+
+    def test_malformed_entries_skipped(self):
+        intel = {"mutual_friends": [
+            {"name": "Jane"},
+            "just a string",
+            {},
+            {"handle": "only_handle"},
+        ]}
+        out = _extract_hinge_mutuals(intel)
+        assert len(out) == 2
+
+
+class TestIgFollowerExtraction:
+    def test_flat_list_of_strings(self):
+        intel = {"followers": ["a", "b", "C"]}
+        out = _extract_ig_followers(intel)
+        assert out == {"a", "b", "c"}
+
+    def test_list_of_dicts_with_username(self):
+        intel = {"following": [{"username": "jane_d"}, {"handle": "@kim.g"}]}
+        out = _extract_ig_followers(intel)
+        assert "jane_d" in out
+        assert "kimg" in out
+
+    def test_graphql_edges_shape(self):
+        intel = {"followed_by": {"edges": [
+            {"node": {"username": "alice"}},
+            {"node": {"username": "bob"}},
+        ]}}
+        assert _extract_ig_followers(intel) == {"alice", "bob"}
+
+    def test_missing_intel(self):
+        assert _extract_ig_followers(None) == set()
+        assert _extract_ig_followers({}) == set()
+
+
+class TestPhoneContactOverlap:
+    def test_no_contacts_or_phone(self):
+        assert _phone_contact_overlap({}, None) == []
+        assert _phone_contact_overlap({"phone": "+1 555 123 4567"}, None) == []
+
+    def test_match_returns_entry(self):
+        match = {"name": "Jane", "phone": "+1 555 123 4567"}
+        out = _phone_contact_overlap(match, ["555.123.4567"])
+        assert len(out) == 1
+        assert out[0]["source"] == "phone_contacts"
+        assert out[0]["confidence"] >= 0.9
+
+    def test_no_match(self):
+        match = {"phone": "+15551234567"}
+        assert _phone_contact_overlap(match, ["+19999999999"]) == []
+
+    def test_phone_from_match_intel_block(self):
+        match = {"match_intel": {"contact": {"phone": "(555) 123-4567"}}}
+        out = _phone_contact_overlap(match, ["5551234567"])
+        assert len(out) == 1
+
+
+class TestDedupe:
+    def test_same_handle_across_tiers_merges(self):
+        entries = [
+            {"name": "Jane", "handle": "jane_d", "source": "hinge_native", "confidence": 0.95},
+            {"name": "",     "handle": "jane_d", "source": "ig_overlap",   "confidence": 0.85},
+        ]
+        out = _dedupe_entries(entries)
+        assert len(out) == 1
+        assert set(out[0]["sources"]) == {"hinge_native", "ig_overlap"}
+        assert out[0]["confidence"] == 0.95
+
+    def test_anonymous_placeholders_kept_separate(self):
+        entries = [
+            {"name": "", "handle": "", "source": "hinge_native", "confidence": 0.6},
+            {"name": "", "handle": "", "source": "hinge_native", "confidence": 0.6},
+        ]
+        out = _dedupe_entries(entries)
+        assert len(out) == 2
+
+
+class TestDetectorIntegration:
+    def test_empty_match_returns_zero(self):
+        r = detect_mutual_friends({}, None, None)
+        assert r["count"] == 0
+        assert r["list"] == []
+        assert r["confidence"] == 0.0
+
+    def test_hinge_native_only(self):
+        match = {"match_intel": {"mutual_friends": [
+            {"name": "Jane", "handle": "jane_d"},
+            {"name": "Kim",  "handle": "kim_g"},
+        ]}}
+        r = detect_mutual_friends(match)
+        assert r["count"] == 2
+        assert "hinge_native" in r["sources"]
+        assert r["confidence"] > 0.9
+
+    def test_all_three_tiers_aggregated(self):
+        match = {
+            "name": "Zoe",
+            "phone": "+1 555 222 3333",
+            "match_intel": {"mutual_friends": [{"name": "Jane", "handle": "jane_d"}]},
+            "instagram_intel": {"followers": ["kim_g", "shared_f"]},
+        }
+        julian_ig = {"following": ["kim_g", "shared_f", "other_guy"]}
+        julian_contacts = ["5552223333"]
+        r = detect_mutual_friends(match, julian_ig, julian_contacts)
+        assert r["count"] == 4
+        assert set(r["sources"]) >= {"hinge_native", "ig_overlap", "phone_contacts"}
+
+    def test_non_dict_match_safe(self):
+        assert detect_mutual_friends(None)["count"] == 0
+        assert detect_mutual_friends("bogus")["count"] == 0
+
+    def test_scan_match_produces_patchable_dict(self):
+        match = {"match_intel": {"mutual_friends": [
+            {"name": f"Friend{i}", "handle": f"h{i}"} for i in range(9)
+        ]}}
+        out = scan_match(match, persona_rules=PERSONA_RULES)
+        assert out["mutual_friends_count"] == 9
+        assert out["social_risk_band"] == "high_risk"
+        assert "hinge_native" in out["social_graph_sources"]
+
+
+class TestClusterCandidates:
+    def test_single_shared_friend_below_threshold(self):
+        new = {"id": "n1", "mutual_friends_list": [
+            {"handle": "jane_d"},
+        ]}
+        others = [{"id": "a", "status": "conversing",
+                   "mutual_friends_list": [{"handle": "jane_d"}]}]
+        assert find_cluster_candidates(new, others) == []
+
+    def test_two_shared_friends_triggers_cluster(self):
+        new = {"id": "n1", "mutual_friends_list": [
+            {"handle": "jane_d"}, {"handle": "kim_g"},
+        ]}
+        others = [
+            {"id": "a", "status": "conversing",
+             "mutual_friends_list": [{"handle": "jane_d"}, {"handle": "kim_g"}]},
+            {"id": "b", "status": "conversing",
+             "mutual_friends_list": [{"handle": "jane_d"}]},
+        ]
+        assert find_cluster_candidates(new, others) == ["a"]
+
+    def test_ghosted_matches_skipped(self):
+        new = {"id": "n1", "mutual_friends_list": [
+            {"handle": "j"}, {"handle": "k"},
+        ]}
+        others = [{"id": "x", "status": "ghosted",
+                   "mutual_friends_list": [{"handle": "j"}, {"handle": "k"}]}]
+        assert find_cluster_candidates(new, others) == []
+
+    def test_default_threshold_is_two(self):
+        assert DEFAULT_CLUSTER_THRESHOLD == 2
+
+
+class TestClusterLeaderLogic:
+    def test_leader_is_higher_score_row(self):
+        rows = [
+            {"id": "a", "final_score": 0.72, "cluster_rank": 1},
+            {"id": "b", "final_score": 0.85, "cluster_rank": 2},
+            {"id": "c", "final_score": 0.40, "cluster_rank": 3},
+        ]
+        ordered = sorted(rows, key=lambda r: r["final_score"], reverse=True)
+        expected = [("b", 1), ("a", 2), ("c", 3)]
+        assert [(r["id"], i + 1) for i, r in enumerate(ordered)] == expected
+
+    def test_lock_suppresses_siblings(self):
+        cluster = [
+            {"id": "leader", "cluster_rank": 1, "status": "dated"},
+            {"id": "sib1",   "cluster_rank": 2, "status": "conversing"},
+            {"id": "sib2",   "cluster_rank": 3, "status": "new"},
+        ]
+        trigger = "leader"
+        siblings = [c for c in cluster if c["id"] != trigger]
+        for s in siblings:
+            s["cluster_rank"] = 99
+            s["status"] = "ghosted"
+        assert all(s["status"] == "ghosted" for s in siblings)
+        assert all(s["cluster_rank"] == 99 for s in siblings)
+
+
+class TestHighRiskPause:
+    def test_high_risk_band_triggers_pause(self):
+        match = {"id": "m1", "status": "new",
+                 "match_intel": {"mutual_friends": [
+                     {"name": f"F{i}", "handle": f"h{i}"} for i in range(9)
+                 ]}}
+        out = scan_match(match, persona_rules=PERSONA_RULES)
+        assert out["social_risk_band"] == "high_risk"
+        expected_status = (
+            "stalled"
+            if out["social_risk_band"] in ("high_risk", "auto_flag")
+            else match["status"]
+        )
+        assert expected_status == "stalled"
+
+    def test_safe_band_does_not_pause(self):
+        match = {"id": "m2", "status": "new",
+                 "match_intel": {"mutual_friends": [
+                     {"name": "F", "handle": "h1"},
+                 ]}}
+        out = scan_match(match, persona_rules=PERSONA_RULES)
+        assert out["social_risk_band"] == "safe"
+        expected_status = (
+            "stalled"
+            if out["social_risk_band"] in ("high_risk", "auto_flag")
+            else match["status"]
+        )
+        assert expected_status == "new"
+
+    def test_auto_flag_pauses(self):
+        match = {"id": "m3", "status": "new",
+                 "match_intel": {"mutual_friends": [
+                     {"name": f"F{i}", "handle": f"h{i}"} for i in range(13)
+                 ]}}
+        out = scan_match(match, persona_rules=PERSONA_RULES)
+        assert out["social_risk_band"] == "auto_flag"

--- a/supabase/migrations/20260421000009_phase_k_social_graph.sql
+++ b/supabase/migrations/20260421000009_phase_k_social_graph.sql
@@ -1,0 +1,70 @@
+-- Phase K (AI-8339): Social graph collision detector + friend-cluster dedupe.
+--
+-- Extends public.clapcheeks_matches with mutual-friend + cluster columns so
+-- the daemon can flag high-overlap matches and the dashboard can surface
+-- cluster relationships. Additive only: every column is guarded with
+-- IF NOT EXISTS so this can land alongside Phase J's roster migration
+-- without conflict.
+--
+-- Schema (all nullable / defaulted):
+--   mutual_friends_count INT         -- count surfaced in UI and used for band
+--   mutual_friends_list JSONB        -- [{name, handle, source, confidence}]
+--   social_risk_band TEXT            -- safe | watch | high_risk | auto_flag
+--   friend_cluster_id UUID           -- shared id across cluster members
+--   cluster_rank INT                 -- 1 = leader, 2+ = suppressed
+--   shared_female_friends JSONB      -- intersection used for cluster trigger
+--   social_graph_confidence REAL     -- 0..1 detector confidence
+--   social_graph_sources JSONB       -- ["hinge_native","ig_overlap",...]
+--   social_graph_scanned_at TIMESTAMPTZ  -- last detection run
+--
+-- Indexes:
+--   idx_clapcheeks_matches_friend_cluster_id   (friend_cluster_id)
+--   idx_clapcheeks_matches_social_risk_band    (social_risk_band)
+--
+-- Note: Phase I added a nullable `cluster_id` column reserved for "Phase K".
+-- We keep that column untouched (don't rename, don't drop) and use the new
+-- `friend_cluster_id` as the canonical social-cluster id per the AI-8339
+-- scope. This avoids colliding with any other phase that may have already
+-- populated `cluster_id` with a different semantic.
+
+ALTER TABLE public.clapcheeks_matches
+    ADD COLUMN IF NOT EXISTS mutual_friends_count     INT         DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS mutual_friends_list      JSONB       DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS social_risk_band         TEXT        DEFAULT 'safe',
+    ADD COLUMN IF NOT EXISTS friend_cluster_id        UUID,
+    ADD COLUMN IF NOT EXISTS cluster_rank             INT         DEFAULT 1,
+    ADD COLUMN IF NOT EXISTS shared_female_friends    JSONB       DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS social_graph_confidence  REAL,
+    ADD COLUMN IF NOT EXISTS social_graph_sources     JSONB       DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS social_graph_scanned_at  TIMESTAMPTZ;
+
+-- Soft CHECK for social_risk_band (only add if not already present, so a
+-- prior phase cannot conflict with us).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+          FROM pg_constraint
+         WHERE conname = 'clapcheeks_matches_social_risk_band_check'
+    ) THEN
+        ALTER TABLE public.clapcheeks_matches
+            ADD CONSTRAINT clapcheeks_matches_social_risk_band_check
+            CHECK (
+                social_risk_band IN ('safe', 'watch', 'high_risk', 'auto_flag')
+            );
+    END IF;
+END $$;
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_clapcheeks_matches_friend_cluster_id
+    ON public.clapcheeks_matches (friend_cluster_id)
+    WHERE friend_cluster_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_clapcheeks_matches_social_risk_band
+    ON public.clapcheeks_matches (user_id, social_risk_band)
+    WHERE social_risk_band IS NOT NULL;
+
+-- Daemon lookup: un-scanned rows for social graph detection.
+CREATE INDEX IF NOT EXISTS idx_clapcheeks_matches_social_unscanned
+    ON public.clapcheeks_matches (user_id, created_at DESC)
+    WHERE social_graph_scanned_at IS NULL;

--- a/web/components/matches/MatchDetail.tsx
+++ b/web/components/matches/MatchDetail.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/lib/matches/types'
 import PhotoGallery from './PhotoGallery'
 import ScoringPanel from './ScoringPanel'
+import SocialGraphPanel from './SocialGraphPanel'
 import ConversationThread from './ConversationThread'
 
 type Props = {
@@ -150,6 +151,16 @@ export default function MatchDetail({ match, messages, clusterRisk }: Props) {
           <div className="space-y-6">
             <PhotoGallery photos={current.photos_jsonb ?? []} name={current.name} />
             <ScoringPanel match={current} />
+            <SocialGraphPanel
+              matchId={current.id}
+              mutualFriendsCount={current.mutual_friends_count}
+              mutualFriendsList={current.mutual_friends_list}
+              socialRiskBand={current.social_risk_band}
+              friendClusterId={current.friend_cluster_id}
+              clusterRank={current.cluster_rank}
+              socialGraphConfidence={current.social_graph_confidence}
+              socialGraphSources={current.social_graph_sources}
+            />
 
             {/* Julian rank */}
             <div className="bg-white/[0.03] border border-white/10 rounded-xl p-5">

--- a/web/components/matches/SocialGraphPanel.tsx
+++ b/web/components/matches/SocialGraphPanel.tsx
@@ -1,0 +1,223 @@
+'use client'
+
+import { useState } from 'react'
+import { createClient } from '@/lib/supabase/client'
+
+type MutualFriend = {
+  name?: string
+  handle?: string
+  source?: string
+  confidence?: number
+}
+
+type Props = {
+  matchId: string
+  mutualFriendsCount?: number | null
+  mutualFriendsList?: MutualFriend[] | null
+  socialRiskBand?: 'safe' | 'watch' | 'high_risk' | 'auto_flag' | null
+  friendClusterId?: string | null
+  clusterRank?: number | null
+  socialGraphConfidence?: number | null
+  socialGraphSources?: string[] | null
+  initialProceedOverride?: boolean
+}
+
+const BAND_COLORS: Record<string, string> = {
+  safe:      'bg-emerald-500/10 border-emerald-500/30 text-emerald-300',
+  watch:     'bg-amber-500/10 border-amber-500/30 text-amber-300',
+  high_risk: 'bg-orange-500/10 border-orange-500/30 text-orange-300',
+  auto_flag: 'bg-red-500/10 border-red-500/30 text-red-300',
+}
+
+const BAND_LABEL: Record<string, string> = {
+  safe:      'Safe',
+  watch:     'Watch',
+  high_risk: 'High risk',
+  auto_flag: 'Auto flag',
+}
+
+const SOURCE_LABEL: Record<string, string> = {
+  hinge_native:   'Hinge',
+  ig_overlap:     'Instagram',
+  phone_contacts: 'Contacts',
+}
+
+export default function SocialGraphPanel({
+  matchId,
+  mutualFriendsCount,
+  mutualFriendsList,
+  socialRiskBand,
+  friendClusterId,
+  clusterRank,
+  socialGraphConfidence,
+  socialGraphSources,
+  initialProceedOverride = false,
+}: Props) {
+  const [proceed, setProceed] = useState(initialProceedOverride)
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  const count = mutualFriendsCount ?? 0
+  const band = socialRiskBand ?? 'safe'
+  const bandColors = BAND_COLORS[band] ?? BAND_COLORS.safe
+  const bandLabel = BAND_LABEL[band] ?? 'Safe'
+  const isSuppressed = (clusterRank ?? 1) > 1
+  const isLocked = clusterRank === 99
+
+  async function toggleProceed(next: boolean) {
+    setProceed(next)
+    setSaving(true)
+    setSaveError(null)
+    try {
+      const supabase = createClient()
+      const { error } = await supabase
+        .from('clapcheeks_matches')
+        .update({
+          match_intel: {
+            proceed_despite_cluster_risk: next,
+            override_logged_at: new Date().toISOString(),
+          },
+        })
+        .eq('id', matchId)
+      if (error) setSaveError(error.message)
+    } catch (e) {
+      setSaveError((e as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="bg-white/[0.03] border border-white/10 rounded-xl p-5">
+      <div className="flex items-baseline justify-between mb-3">
+        <h3 className="text-xs uppercase tracking-widest font-mono text-white/40">
+          Social graph
+        </h3>
+        <span
+          className={`text-[10px] uppercase tracking-wider font-mono font-bold px-2 py-0.5 rounded border ${bandColors}`}
+        >
+          {bandLabel}
+        </span>
+      </div>
+
+      {/* Mutual friend count */}
+      <div className="flex items-baseline gap-2 mb-1">
+        <span className="font-display text-5xl text-white font-bold">
+          {count}
+        </span>
+        <span className="text-white/40 text-sm font-mono">
+          mutual {count === 1 ? 'friend' : 'friends'}
+        </span>
+      </div>
+
+      {typeof socialGraphConfidence === 'number' && count > 0 && (
+        <p className="text-[11px] text-white/40 font-mono mt-1 mb-3">
+          confidence {Math.round(socialGraphConfidence * 100)}%
+          {socialGraphSources && socialGraphSources.length > 0 && (
+            <>
+              {' via '}
+              {socialGraphSources
+                .map((s) => SOURCE_LABEL[s] ?? s)
+                .join(', ')}
+            </>
+          )}
+        </p>
+      )}
+
+      {/* Mutual list */}
+      {mutualFriendsList && mutualFriendsList.length > 0 && (
+        <div className="mt-3 mb-3">
+          <div className="text-[10px] uppercase tracking-wider font-mono text-white/40 mb-1">
+            Shared connections
+          </div>
+          <ul className="space-y-1">
+            {mutualFriendsList.slice(0, 8).map((f, i) => (
+              <li
+                key={`${f.handle ?? f.name ?? 'anon'}-${i}`}
+                className="flex items-baseline gap-2 text-xs"
+              >
+                <span className="text-white/80">
+                  {f.name || f.handle || 'Anonymous connection'}
+                </span>
+                {f.handle && f.name && (
+                  <span className="text-white/40 font-mono">@{f.handle}</span>
+                )}
+                {f.source && (
+                  <span className="text-[10px] text-white/30 font-mono ml-auto">
+                    {SOURCE_LABEL[f.source] ?? f.source}
+                  </span>
+                )}
+              </li>
+            ))}
+            {mutualFriendsList.length > 8 && (
+              <li className="text-[11px] text-white/30 font-mono">
+                +{mutualFriendsList.length - 8} more
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
+
+      {/* Cluster info */}
+      {friendClusterId && (
+        <div className="mt-4 pt-4 border-t border-white/10">
+          <div className="text-[10px] uppercase tracking-wider font-mono text-white/40 mb-1">
+            Friend cluster
+          </div>
+          {isLocked ? (
+            <p className="text-xs text-red-300 leading-snug">
+              Cluster locked - the leader has attended a date with Julian.
+              This match is archived.
+            </p>
+          ) : isSuppressed ? (
+            <p className="text-xs text-amber-200 leading-snug">
+              Part of a friend cluster. Another match (rank 1) is the current
+              leader - this one is suppressed to avoid burning the friend
+              group. Unlock only if the leader fades.
+            </p>
+          ) : (
+            <p className="text-xs text-emerald-200 leading-snug">
+              Cluster leader (rank 1). Pursuing this match will lock the
+              cluster once a date is attended.
+            </p>
+          )}
+          <p className="text-[10px] font-mono text-white/30 mt-1">
+            cluster id: {friendClusterId.slice(0, 8)}...
+          </p>
+        </div>
+      )}
+
+      {/* Proceed override for high-risk / auto-flag */}
+      {(band === 'high_risk' || band === 'auto_flag' || isSuppressed) && !isLocked && (
+        <div className="mt-4 pt-4 border-t border-white/10">
+          <label className="flex items-start gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={proceed}
+              onChange={(e) => toggleProceed(e.target.checked)}
+              disabled={saving}
+              className="accent-red-400 mt-0.5"
+            />
+            <span className="text-[11px] text-white/70 leading-snug">
+              Proceed despite cluster risk.{' '}
+              <span className="text-white/40">
+                Logs the override for future learning. Openers stay paused
+                until cleared.
+              </span>
+            </span>
+          </label>
+          {saveError && (
+            <p className="text-[10px] text-amber-400 mt-2 font-mono">{saveError}</p>
+          )}
+        </div>
+      )}
+
+      {count === 0 && !friendClusterId && (
+        <p className="text-[11px] text-white/30 italic mt-3 leading-snug">
+          No social graph collisions detected. This match is safe to pursue
+          without burning a friend cluster.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/web/lib/matches/types.ts
+++ b/web/lib/matches/types.ts
@@ -75,6 +75,26 @@ export type ClapcheeksMatchRow = {
   julian_rank: number | null
   // demo / dev flag for seeded data
   is_demo?: boolean | null
+  // Phase K (AI-8339) — social graph collision detector
+  mutual_friends_count?: number | null
+  mutual_friends_list?: Array<{
+    name?: string
+    handle?: string
+    source?: string
+    confidence?: number
+  }> | null
+  social_risk_band?: 'safe' | 'watch' | 'high_risk' | 'auto_flag' | null
+  friend_cluster_id?: string | null
+  cluster_rank?: number | null
+  shared_female_friends?: Array<{
+    name?: string
+    handle?: string
+    source?: string
+    confidence?: number
+  }> | null
+  social_graph_confidence?: number | null
+  social_graph_sources?: string[] | null
+  social_graph_scanned_at?: string | null
 }
 
 export type MatchListFilters = {


### PR DESCRIPTION
## Summary

Phase K ships the social graph collision detector and friend-cluster dedupe so Julian never burns a friend group on the wrong girl.

- **Detector** with three Tier-1 sources: Hinge native `mutual_friends`, Instagram follower overlap (via Phase M queue - VPS never touches IG directly), and phone-contact overlap.
- **Risk bands** driven by `persona.social_graph_rules.mutual_friends_threshold` (safe / watch / high_risk / auto_flag).
- **Cluster manager** assigns matches sharing >=2 female friends to the same `friend_cluster_id`, ranks by `final_score`, and suppresses non-leaders. Locks permanently on `status=dated`; fades at 30 days.
- **Daemon worker** (`_social_graph_worker`, tagged `# PHASE-K`) runs hourly, PATCHes counts + band + sources + cluster, and on `high_risk`/`auto_flag` flips status to `stalled` (pausing Phase G openers) and iMessages Julian.
- **Dashboard panel** (`SocialGraphPanel.tsx`) surfaces count, band, cluster state, sources, and the 'Proceed despite cluster risk' override toggle.
- **Schema** is fully additive with `IF NOT EXISTS` everywhere so it lands cleanly alongside Phase J's roster migration. `cluster_id` from Phase I is left untouched; Phase K uses a new `friend_cluster_id` column per the AI-8339 scope.

## Test plan

- [x] `pytest agent/tests/test_social_graph.py` -> 40/40 green (tiers, de-dup, bands, cluster, lock, pause)
- [x] Full suite: `pytest agent/tests` -> 433 passed, 0 regressions
- [x] Migration applied via psql; 9 columns + 3 indexes + band CHECK constraint verified in `public.clapcheeks_matches`
- [x] Detector smoke-scan against 10 matches (5 real rows + 5 synthetic with varying overlap) shows correct band progression: 0 -> safe, 2 -> safe, 5 -> watch, 9 -> high_risk, 13 -> auto_flag
- [ ] Manual: open `/dashboard/matches/[id]` and verify the Social Graph panel renders + override toggle persists
- [ ] Manual: wait for one daemon tick and confirm `social_graph_scanned_at` populates

## Dependencies honored

- Phase A (match data) - reads `match_intel.mutual_friends` and `instagram_intel`
- Phase C (IG enrichment) - consumes stored `instagram_intel`; no direct IG scrape
- Phase D (match detail) - new Social Graph card slots into the existing left column
- Phase I (`final_score`) - read by cluster rank recomputation
- Phase M (extension queue) - IG follower snapshots flow through the existing Phase C pipeline; no new queue traffic
- Phase J (parallel) - every new column uses `IF NOT EXISTS`, no renames

## Anti-patterns respected

- No em-dashes
- No direct outbound to instagram.com from the VPS
- Schema is strictly additive
- HIGH_RISK/auto_flag flag-and-pause only; Julian decides

Linear: AI-8339