### PR TITLE
feat(clapcheeks): P2+P6+P7 - anti-LLM voice guards, memo injection, staleness recovery

### DIFF
--- a/agent/clapcheeks/imessage/ai_reply.py
+++ b/agent/clapcheeks/imessage/ai_reply.py
@@ -1,11 +1,271 @@
-"""Local Ollama reply generator — all inference stays on-device."""
+"""Local Ollama reply generator — all inference stays on-device.
+
+Includes the P2 anti-LLM-voice guard stack, P6 per-contact memo injection
+(read side), and P7 time-aware staleness recovery prompting.
+"""
 from __future__ import annotations
 
 import logging
+import os
+import re
+import time
+from pathlib import Path
 
 from clapcheeks.config import load as load_config
 
+try:  # optional dependency
+    import ollama  # type: ignore
+except ImportError:  # pragma: no cover - exercised when ollama is absent
+    ollama = None  # type: ignore[assignment]
+
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# P2 — anti-LLM-voice guard tables
+# ---------------------------------------------------------------------------
+
+META_LEAK = [
+    "based on her",
+    "match her energy",
+    "draft:",
+    "option 1",
+    "as julian",
+    "let me draft",
+    "i should respond",
+    "based on the conversation",
+    "the system prompt",
+    "as the assistant",
+    "her profile",
+    "from her profile",
+    "match her tone",
+    "let me respond",
+    "i'll respond",
+]
+
+SAFETY_BLOCK = [
+    "absolutely",
+    "certainly",
+    "explore",
+    "could you",
+    "i need to",
+    "share what",
+    "local guide",
+    "here's a draft",
+    "i'd love to",
+    "what a lovely",
+    "what a great",
+    "that's wonderful",
+    "that's so",
+    "i appreciate",
+]
+
+MONEY_JK_BLOCK = [
+    "cashapp",
+    "venmo",
+    "zelle",
+    "send it",
+    "i'll send",
+    "ill send",
+    "sending now",
+    "sent it",
+    "lol jk",
+    "lol j/k",
+    "just kidding",
+    "jk jk",
+    "fly out",
+    "book a flight",
+    "book my flight",
+    "planning a trip",
+    "i'll be in vegas",
+    "i'll be in la",
+    "i'll be in miami",
+    "i'll be in phoenix",
+    "ill be in vegas",
+    "ill be in la",
+    "ill be in miami",
+    "ill be in phoenix",
+    "come out there",
+    "come visit you",
+    "come see you",
+    "i'll be there",
+    "ill be there",
+    "coming to la",
+    "coming to miami",
+    "coming to phoenix",
+    "coming to vegas",
+    "heading to la",
+    "heading to miami",
+    "heading to vegas",
+    "heading to phoenix",
+    "pick you up in vegas",
+    "pick you up in la",
+    "pick you up in miami",
+    "pick you up in phoenix",
+    "pick you up at the airport",
+]
+
+SLANG_BLOCK = [
+    "aight",
+    "fr fr ",
+    " yo ",
+    "no cap",
+    "deadass",
+    "sup brodie",
+]
+
+PHONE_RE = re.compile(r"\d{3}[-.\s]?\d{3}[-.\s]?\d{4}")
+QUESTION_RE = re.compile(r"(?:what|where|how|when|who)\s+\w+", re.IGNORECASE)
+
+TIME_WORDS = [
+    "tonight",
+    "this evening",
+    "right now",
+    "today",
+    "this afternoon",
+    "this morning",
+    " rn",
+    " tn",
+]
+
+
+def _preview(text: str, n: int = 80) -> str:
+    """Trim text for log preview."""
+    flat = text.replace("\n", " ").strip()
+    return flat[:n]
+
+
+def _clean_output(text: str, prior_messages: list[str]) -> str:
+    """Run LLM output through the P2 anti-LLM-voice guard stack.
+
+    Returns "" if the output is rejected by any guard, otherwise the cleaned text.
+
+    Guards (in order):
+    1. Last-paragraph keep (kills reasoning leaks).
+    2. META_LEAK blocklist.
+    3. SAFETY_BLOCK (LLM tells).
+    4. Money/JK/travel guard.
+    5. Slang block.
+    6. Em-dash strip.
+    7. Length cap (>250 reject, <2 reject).
+    8. Fake phone number guard.
+    9. >60% word-overlap with prior messages.
+    10. Question repetition.
+    """
+    if text is None:
+        return ""
+
+    # 1. Keep last paragraph only
+    text = text.split("\n\n")[-1].strip()
+    lower = text.lower()
+
+    # 2. META_LEAK
+    for needle in META_LEAK:
+        if needle in lower:
+            logger.info("BLOCKED (meta_leak '%s'): %s", needle, _preview(text))
+            return ""
+
+    # 3. SAFETY_BLOCK
+    for needle in SAFETY_BLOCK:
+        if needle in lower:
+            logger.info("BLOCKED (safety_block '%s'): %s", needle, _preview(text))
+            return ""
+
+    # 4. Money / JK / travel
+    for needle in MONEY_JK_BLOCK:
+        if needle in lower:
+            logger.info("BLOCKED (money_jk '%s'): %s", needle, _preview(text))
+            return ""
+
+    # 5. Slang
+    for needle in SLANG_BLOCK:
+        if needle in lower:
+            logger.info("BLOCKED (slang '%s'): %s", needle, _preview(text))
+            return ""
+
+    # 6. Em-dash strip
+    text = (
+        text.replace(" — ", ", ")
+        .replace(" – ", ", ")
+        .replace("—", ",")
+        .replace("–", ",")
+    )
+
+    # 7. Length cap
+    if len(text) > 250:
+        logger.info("BLOCKED (length>250): %s", _preview(text))
+        return ""
+    if len(text) < 2:
+        logger.info("BLOCKED (length<2): %s", _preview(text))
+        return ""
+
+    # 8. Fake phone regex
+    phone_match = PHONE_RE.search(text)
+    if phone_match:
+        digits = re.sub(r"\D", "", phone_match.group(0))
+        my_digits = os.environ.get("MY_PHONE_DIGITS", "")
+        if digits != my_digits:
+            logger.info("BLOCKED (fake_phone '%s'): %s", digits, _preview(text))
+            return ""
+
+    # 9. Word-overlap >60% vs last 5 prior messages
+    resp_words = {w.lower() for w in re.findall(r"\w+", text)}
+    if len(resp_words) >= 4:
+        for prior in prior_messages[-5:]:
+            if not prior:
+                continue
+            prior_words = {w.lower() for w in re.findall(r"\w+", prior)}
+            if not prior_words:
+                continue
+            overlap = len(resp_words & prior_words) / len(resp_words)
+            if overlap > 0.6:
+                logger.info(
+                    "BLOCKED (overlap=%.2f vs prior): %s",
+                    overlap,
+                    _preview(text),
+                )
+                return ""
+
+    # 10. Question repetition
+    response_questions = QUESTION_RE.findall(text)
+    if response_questions:
+        for prior in prior_messages:
+            if not prior:
+                continue
+            prior_questions = QUESTION_RE.findall(prior)
+            for rq in response_questions:
+                rq_l = rq.lower().strip()
+                for pq in prior_questions:
+                    if pq.lower().strip() == rq_l:
+                        logger.info(
+                            "BLOCKED (question_repeat '%s'): %s",
+                            rq_l,
+                            _preview(text),
+                        )
+                        return ""
+
+    return text
+
+
+# ---------------------------------------------------------------------------
+# P6 (read side) — load per-contact memo
+# ---------------------------------------------------------------------------
+
+def _load_memo(handle_id: str) -> str:
+    """Load per-contact memo from ~/.clapcheeks/memos/<handle_id>.md if it exists.
+
+    handle_id is typically a phone like '+15551234567' or an email address.
+    Returns empty string when no memo file exists.
+    """
+    if not handle_id:
+        return ""
+    memo_dir = Path.home() / ".clapcheeks" / "memos"
+    safe_name = handle_id.replace("/", "_")
+    memo_path = memo_dir / f"{safe_name}.md"
+    try:
+        return memo_path.read_text().strip()
+    except (FileNotFoundError, OSError):
+        return ""
 
 
 class ReplyGenerator:
