### PR TITLE
AI-8334: Phase 35 anti-detection + safety fixes

### DIFF
--- a/agent/clapcheeks/safety/ban_monitor.py
+++ b/agent/clapcheeks/safety/ban_monitor.py
@@ -25,6 +25,22 @@ from clapcheeks.safety.emergency_stop import emergency_stop
 
 logger = logging.getLogger(__name__)
 
+# Severity ordering for BanStatus. Higher = worse. Used to take the max
+# severity across independent signals in a single API response without
+# relying on alphabetical comparison of enum .value strings (which would
+# put "hard_ban" < "suspected" by accident).
+_BAN_STATUS_SEVERITY: dict[BanStatus, int] = {
+    BanStatus.CLEAN: 0,
+    BanStatus.SUSPECTED: 1,
+    BanStatus.SOFT_BAN: 2,
+    BanStatus.HARD_BAN: 3,
+}
+
+
+def _worse(a: BanStatus, b: BanStatus) -> bool:
+    """Return True when `a` is a more severe ban status than `b`."""
+    return _BAN_STATUS_SEVERITY.get(a, 0) > _BAN_STATUS_SEVERITY.get(b, 0)
+
 
 # Platform family grouping — same corporate owner shares ban signals
 PLATFORM_FAMILIES: dict[str, list[str]] = {
@@ -150,9 +166,14 @@ class BanMonitor:
         """Inspect an API response for ban indicators.
 
         Checks HTTP status codes, JSON body patterns, and keyword scans.
-        Returns the worst-case BanStatus found.
+        Returns the worst-case BanStatus found. Each signal is recorded at
+        most once per call — the keyword-scan fallback is skipped when the
+        HTTP status code already flagged the response, otherwise 403/451
+        responses would double-increment `_hard_ban_count` and wrongly trip
+        the emergency-stop threshold on the very first hard-ban observation.
         """
         status = BanStatus.CLEAN
+        http_already_flagged = False
 
         # --- HTTP status code check ---
         ban_codes = PLATFORM_BAN_CODES.get(platform, {})
@@ -162,30 +183,34 @@ class BanMonitor:
             status = self._record_and_correlate(
                 platform, f"http_{status_code}", reason or f"HTTP {status_code} response"
             )
+            http_already_flagged = True
         elif status_code == 429:
             status = self._handle_rate_limit(platform, reason or "HTTP 429 rate limit")
+            http_already_flagged = True
         elif status_code == 401:
             logger.warning("[%s] Auth error (401): %s", platform, reason)
             status = BanStatus.SUSPECTED
+            http_already_flagged = True
 
         # --- JSON body pattern matching ---
         if isinstance(body, dict):
             pattern_status = self._check_json_patterns(platform, body)
-            if pattern_status.value > status.value:
+            if _worse(pattern_status, status):
                 status = pattern_status
 
         # --- Keyword scan (fallback to basic detector) ---
-        try:
-            from clapcheeks.session.ban_detector import check_response_for_ban
-            check_response_for_ban(platform, status_code, body)
-        except BanSignalException as exc:
-            signal_status = self._record_and_correlate(
-                platform, exc.signal_type, exc.details
-            )
-            if signal_status.value > status.value:
-                status = signal_status
-            if raise_on_ban:
-                raise
+        if not http_already_flagged:
+            try:
+                from clapcheeks.session.ban_detector import check_response_for_ban
+                check_response_for_ban(platform, status_code, body)
+            except BanSignalException as exc:
+                signal_status = self._record_and_correlate(
+                    platform, exc.signal_type, exc.details
+                )
+                if _worse(signal_status, status):
+                    status = signal_status
+                if raise_on_ban:
+                    raise
 
         return status
 

--- a/agent/clapcheeks/safety/emergency_stop.py
+++ b/agent/clapcheeks/safety/emergency_stop.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import signal
+import sys
 import threading
 import time
 from datetime import datetime
@@ -26,6 +27,15 @@ from pathlib import Path
 from typing import Callable
 
 logger = logging.getLogger(__name__)
+
+
+def _running_under_pytest() -> bool:
+    """True when the current process was launched by pytest (or is inside a
+    pytest run). Used to avoid auto-adopting a stale on-disk EMERGENCY_STOP
+    file as "already triggered" at module import time — that file is typically
+    a leftover from a prior debug session and would block the whole test run.
+    """
+    return "pytest" in sys.modules or bool(os.environ.get("PYTEST_CURRENT_TEST"))
 
 STOP_FILE = Path.home() / ".clapcheeks" / "EMERGENCY_STOP"
 STOP_LOG = Path.home() / ".clapcheeks" / "emergency_stop.log"
@@ -66,8 +76,12 @@ class EmergencyStop:
         self._callbacks: list[Callable[[], None]] = []
         self._watchdog_thread: threading.Thread | None = None
 
-        # Check if stop file already exists (from a previous crash or manual trigger)
-        if STOP_FILE.exists():
+        # Adopt an existing stop file (from a previous crash or manual trigger),
+        # but NOT when running under pytest — a stale ~/.clapcheeks/EMERGENCY_STOP
+        # left behind by a prior debug session would latch the test process into
+        # a stopped state that fixtures can't recover from (they monkeypatch
+        # STOP_FILE *after* the singleton's __init__ has already run).
+        if STOP_FILE.exists() and not _running_under_pytest():
             self._stop_event.set()
             self._reason = "Stop file present from previous session"
             self._triggered_at = datetime.now()

--- a/agent/clapcheeks/session/ban_detector.py
+++ b/agent/clapcheeks/session/ban_detector.py
@@ -19,12 +19,41 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+_DEFAULT_STATE_FILE = Path.home() / ".clapcheeks" / "ban_state.json"
+
+
+def _resolve_state_file(default: Path) -> Path:
+    """Resolve the ban state file location.
+
+    Priority:
+    1. CLAPCHEEKS_BAN_STATE_FILE env var (explicit override)
+    2. If the caller already patched STATE_FILE away from the default
+       (e.g. via `patch.object(BanDetector, "STATE_FILE", ...)`), honor it.
+    3. Per-test temp file when running under pytest with the default path —
+       prevents test-to-test pollution for tests that instantiate BanDetector
+       without patching STATE_FILE (TestBanMonitor, safety integration tests).
+    4. The provided default (~/.clapcheeks/ban_state.json) for prod.
+    """
+    override = os.environ.get("CLAPCHEEKS_BAN_STATE_FILE")
+    if override:
+        return Path(override)
+    if default != _DEFAULT_STATE_FILE:
+        return default
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        slug = os.environ.get("PYTEST_CURRENT_TEST", "session").split(" ")[0]
+        safe = "".join(c if c.isalnum() else "_" for c in slug)[:80]
+        return Path(tempfile.gettempdir()) / f"clapcheeks_ban_state_{safe}.json"
+    return default
 
 # Keywords in HTTP responses / DOM text that indicate a hard ban
 BAN_KEYWORDS = frozenset({
@@ -117,6 +146,11 @@ class BanDetector:
     STATE_FILE = Path.home() / ".clapcheeks" / "ban_state.json"
 
     def __init__(self) -> None:
+        # Resolve actual state file path — honors env overrides and auto-isolates
+        # under pytest so tests that instantiate BanDetector without patching
+        # the class attribute don't leak persistence into a shared ~/.clapcheeks
+        # file. Prod callers get the original STATE_FILE unchanged.
+        self._state_file: Path = _resolve_state_file(self.STATE_FILE)
         self._states: dict[str, PlatformBanState] = self.load_state()
 
     # ------------------------------------------------------------------
@@ -124,9 +158,9 @@ class BanDetector:
     # ------------------------------------------------------------------
 
     def load_state(self) -> dict[str, PlatformBanState]:
-        if self.STATE_FILE.exists():
+        if self._state_file.exists():
             try:
-                raw = json.loads(self.STATE_FILE.read_text())
+                raw = json.loads(self._state_file.read_text())
                 return {k: PlatformBanState.from_dict(v) for k, v in raw.items()}
             except Exception as exc:
                 logger.warning("Failed to load ban state: %s", exc)
@@ -135,9 +169,9 @@ class BanDetector:
     def save_state(self, states: dict[str, PlatformBanState] | None = None) -> None:
         if states is not None:
             self._states = states
-        self.STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+        self._state_file.parent.mkdir(parents=True, exist_ok=True)
         raw = {k: v.to_dict() for k, v in self._states.items()}
-        self.STATE_FILE.write_text(json.dumps(raw, indent=2))
+        self._state_file.write_text(json.dumps(raw, indent=2))
 
     def _get_or_create(self, platform: str) -> PlatformBanState:
         if platform not in self._states:
@@ -333,6 +367,13 @@ class BanDetector:
         if not state:
             return []
         return [s.to_dict() for s in state.signals]
+
+    def get_status(self, platform: str) -> BanStatus:
+        """Return the current BanStatus for a platform (CLEAN if unknown)."""
+        state = self._states.get(platform)
+        if not state:
+            return BanStatus.CLEAN
+        return state.status
 
 
 def check_response_for_ban(platform: str, status_code: int, body: str | dict) -> None:

--- a/docs/PHASE_35_SAFETY.md
+++ b/docs/PHASE_35_SAFETY.md
@@ -1,0 +1,107 @@
+# Phase 35: Anti-Detection & Safety
+
+Linear: [AI-8334](https://linear.app/ai-acrobatics/issue/AI-8334)
+
+## Goal
+
+Keep the Clapcheeks autonomous agent operating inside the safe envelope of every
+supported dating platform so that users are never banned because of automation.
+
+## Components
+
+| Module | Responsibility |
+|--------|----------------|
+| `clapcheeks.safety.emergency_stop` | Process-wide kill switch. Triggered by CLI, file, API, or programmatic call. All workers observe it within 5s via an in-process `threading.Event` plus a cross-process sentinel file. |
+| `clapcheeks.safety.human_delay` | Gaussian + fatigue + time-of-day delay distributions. Produces delays per action type ("swipe", "message", "read_bio", …) and enforces session lifetimes + inter-session gaps. |
+| `clapcheeks.safety.platform_limits` | Declarative per-platform safety envelope (`PLATFORM_SAFETY_LIMITS`) plus an in-memory tracker (`PlatformLimits`) that enforces hourly caps and session counts. |
+| `clapcheeks.safety.ban_monitor` | Enhanced ban detector wrapping `session.ban_detector`. Adds cross-platform family correlation (Match Group, Bumble Inc), JSON body pattern matching, historical event log, and emergency-stop escalation when two hard bans land in a single run. |
+| `clapcheeks.safety.proxy_validator` | Health checks for residential proxies: latency, egress IP, DNS, and rotation sanity. |
+| `clapcheeks.session.ban_detector` | Persistent per-platform ban state (`ban_state.json`) with soft-ban pause (48h), hard-ban halt, and auto-resume. |
+| `clapcheeks.session.safety` | Session-level hourly swipe limits, cooldowns, and match-rate back-off. |
+
+## Safe Operating Limits Per Platform
+
+Free tier daily caps (conservative; paid tiers are higher — see `PLATFORM_SAFETY_LIMITS[<platform>].daily_right_swipes_paid`):
+
+| Platform | Daily right-swipes (free) | Hourly cap | Daily messages | Recovery after soft ban |
+|----------|---------------------------|------------|----------------|------------------------|
+| Tinder   | 50                        | 30         | 30             | 48h                    |
+| Hinge    | 8                         | 15         | 20             | 72h                    |
+| Bumble   | 25                        | 20         | 25             | 48h                    |
+| Grindr   | 100                       | 50         | 50             | 24h                    |
+| Badoo    | 50                        | 25         | 30             | 48h                    |
+| Happn    | 50                        | 25         | 30             | 48h                    |
+| OkCupid  | 40                        | 20         | 30             | 72h                    |
+| POF      | 50                        | 25         | 30             | 48h                    |
+| Feeld    | 30                        | 15         | 20             | 72h                    |
+| CMB      | 21                        | 21         | 21             | 24h                    |
+
+The authoritative source is `agent/clapcheeks/safety/platform_limits.py` — each
+entry carries `ban_risk_factors`, `swipe_speed_min/max_seconds`, and a free-text
+`notes` field describing the detection model on that platform. The table above
+is a summary; code reads the dataclass directly.
+
+## Success Criteria (AI-8334)
+
+1. **7-day run with zero bans on test accounts** — session-level `ban_log`
+   records events; `get_ban_test_report()` returns an `overall_pass` bool and
+   per-platform counts consumed by the nightly soak test.
+2. **Rate limiter respects per-platform caps** — `PlatformLimits.check_hourly_cap()`
+   plus `session.safety.check_hourly_limit()` cover both in-process and
+   persistent counters. Exercised by `TestPlatformLimits` and
+   `TestSafetyHourlyLimits`.
+3. **Ban detector pauses within 1 action** — `BanMonitor.check_response()`
+   raises/marks hard bans on the first 403/451 and immediately updates the
+   shared detector state that `is_safe_to_proceed()` reads. Verified by
+   `TestBanMonitor::test_403_triggers_hard_ban` and the smoke check in this
+   phase.
+4. **Emergency stop kills automation within 5s** — `EmergencyStop.trigger()`
+   sets an in-process event (<1ms) and writes a cross-process stop file that
+   the watchdog observes on a 1s poll interval. Verified by
+   `TestEmergencyStop::test_trigger_sets_stop`.
+
+## Fixes Landed in This Phase
+
+1. **`BanDetector.get_status()`** — added the accessor that `BanMonitor` and
+   status reporting rely on. Previously missing, which made
+   `is_safe_to_proceed()` and `get_status_report()` raise `AttributeError`.
+2. **`BanDetector` state-file isolation** — under pytest, persistence is
+   redirected to a per-test temp file so one test's recorded hard ban cannot
+   leak into the next test's `~/.clapcheeks/ban_state.json`. Production
+   behaviour is unchanged; the override only activates when
+   `PYTEST_CURRENT_TEST` is set (or the explicit `CLAPCHEEKS_BAN_STATE_FILE`
+   env var is provided).
+3. **`BanMonitor.check_response()` no longer double-records** — for a 403 the
+   HTTP-status branch and the keyword-scan fallback both used to invoke
+   `_record_and_correlate`, incrementing `_hard_ban_count` twice from a single
+   API response and tripping the 2-bans emergency-stop threshold on the very
+   first hard ban. The keyword scan now runs only when the HTTP branch did not
+   already flag the response. A semantic severity comparator replaces the
+   previous string `.value` comparison that was ordering statuses
+   alphabetically.
+4. **`EmergencyStop` adopts a stale sentinel file only outside pytest** — a
+   leftover `~/.clapcheeks/EMERGENCY_STOP` from a prior debug session used to
+   latch the test process into a permanently-stopped state at import time,
+   before fixtures could monkeypatch `STOP_FILE`. Prod code is unaffected;
+   the carve-out is gated on pytest being loaded.
+
+## Operational Runbook
+
+| Situation | Action |
+|-----------|--------|
+| Agent reports intermittent 429s | Respect `_handle_rate_limit` back-off; if 5+ in an hour, detector escalates to a soft ban and pauses 48h. |
+| Account shows selfie verification | Pause platform manually (`BanDetector.pause_platform(platform, hours=24)`). Don't retry syncs until the user confirms unlocked. |
+| Multiple platforms flagged same day | Expect family-contamination auto-pause on Match Group / Bumble Inc siblings. Two hard bans trigger emergency stop — investigate before clearing. |
+| Need a hard kill | `touch ~/.clapcheeks/EMERGENCY_STOP` — every in-flight worker sees it on the next poll (≤1s in-process, ≤5s cross-process). `rm ~/.clapcheeks/EMERGENCY_STOP` to resume. |
+
+## Tests
+
+Run locally:
+
+```bash
+cd agent
+python3 -m pytest tests/test_safety.py tests/test_ban_detector.py \
+                  tests/test_rate_limiter.py -q
+```
+
+Current status: 250 tests pass across the agent test suite.


### PR DESCRIPTION
## Summary

Closes Linear AI-8334 (Phase 35: Anti-Detection & Safety). Ships four bug fixes in the safety module + operational documentation so the phase's acceptance criteria are actually verifiable.

**Bugs fixed:**
1. `BanDetector.get_status()` — missing accessor that `BanMonitor.is_safe_to_proceed()` depended on (was raising `AttributeError`)
2. `BanDetector` state-file isolation under pytest — prevents cross-test pollution via `~/.clapcheeks/ban_state.json`
3. `BanMonitor.check_response()` double-recording — a 403 was bumping `_hard_ban_count` twice, tripping the 2-bans emergency threshold on the first hard ban. Also replaces buggy `.value` string comparison on `BanStatus` with a semantic severity comparator.
4. `EmergencyStop` stale-sentinel adoption — a leftover `EMERGENCY_STOP` file used to latch the test process as stopped at import time, before fixtures could monkeypatch `STOP_FILE`. Gate on pytest import so prod is untouched.

**Docs added:** `docs/PHASE_35_SAFETY.md` with component table, per-platform safe operating limits (10 platforms), success-criteria mapping, and runbook.

## Acceptance criteria (AI-8334)

| Criterion | Status | Evidence |
|-----------|--------|----------|
| 7-day run with zero bans on test accounts | Infra ready | `ban_log` + `get_ban_test_report()` wired to nightly soak |
| Rate limiter respects per-platform caps | ✅ | `TestPlatformLimits` + `TestSafetyHourlyLimits` |
| Ban detector pauses within 1 action | ✅ | `TestBanMonitor::test_403_triggers_hard_ban` |
| Emergency stop kills automation within 5s | ✅ | `TestEmergencyStop::test_trigger_sets_stop` — trigger measured at 0.4ms |

## Test plan

- [x] `pytest tests/test_safety.py tests/test_ban_detector.py` — 140 passed
- [x] Full agent suite — 250 passed
- [x] Smoke check: emergency stop trigger < 5000ms (0.4ms measured)
- [x] Smoke check: all 10 platforms have configured limits

## Notes

This PR branches from `8c84f57` (AI-8333 Phase 34) because that commit introduces the safety module itself and has not yet landed on `main`. Merging order: AI-8333 -> this PR -> main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)