### PR TITLE
feat(ui): light mode support

### DIFF
--- a/web/app/(main)/layout.tsx
+++ b/web/app/(main)/layout.tsx
@@ -27,7 +27,7 @@ export default async function MainLayout({ children }: { children: React.ReactNo
           <main className="min-h-screen">{children}</main>
         </div>
       </div>
-      <Toaster theme="dark" position="bottom-right" richColors closeButton />
+      <Toaster position="bottom-right" richColors closeButton />
     </>
   )
 }

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3,8 +3,26 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/*
+ * Light mode (default when `.dark` class is not on <html>).
+ *
+ * Clapcheeks was originally designed dark-only with a LOT of hardcoded
+ * `text-white`, `bg-black`, `bg-white/5`, `border-white/10` utilities
+ * across ~58 files.  Rather than rewrite every component, we remap the
+ * underlying Tailwind v4 color tokens (`--color-white`, `--color-black`)
+ * at the `:root` level for light mode so those utilities automatically
+ * invert.  The semantic tokens (`--background`, `--foreground`, etc.)
+ * continue to work for shadcn/ui primitives.
+ */
 :root {
-  --background: oklch(1 0 0);
+  /* Remap Tailwind's base white/black tokens so hardcoded
+   * `bg-white/5`, `text-white/60`, `bg-black`, `border-white/10`
+   * all flip to sensible light-mode values when `.dark` is NOT on <html>.
+   * These are the same tokens Tailwind v4 emits in theme.css. */
+  --color-white: #0a0a12;   /* "white" means "primary text color" in this codebase — flip to near-black on light */
+  --color-black: #f7f7fb;   /* "black" means "page background" — flip to near-white on light */
+
+  --background: oklch(0.99 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -40,6 +58,12 @@
 }
 
 .dark {
+  /* Restore the true white/black tokens in dark mode so the
+   * original design (white text on near-black backgrounds) looks
+   * exactly like it did before. */
+  --color-white: #ffffff;
+  --color-black: #000000;
+
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.145 0 0);
@@ -124,4 +148,65 @@
   body {
     @apply bg-background text-foreground;
   }
+}
+
+/*
+ * Light-mode fixups for hardcoded hex backgrounds that can't ride on
+ * --color-white / --color-black.  These were originally fixed dark
+ * shades (`bg-[#05050A]`, `bg-[#0a0a0f]`, `bg-[#0B0B14]`, `bg-[#0a0a14]`).
+ * When `.dark` is NOT on <html>, we flip them to light surface colors
+ * so page backgrounds and side panels read correctly.
+ *
+ * Attribute selectors match Tailwind's escaped class names in the
+ * compiled CSS (e.g. `.bg-\[\#05050A\]\/95`).
+ */
+html:not(.dark) [class*="bg-[#05050A]"],
+html:not(.dark) [class*="bg-[#0a0a0f]"],
+html:not(.dark) [class*="bg-[#0B0B14]"],
+html:not(.dark) [class*="bg-[#0a0a14]"],
+html:not(.dark) [class*="bg-[#0b0b14]"] {
+  background-color: oklch(0.98 0 0) !important;
+}
+
+/*
+ * The landing page's `.alpha-card`, `.glass-card`, `.code-block`
+ * use explicit rgba backgrounds that assume a dark substrate.
+ * Re-point them in light mode.
+ */
+html:not(.dark) .alpha-card {
+  background: rgba(255, 255, 255, 0.75);
+  border-color: rgba(201, 164, 39, 0.35);
+}
+html:not(.dark) .alpha-card::before {
+  background: linear-gradient(135deg, rgba(201, 164, 39, 0.05) 0%, transparent 60%);
+}
+html:not(.dark) .glass-card {
+  background: rgba(0, 0, 0, 0.025);
+  border-color: rgba(0, 0, 0, 0.08);
+}
+html:not(.dark) .code-block {
+  background: rgba(0, 0, 0, 0.04);
+  border-color: rgba(201, 164, 39, 0.25);
+}
+html:not(.dark) .diagonal-slash {
+  background: oklch(0.98 0 0);
+}
+
+/*
+ * Make the gold-text gradient still readable in light mode by
+ * darkening the gold tones slightly (the shimmer on white is too
+ * bright otherwise).
+ */
+html:not(.dark) .gold-text,
+html:not(.dark) .gradient-text {
+  background: linear-gradient(135deg, #9c7e1e 0%, #b8941f 50%, #9c7e1e 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+/* Soften the PageOrbs in light mode — the purple/red orbs become
+   muddy blobs on white.  Turn them off for readability. */
+html:not(.dark) .orb {
+  display: none;
 }

--- a/web/components/layout/app-sidebar.tsx
+++ b/web/components/layout/app-sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import { logout } from '@/app/auth/actions'
+import { ThemeToggle } from '@/components/theme-toggle'
 
 type NavItem = {
   href: string
@@ -66,13 +67,16 @@ export default function AppSidebar() {
           <Logo />
           <span className="font-display text-xl gold-text uppercase tracking-wide">Clapcheeks</span>
         </Link>
-        <button
-          onClick={() => setMobileOpen((v) => !v)}
-          className="w-9 h-9 flex items-center justify-center rounded-lg bg-white/5 border border-white/10"
-          aria-label="Menu"
-        >
-          {mobileOpen ? <CloseIcon /> : <MenuIcon />}
-        </button>
+        <div className="flex items-center gap-1">
+          <ThemeToggle className="text-white/70 hover:text-white hover:bg-white/5" />
+          <button
+            onClick={() => setMobileOpen((v) => !v)}
+            className="w-9 h-9 flex items-center justify-center rounded-lg bg-white/5 border border-white/10"
+            aria-label="Menu"
+          >
+            {mobileOpen ? <CloseIcon /> : <MenuIcon />}
+          </button>
+        </div>
       </div>
 
       {/* Sidebar — desktop always, mobile overlay when open */}
@@ -126,6 +130,7 @@ export default function AppSidebar() {
               <div className="text-xs text-white/80 truncate">{email || 'Signed in'}</div>
               <div className="text-[10px] text-white/30">clapcheeks.tech</div>
             </div>
+            <ThemeToggle className="text-white/60 hover:text-white hover:bg-white/5" />
           </div>
           <form action={logout}>
             <button


### PR DESCRIPTION
## Summary

Adds a working light mode to the Clapcheeks dashboard while keeping dark as the default. Toggle lives in the authenticated sidebar (desktop + mobile top bar) with Sun / Moon / Monitor (system) options driven by `next-themes`.

## Preview

- Branch URL: https://clapcheeks-tech-git-feat-light-mode-ai-acrobatics.vercel.app
- Specific deploy: https://clapcheeks-tech-g0y7h8qq2-ai-acrobatics.vercel.app

(Vercel SSO is enabled on previews — sign in with the team account to view.)

## How it works

The `(main)` dashboard routes have ~970 occurrences of hardcoded `text-white`, `text-white/60`, `bg-white/[0.03]`, `border-white/10`, `bg-black`, etc. across 58 files. Rewriting them all was out of scope.

Instead, this PR **remaps Tailwind v4's base color tokens** at the root level:

```css
:root           { --color-white: #0a0a12;  --color-black: #f7f7fb; }  /* light */
html.dark       { --color-white: #ffffff;  --color-black: #000000; }  /* dark, original */
```

Because Tailwind v4 compiles `text-white` -> `color: var(--color-white)` and `bg-white/5` -> `color-mix(in oklab, var(--color-white) 5%, transparent)`, redefining those two tokens flips every hardcoded utility automatically. No component edits required. Brand accents (`yellow-500`, `red-600`, `purple-*`) are unaffected and continue to work in both modes.

Verified in the compiled `_next/static/css/*.css`:
```
color-white:#fff       <- @theme default
color-white:#0a0a12    <- :root override (light)
color-white:#fff       <- .dark override (restored)
```

## Changes (3 files)

- `web/app/globals.css` — remap `--color-white` / `--color-black` for light mode; fix hardcoded hex surfaces (`bg-[#05050A]`, `bg-[#0a0a0f]`, `bg-[#0B0B14]`, `bg-[#0a0a14]`); adjust `.alpha-card` / `.glass-card` / `.code-block` / `.gold-text` for light substrate; hide `PageOrbs` in light mode.
- `web/components/layout/app-sidebar.tsx` — render `ThemeToggle` in desktop user row + mobile top bar.
- `web/app/(main)/layout.tsx` — drop hardcoded `theme="dark"` on the `(main)` `Toaster` so it follows the active theme.

## What's NOT in this PR

- No component layout changes.
- No auth / Supabase / Stripe / API route touches.
- The marketing landing page in `app/(main)/page.tsx` will inherit the same theming but wasn't the explicit focus — priority was authenticated dashboard routes.

## Follow-ups (worth flagging)

- A few inline SVG `stroke="black"` / `fill="black"` glyphs (e.g. the sidebar `<Logo />` icon, plan badges) won't auto-flip. They look fine on both modes today because they sit on coloured gradient backgrounds, but if any look off in light mode after Julian's review, swap to `stroke="currentColor"` and let Tailwind drive.
- `inline style={{ color: '#fff' }}` (rare) won't flip — the audit didn't surface any in `(main)`, but if one shows up, replace with a class.

## Test plan

- [x] `npm run build` passes locally (no new TS errors)
- [x] Compiled CSS contains both light + dark `--color-white` definitions
- [x] Vercel preview build succeeded (READY)
- [ ] Toggle theme on `/dashboard` once SSO-authed — verify background, cards, text, borders all flip cleanly
- [ ] Visit `/matches`, `/settings`, `/analytics`, `/billing`, `/scheduled`, `/autonomy`, `/coaching`, `/referrals` in both modes
- [ ] Confirm brand gold / accent colors still look right
- [ ] Confirm theme preference persists across reloads (next-themes writes to localStorage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)