@@ -21,14 +281,31 @@ class ReplyGenerator:
         conversation: list[dict],
         contact_name: str = "",
         temperature: float = 0.7,
+        handle_id: str = "",
+        last_msg_timestamp: float = 0.0,
+        last_msg_text: str = "",
     ) -> str:
         """Generate a single reply suggestion via local Ollama.
 
         All inference runs on localhost:11434 — no data leaves the device.
+
+        Parameters
+        ----------
+        conversation:
+            Last N messages (each dict has ``text`` and ``is_from_me``).
+        contact_name:
+            Display name of the recipient (optional).
+        temperature:
+            Ollama sampling temperature.
+        handle_id:
+            Phone number / email used to look up persistent memo (P6).
+        last_msg_timestamp:
+            UNIX timestamp of her last inbound message; used for P7
+            time-staleness recovery prompt.
+        last_msg_text:
+            Text of her last inbound message (used by P7).
         """
-        try:
-            import ollama
-        except ImportError:
+        if ollama is None:
             return "Error: ollama package not installed. Run: pip install ollama"
 
         system_prompt = (
@@ -41,8 +318,36 @@ class ReplyGenerator:
         if contact_name:
             system_prompt += f" The user is texting {contact_name}."
 
+        # P7 — time-aware staleness recovery
+        hours_since = (
+            (time.time() - last_msg_timestamp) / 3600 if last_msg_timestamp else 0
+        )
+        is_stale_time_sensitive = (
+            hours_since > 4
+            and last_msg_text
+            and any(w in last_msg_text.lower() for w in TIME_WORDS)
+        )
+        if is_stale_time_sensitive:
+            system_prompt += (
+                f"\n\nNOTE: Her last message was {hours_since:.0f}h ago and "
+                "referenced time-sensitive plans. Apologize briefly for the "
+                "late reply and propose a NEW plan for later this week. "
+                "Do NOT proceed as if the original time-sensitive plan is "
+                "still on."
+            )
+
+        # P6 — per-contact memo injection
+        memo = _load_memo(handle_id)
+        if memo:
+            system_prompt = (
+                "[PERSISTENT MEMO about this contact - treat as facts you "
+                f"already know about her]:\n{memo}\n\n" + system_prompt
+            )
+
         # Build message history from last 10 messages
-        messages: list[dict[str, str]] = [{"role": "system", "content": system_prompt}]
+        messages: list[dict[str, str]] = [
+            {"role": "system", "content": system_prompt}
+        ]
         for msg in conversation[-10:]:
             role = "assistant" if msg.get("is_from_me") else "user"
             text = msg.get("text", "")
@@ -55,24 +360,43 @@ class ReplyGenerator:
                 messages=messages,
                 options={"temperature": temperature},
             )
-            return response["message"]["content"].strip()
+            raw_text = response["message"]["content"].strip()
         except ConnectionError:
             return "Ollama not running. Start it with: ollama serve"
         except Exception as exc:
             logger.error("Ollama chat failed: %s", exc)
             return f"Error generating reply: {exc}"
 
+        # P2 — guard stack
+        prior_messages = [
+            m.get("text", "")
+            for m in conversation
+            if m.get("is_from_me") and m.get("text")
+        ]
+        cleaned = _clean_output(raw_text, prior_messages)
+        return cleaned
+
     def suggest_multiple(
         self,
         conversation: list[dict],
         contact_name: str = "",
         count: int = 3,
+        handle_id: str = "",
+        last_msg_timestamp: float = 0.0,
+        last_msg_text: str = "",
     ) -> list[str]:
         """Generate multiple reply options with varying temperature."""
         temperatures = [0.7, 0.9, 1.1]
         results: list[str] = []
         for i in range(count):
             temp = temperatures[i] if i < len(temperatures) else 0.9
-            reply = self.suggest_reply(conversation, contact_name, temperature=temp)
+            reply = self.suggest_reply(
+                conversation,
+                contact_name,
+                temperature=temp,
+                handle_id=handle_id,
+                last_msg_timestamp=last_msg_timestamp,
+                last_msg_text=last_msg_text,
+            )
             results.append(reply)
         return results

--- a/agent/clapcheeks/imessage/watcher.py
+++ b/agent/clapcheeks/imessage/watcher.py
@@ -159,7 +159,15 @@ class IMMessageWatcher:
 
         # Generate reply from conversation context
         messages = self._reader.get_messages(chat_id, limit=15)
-        reply = self._reply_gen.suggest_reply(messages, contact_name=contact_name)
+        last_ts = float(message.get("timestamp") or 0.0)
+        last_txt = message.get("text", "") or ""
+        reply = self._reply_gen.suggest_reply(
+            messages,
+            contact_name=contact_name,
+            handle_id=handle_id,
+            last_msg_timestamp=last_ts,
+            last_msg_text=last_txt,
+        )
 
         if not reply or reply.startswith("Error") or reply.startswith("Ollama"):
             console.print(f"[red]Reply generation failed:[/red] {reply}")

--- a/agent/tests/test_ai_reply_guards.py
+++ b/agent/tests/test_ai_reply_guards.py
@@ -1,0 +1,317 @@
+"""Tests for P2 anti-LLM-voice guards, P6 memo injection, and P7 staleness recovery.
+
+All Ollama calls are mocked - no network or local model required.
+"""
+from __future__ import annotations
+
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub the optional `ollama` dependency so the import in suggest_reply()
+# succeeds without requiring the real package to be installed.
+# ---------------------------------------------------------------------------
+if "ollama" not in sys.modules:
+    sys.modules["ollama"] = types.SimpleNamespace(chat=lambda **_: {})
+
+from clapcheeks.imessage import ai_reply  # noqa: E402
+from clapcheeks.imessage.ai_reply import (  # noqa: E402
+    ReplyGenerator,
+    _clean_output,
+    _load_memo,
+)
+
+
+# ---------------------------------------------------------------------------
+# _clean_output guards (P2)
+# ---------------------------------------------------------------------------
+
+class TestCleanOutputGuards:
+    def test_keeps_clean_text(self):
+        assert _clean_output("haha that's fun, what kind of dog?", []) != ""
+
+    def test_meta_leak_blocked(self):
+        text = "Based on her profile she likes dogs. Reply: that's fun"
+        assert _clean_output(text, []) == ""
+
+    def test_meta_leak_let_me_draft(self):
+        assert _clean_output("Let me draft something flirty", []) == ""
+
+    def test_safety_block_absolutely(self):
+        assert _clean_output("absolutely, that sounds amazing", []) == ""
+
+    def test_safety_block_certainly(self):
+        assert _clean_output("certainly! lets explore that idea", []) == ""
+
+    def test_money_jk_blocked_venmo(self):
+        assert _clean_output("send me your venmo lol", []) == ""
+
+    def test_money_jk_blocked_fly_out(self):
+        assert _clean_output("i could fly out to see you", []) == ""
+
+    def test_money_jk_blocked_just_kidding(self):
+        assert _clean_output("send $50 just kidding", []) == ""
+
+    def test_slang_blocked_no_cap(self):
+        assert _clean_output("no cap that was fire", []) == ""
+
+    def test_slang_blocked_aight(self):
+        assert _clean_output("aight bet, tomorrow then", []) == ""
+
+    def test_em_dash_stripped(self):
+        out = _clean_output("hey - what's up", [])
+        # Use the actual em-dash via codepoint
+        em = "—"
+        out2 = _clean_output(f"hey {em} what's up", [])
+        assert em not in out2
+        assert "," in out2
+
+    def test_en_dash_stripped(self):
+        en = "–"
+        out = _clean_output(f"yeah {en} sounds good", [])
+        assert en not in out
+
+    def test_length_cap_too_long(self):
+        long_text = "ok " * 100  # 300 chars
+        assert _clean_output(long_text, []) == ""
+
+    def test_length_cap_too_short(self):
+        assert _clean_output("a", []) == ""
+
+    def test_length_cap_empty(self):
+        assert _clean_output("", []) == ""
+
+    def test_fake_phone_blocked(self):
+        assert _clean_output("call me at 555-123-4567", []) == ""
+
+    def test_my_phone_allowed(self, monkeypatch):
+        monkeypatch.setenv("MY_PHONE_DIGITS", "5551234567")
+        out = _clean_output("here is my cell 555-123-4567", [])
+        assert out != ""
+
+    def test_word_overlap_blocked(self):
+        prior = ["pizza tonight at 8 sounds perfect honestly"]
+        # response shares basically every content word with prior
+        response = "pizza tonight at 8 sounds perfect honestly to me"
+        assert _clean_output(response, prior) == ""
+
+    def test_low_overlap_allowed(self):
+        prior = ["pizza tonight"]
+        response = "haha sure i'm in for that"
+        assert _clean_output(response, prior) != ""
+
+    def test_question_repetition_blocked(self):
+        prior = ["what kind of dog do you have"]
+        response = "what kind of dog?"
+        assert _clean_output(response, prior) == ""
+
+    def test_last_paragraph_kept(self):
+        text = "I should respond casually.\n\nhaha yeah for sure"
+        out = _clean_output(text, [])
+        assert out == "haha yeah for sure"
+
+    def test_none_input_returns_empty(self):
+        assert _clean_output(None, []) == ""
+
+
+# ---------------------------------------------------------------------------
+# _load_memo (P6 read side)
+# ---------------------------------------------------------------------------
+
+class TestLoadMemo:
+    def test_returns_memo_contents(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        memo_dir = tmp_path / ".clapcheeks" / "memos"
+        memo_dir.mkdir(parents=True)
+        (memo_dir / "+15551234567.md").write_text(
+            "Likes: yoga, pho.\nAvoid: politics."
+        )
+        out = _load_memo("+15551234567")
+        assert "yoga" in out
+        assert "politics" in out
+
+    def test_returns_empty_when_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        assert _load_memo("+19998887777") == ""
+
+    def test_returns_empty_for_blank_handle(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        assert _load_memo("") == ""
+
+    def test_strips_whitespace(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        memo_dir = tmp_path / ".clapcheeks" / "memos"
+        memo_dir.mkdir(parents=True)
+        (memo_dir / "alice@example.com.md").write_text("\n\n  hello  \n\n")
+        assert _load_memo("alice@example.com") == "hello"
+
+    def test_handles_slash_in_id(self, tmp_path, monkeypatch):
+        """Slashes in handle_id are sanitized to '_' so we never escape memos/."""
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        memo_dir = tmp_path / ".clapcheeks" / "memos"
+        memo_dir.mkdir(parents=True)
+        (memo_dir / "evil_path.md").write_text("safe")
+        assert _load_memo("evil/path") == "safe"
+
+
+# ---------------------------------------------------------------------------
+# suggest_reply with mocked ollama - wires guards + memo + staleness together
+# ---------------------------------------------------------------------------
+
+def _mk_ollama_response(text: str):
+    return {"message": {"content": text}}
+
+
+class TestSuggestReplyIntegration:
+    def test_guards_remove_bad_llm_output(self):
+        gen = ReplyGenerator(model="dummy", style_prompt="be casual")
+        with patch.object(
+            ai_reply,
+            "ollama",
+            MagicMock(chat=MagicMock(return_value=_mk_ollama_response(
+                "Based on her profile, she seems fun"
+            ))),
+            create=True,
+        ):
+            out = gen.suggest_reply(
+                conversation=[{"text": "hey", "is_from_me": False}],
+                contact_name="Alex",
+            )
+        assert out == ""
+
+    def test_clean_output_passes_through(self):
+        gen = ReplyGenerator(model="dummy", style_prompt="be casual")
+        with patch.object(
+            ai_reply,
+            "ollama",
+            MagicMock(chat=MagicMock(return_value=_mk_ollama_response(
+                "haha yeah, what're you up to later?"
+            ))),
+            create=True,
+        ):
+            out = gen.suggest_reply(
+                conversation=[{"text": "hey", "is_from_me": False}],
+                contact_name="Alex",
+            )
+        assert out.startswith("haha")
+
+    def test_memo_injected_into_system_prompt(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        memo_dir = tmp_path / ".clapcheeks" / "memos"
+        memo_dir.mkdir(parents=True)
+        (memo_dir / "+15551234567.md").write_text("She has a corgi named Pickle.")
+
+        captured = {}
+
+        def fake_chat(**kwargs):
+            captured["messages"] = kwargs["messages"]
+            return _mk_ollama_response("nice")
+
+        gen = ReplyGenerator(model="dummy", style_prompt="be casual")
+        with patch.object(
+            ai_reply,
+            "ollama",
+            MagicMock(chat=fake_chat),
+            create=True,
+        ):
+            gen.suggest_reply(
+                conversation=[{"text": "yo", "is_from_me": False}],
+                contact_name="Alex",
+                handle_id="+15551234567",
+            )
+
+        sys_msg = captured["messages"][0]
+        assert sys_msg["role"] == "system"
+        assert "PERSISTENT MEMO" in sys_msg["content"]
+        assert "Pickle" in sys_msg["content"]
+
+    def test_p7_staleness_prompt_appended(self):
+        captured = {}
+
+        def fake_chat(**kwargs):
+            captured["messages"] = kwargs["messages"]
+            return _mk_ollama_response("hey sorry, this week instead?")
+
+        gen = ReplyGenerator(model="dummy", style_prompt="be casual")
+        # Her message was 6h ago and mentioned 'tonight'
+        old_ts = time.time() - (6 * 3600)
+        with patch.object(
+            ai_reply,
+            "ollama",
+            MagicMock(chat=fake_chat),
+            create=True,
+        ):
+            gen.suggest_reply(
+                conversation=[{"text": "wanna grab drinks tonight?", "is_from_me": False}],
+                contact_name="Alex",
+                last_msg_timestamp=old_ts,
+                last_msg_text="wanna grab drinks tonight?",
+            )
+
+        assert "NOTE" in captured["messages"][0]["content"]
+        assert "late reply" in captured["messages"][0]["content"]
+
+    def test_p7_no_staleness_if_recent(self):
+        captured = {}
+
+        def fake_chat(**kwargs):
+            captured["messages"] = kwargs["messages"]
+            return _mk_ollama_response("yeah sounds great")
+
+        gen = ReplyGenerator(model="dummy", style_prompt="be casual")
+        with patch.object(
+            ai_reply,
+            "ollama",
+            MagicMock(chat=fake_chat),
+            create=True,
+        ):
+            gen.suggest_reply(
+                conversation=[{"text": "tonight?", "is_from_me": False}],
+                contact_name="Alex",
+                last_msg_timestamp=time.time() - 60,  # 1 minute ago
+                last_msg_text="tonight?",
+            )
+        assert "NOTE" not in captured["messages"][0]["content"]
+
+    def test_p7_no_staleness_if_no_time_words(self):
+        captured = {}
+
+        def fake_chat(**kwargs):
+            captured["messages"] = kwargs["messages"]
+            return _mk_ollama_response("yeah totally")
+
+        gen = ReplyGenerator(model="dummy", style_prompt="be casual")
+        with patch.object(
+            ai_reply,
+            "ollama",
+            MagicMock(chat=fake_chat),
+            create=True,
+        ):
+            gen.suggest_reply(
+                conversation=[{"text": "how was your weekend", "is_from_me": False}],
+                contact_name="Alex",
+                last_msg_timestamp=time.time() - (6 * 3600),
+                last_msg_text="how was your weekend",
+            )
+        assert "NOTE" not in captured["messages"][0]["content"]
+
+    def test_suggest_multiple_returns_count(self):
+        gen = ReplyGenerator(model="dummy", style_prompt="be casual")
+        with patch.object(
+            ai_reply,
+            "ollama",
+            MagicMock(chat=MagicMock(return_value=_mk_ollama_response("haha yeah"))),
+            create=True,
+        ):
+            out = gen.suggest_multiple(
+                conversation=[{"text": "hi", "is_from_me": False}],
+                contact_name="Alex",
+                count=3,
+            )
+        assert len(out) == 3
+        assert all(o.startswith("haha") for o in out)


### PR DESCRIPTION
## Summary

Implements three patches against `agent/clapcheeks/imessage/ai_reply.py`:

- **P2 (AI-8736)** — 10-stage `_clean_output()` guard stack: keep last paragraph, META_LEAK / SAFETY_BLOCK / money-JK / slang blocklists, em-dash strip, length cap, fake-phone regex, >60% word-overlap with priors, exact question repetition. Every block logs `BLOCKED (<reason>): <preview>`.
- **P6 read side (AI-8740)** — `_load_memo()` reads `~/.clapcheeks/memos/<handle_id>.md` and prepends a `[PERSISTENT MEMO ...]` block to the system prompt so per-girl context informs every reply. Slashes in `handle_id` are sanitized to `_` so the memo file lookup can never escape the directory.
- **P7 (AI-8741)** — Time-aware staleness recovery: if her last inbound message was >4h ago AND contained a time-sensitive word (tonight / today / this evening / right now / rn / tn / etc), append a NOTE to the system prompt instructing a brief apology + a fresh proposal for later this week.

`watcher.py` now passes `handle_id`, `last_msg_timestamp`, and `last_msg_text` through to `ReplyGenerator.suggest_reply()`. `suggest_multiple()` forwards the same parameters.

## Test plan
- [x] 34 new unit tests in `agent/tests/test_ai_reply_guards.py` cover every guard branch, memo load (present / missing / blank handle / whitespace / slash sanitization), staleness on/off branching, and `suggest_multiple()` count behavior. All Ollama calls are mocked.
- [x] Full `pytest tests/` run: 632 passed, 3 pre-existing `test_vision.py` failures unrelated to this change (`_process_match_vision` is missing from daemon module on `origin/main` already — confirmed).
- [ ] Manual smoke on the Mac agent against a real Ollama once merged (requires Mac Mini access).

## Files touched
- `agent/clapcheeks/imessage/ai_reply.py` (+modified, ~+330 lines)
- `agent/clapcheeks/imessage/watcher.py` (+pass-through to ReplyGenerator)
- `agent/tests/test_ai_reply_guards.py` (+new, 34 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)