### PR TITLE
feat(clapcheeks): P3+P4 — chat.db pre-send recheck + account-index SMS/iMessage routing

### DIFF
--- a/agent/clapcheeks/imessage/sender.py
+++ b/agent/clapcheeks/imessage/sender.py
@@ -6,17 +6,46 @@ is not on PATH.
 
 Keeps a narrow surface so the drafting pipeline can remain platform-
 agnostic — callers pass (phone_e164, body).
+
+Patches:
+- P3 (AI-8737): pre-send chat.db recheck — abort if the operator just
+  typed a message manually on the same handle (avoid double-texting).
+- P4 (AI-8738): explicit AppleScript account-index routing for the
+  osascript fallback so SMS handles route via the SMS account
+  (Continuity / Messages in iCloud) instead of the iMessage account.
 """
 from __future__ import annotations
 
 import logging
+import os
 import shutil
+import sqlite3
 import subprocess
 from dataclasses import dataclass
+from pathlib import Path
 
 from clapcheeks.imessage.reader import to_e164_us
 
 logger = logging.getLogger("clapcheeks.imessage.sender")
+
+
+# ---------------------------------------------------------------------------
+# Paths / configuration
+# ---------------------------------------------------------------------------
+
+IMESSAGE_DB_PATH = Path.home() / "Library" / "Messages" / "chat.db"
+
+# AppleScript "account N" routing. macOS Messages.app exposes both an
+# iMessage account and an SMS-forwarding account; their indices are stable
+# per-Mac but vary across machines. Override per-Mac with env vars.
+IMESSAGE_ACCOUNT_INDEX = int(os.environ.get("IMESSAGE_ACCOUNT_INDEX", "5"))
+SMS_ACCOUNT_INDEX = int(os.environ.get("SMS_ACCOUNT_INDEX", "2"))
+
+# Country-code prefixes that we treat as SMS-by-default (Android-heavy
+# regions where iMessage delivery routinely fails). Operator can extend
+# this list per-handle via SMS_HANDLES_FILE.
+SMS_PREFIXES = ("+52", "+91")  # +52 Mexico, +91 India
+SMS_HANDLES_FILE = Path.home() / ".clapcheeks" / "sms-handles.txt"
 
 
 @dataclass
@@ -26,6 +55,10 @@ class SendResult:
     error: str | None = None
 
 
+# ---------------------------------------------------------------------------
+# Helpers — transport detection
+# ---------------------------------------------------------------------------
+
 def _which_god() -> str | None:
     return shutil.which("god")
 
@@ -34,13 +67,77 @@ def _which_osascript() -> str | None:
     return shutil.which("osascript")
 
 
+# ---------------------------------------------------------------------------
+# P3 — pre-send chat.db recheck
+# ---------------------------------------------------------------------------
+
+def _recheck_no_double_text(handle_id: str) -> bool:
+    """Re-query chat.db for the LAST message on this handle.
+
+    Returns False if is_from_me=1 (operator typed manually since the draft
+    was generated). Returns True if safe to send (her last, or no prior).
+
+    Fails OPEN — if chat.db is unavailable (not on Mac, FDA revoked, etc.)
+    we let the send proceed rather than silently dropping every draft.
+    """
+    if not IMESSAGE_DB_PATH.exists():
+        return True  # not on Mac with chat.db — let send proceed
+    try:
+        db = sqlite3.connect(f"file:{IMESSAGE_DB_PATH}?mode=ro", uri=True, timeout=2)
+        last = db.execute(
+            """SELECT is_from_me FROM message m
+               JOIN handle h ON m.handle_id = h.rowid
+               WHERE h.id = ? ORDER BY date DESC LIMIT 1""",
+            (handle_id,),
+        ).fetchone()
+        db.close()
+        return last is None or last[0] == 0
+    except Exception as exc:  # noqa: BLE001 — fail-open on any DB error
+        logger.warning(
+            "chat.db recheck failed for %s: %s — proceeding with send",
+            handle_id, exc,
+        )
+        return True  # fail-open
+
+
+# ---------------------------------------------------------------------------
+# P4 — SMS handle classification
+# ---------------------------------------------------------------------------
+
+def _is_sms_handle(handle: str) -> bool:
+    """Decide whether a phone handle should route through the SMS account.
+
+    Rules (in order):
+    1. Country-code prefix matches SMS_PREFIXES (Mexico, India, ...).
+    2. Operator-overridden allow-list at ~/.clapcheeks/sms-handles.txt
+       (one E.164 handle per line; blank lines and whitespace ignored).
+    """
+    if any(handle.startswith(p) for p in SMS_PREFIXES):
+        return True
+    if SMS_HANDLES_FILE.exists():
+        try:
+            entries = {
+                line.strip()
+                for line in SMS_HANDLES_FILE.read_text().splitlines()
+                if line.strip()
+            }
+            return handle in entries
+        except OSError:
+            pass
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
 def send_imessage(
     phone: str,
     body: str,
     *,
     dry_run: bool = False,
 ) -> SendResult:
-    """Send `body` to `phone` via iMessage.
+    """Send `body` to `phone` via iMessage / SMS.
 
     Normalizes phone to E.164 first. On dry_run (or if no transport is
     available), returns a noop SendResult without raising.
@@ -54,6 +151,14 @@ def send_imessage(
     if dry_run:
         logger.info("[dry_run] would send iMessage to %s: %s", e164, body[:80])
         return SendResult(ok=True, channel="noop")
+
+    # P3: chat.db recheck — abort if operator typed manually since draft.
+    if not _recheck_no_double_text(e164):
+        logger.info(
+            "send aborted for %s — last message is_from_me=1 (operator typed)",
+            e164,
+        )
+        return SendResult(ok=False, channel="noop", error="double_text_aborted")
 
     god = _which_god()
     if god:
@@ -73,13 +178,15 @@ def send_imessage(
 
     osa = _which_osascript()
     if osa:
-        # Local Mac fallback.
-        escaped_body = body.replace('"', '\\"')
+        # P4: explicit account-index routing. Pick SMS account for handles
+        # we know are SMS, otherwise iMessage account.
+        account_index = (
+            SMS_ACCOUNT_INDEX if _is_sms_handle(e164) else IMESSAGE_ACCOUNT_INDEX
+        )
+        escaped_body = body.replace("\\", "\\\\").replace('"', '\\"')
         script = (
-            'tell application "Messages"\n'
-            f'set theBuddy to participant "{e164}" of (service "iMessage")\n'
-            f'send "{escaped_body}" to theBuddy\n'
-            'end tell'
+            f'tell application "Messages" to send "{escaped_body}" '
+            f'to participant "{e164}" of account {account_index}'
         )
         try:
             proc = subprocess.run(

--- a/agent/tests/test_sender_p3_p4.py
+++ b/agent/tests/test_sender_p3_p4.py
@@ -1,0 +1,250 @@
+"""Tests for sender.py P3 (chat.db pre-send recheck) + P4 (account-index routing).
+
+AI-8737 / AI-8738.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from clapcheeks.imessage import sender
+from clapcheeks.imessage.sender import (
+    SendResult,
+    _is_sms_handle,
+    _recheck_no_double_text,
+    send_imessage,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — synthetic chat.db
+# ---------------------------------------------------------------------------
+
+def _make_chat_db(path: Path, rows: list) -> None:
+    """Build a minimal chat.db schema and seed it with (handle_id, is_from_me, date) rows."""
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE handle (
+            ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+            id TEXT
+        );
+        CREATE TABLE message (
+            ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+            handle_id INTEGER,
+            is_from_me INTEGER,
+            date INTEGER
+        );
+        """
+    )
+    handle_ids = {}
+    for handle, _, _ in rows:
+        if handle not in handle_ids:
+            cur = conn.execute("INSERT INTO handle (id) VALUES (?)", (handle,))
+            handle_ids[handle] = cur.lastrowid
+    for handle, is_from_me, date in rows:
+        conn.execute(
+            "INSERT INTO message (handle_id, is_from_me, date) VALUES (?, ?, ?)",
+            (handle_ids[handle], is_from_me, date),
+        )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def temp_chat_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "chat.db"
+    monkeypatch.setattr(sender, "IMESSAGE_DB_PATH", db_path)
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# P3 — _recheck_no_double_text
+# ---------------------------------------------------------------------------
+
+class TestRecheckNoDoubleText:
+    def test_last_from_me_returns_false(self, temp_chat_db):
+        """Operator typed last (is_from_me=1) -> abort send."""
+        _make_chat_db(temp_chat_db, [
+            ("+15551234567", 0, 100),
+            ("+15551234567", 1, 200),
+        ])
+        assert _recheck_no_double_text("+15551234567") is False
+
+    def test_last_from_her_returns_true(self, temp_chat_db):
+        """Her message is last (is_from_me=0) -> safe to send."""
+        _make_chat_db(temp_chat_db, [
+            ("+15551234567", 1, 100),
+            ("+15551234567", 0, 200),
+        ])
+        assert _recheck_no_double_text("+15551234567") is True
+
+    def test_empty_db_returns_true(self, temp_chat_db):
+        """No rows -> safe to send."""
+        _make_chat_db(temp_chat_db, [])
+        assert _recheck_no_double_text("+15551234567") is True
+
+    def test_missing_db_file_returns_true(self, tmp_path, monkeypatch):
+        """Missing chat.db -> fail-open."""
+        missing = tmp_path / "does-not-exist.db"
+        monkeypatch.setattr(sender, "IMESSAGE_DB_PATH", missing)
+        assert _recheck_no_double_text("+15551234567") is True
+
+    def test_other_handle_unaffected(self, temp_chat_db):
+        """is_from_me=1 on a DIFFERENT handle should not block ours."""
+        _make_chat_db(temp_chat_db, [
+            ("+15550000000", 1, 200),
+            ("+15551234567", 0, 150),
+        ])
+        assert _recheck_no_double_text("+15551234567") is True
+
+    def test_corrupt_db_fails_open(self, tmp_path, monkeypatch):
+        """Unreadable chat.db -> log + return True (fail-open)."""
+        bad = tmp_path / "chat.db"
+        bad.write_bytes(b"this is not a sqlite database")
+        monkeypatch.setattr(sender, "IMESSAGE_DB_PATH", bad)
+        assert _recheck_no_double_text("+15551234567") is True
+
+
+# ---------------------------------------------------------------------------
+# P3 — integration: send_imessage abort path
+# ---------------------------------------------------------------------------
+
+class TestSendImessageDoubleTextAbort:
+    def test_double_text_aborted_never_calls_subprocess(self, temp_chat_db, monkeypatch):
+        """Operator just typed -> abort, never shell out."""
+        _make_chat_db(temp_chat_db, [
+            ("+15551234567", 0, 100),
+            ("+15551234567", 1, 200),
+        ])
+        monkeypatch.setattr(sender, "_which_god", lambda: "/usr/local/bin/god")
+        monkeypatch.setattr(sender, "_which_osascript", lambda: "/usr/bin/osascript")
+
+        with mock.patch("clapcheeks.imessage.sender.subprocess.run") as run_spy:
+            result = send_imessage("+15551234567", "hey what's up")
+
+        assert result.ok is False
+        assert result.channel == "noop"
+        assert result.error == "double_text_aborted"
+        run_spy.assert_not_called()
+
+    def test_safe_to_send_does_call_subprocess(self, temp_chat_db, monkeypatch):
+        """Her message is last -> send proceeds normally."""
+        _make_chat_db(temp_chat_db, [
+            ("+15551234567", 1, 100),
+            ("+15551234567", 0, 200),
+        ])
+        monkeypatch.setattr(sender, "_which_god", lambda: "/usr/local/bin/god")
+
+        completed = mock.Mock(returncode=0, stdout="", stderr="")
+        with mock.patch(
+            "clapcheeks.imessage.sender.subprocess.run", return_value=completed,
+        ) as run_spy:
+            result = send_imessage("+15551234567", "hey what's up")
+
+        assert result.ok is True
+        assert result.channel == "god-mac"
+        run_spy.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# P4 — _is_sms_handle
+# ---------------------------------------------------------------------------
+
+class TestIsSmsHandle:
+    def test_mexico_prefix_is_sms(self):
+        assert _is_sms_handle("+5212345678901") is True
+
+    def test_india_prefix_is_sms(self):
+        assert _is_sms_handle("+919876543210") is True
+
+    def test_us_prefix_is_not_sms(self):
+        assert _is_sms_handle("+15551234567") is False
+
+    def test_no_handles_file_us_not_sms(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sender, "SMS_HANDLES_FILE", tmp_path / "does-not-exist.txt")
+        assert _is_sms_handle("+15551234567") is False
+
+    def test_handles_file_overrides(self, tmp_path, monkeypatch):
+        handles_file = tmp_path / "sms-handles.txt"
+        handles_file.write_text("+15551234567\n+15559999999\n\n")
+        monkeypatch.setattr(sender, "SMS_HANDLES_FILE", handles_file)
+        assert _is_sms_handle("+15551234567") is True
+        assert _is_sms_handle("+15559999999") is True
+        assert _is_sms_handle("+15550000000") is False
+
+    def test_handles_file_strips_whitespace(self, tmp_path, monkeypatch):
+        handles_file = tmp_path / "sms-handles.txt"
+        handles_file.write_text("  +15551234567  \n   \n+15559999999\n")
+        monkeypatch.setattr(sender, "SMS_HANDLES_FILE", handles_file)
+        assert _is_sms_handle("+15551234567") is True
+        assert _is_sms_handle("+15559999999") is True
+
+
+# ---------------------------------------------------------------------------
+# P4 — osascript account-index routing
+# ---------------------------------------------------------------------------
+
+class TestOsascriptAccountIndex:
+    def _force_osascript_path(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sender, "_which_god", lambda: None)
+        monkeypatch.setattr(sender, "_which_osascript", lambda: "/usr/bin/osascript")
+        monkeypatch.setattr(sender, "IMESSAGE_DB_PATH", tmp_path / "no-db.db")
+        monkeypatch.setattr(sender, "IMESSAGE_ACCOUNT_INDEX", 5)
+        monkeypatch.setattr(sender, "SMS_ACCOUNT_INDEX", 2)
+        monkeypatch.setattr(sender, "SMS_HANDLES_FILE", tmp_path / "empty-handles.txt")
+
+    def test_imessage_handle_uses_index_5(self, monkeypatch, tmp_path):
+        self._force_osascript_path(monkeypatch, tmp_path)
+        completed = mock.Mock(returncode=0, stdout="", stderr="")
+        with mock.patch(
+            "clapcheeks.imessage.sender.subprocess.run", return_value=completed,
+        ) as run_spy:
+            result = send_imessage("+15551234567", "hi there")
+
+        assert result.ok is True
+        assert result.channel == "osascript"
+        run_spy.assert_called_once()
+        cmd = run_spy.call_args.args[0]
+        assert cmd[0] == "/usr/bin/osascript"
+        assert cmd[1] == "-e"
+        script = cmd[2]
+        assert "of account 5" in script
+        assert 'participant "+15551234567"' in script
+        assert '"hi there"' in script
+
+    def test_sms_prefix_handle_uses_index_2(self, monkeypatch, tmp_path):
+        self._force_osascript_path(monkeypatch, tmp_path)
+        # to_e164_us only handles US — patch within sender to no-op for non-US.
+        monkeypatch.setattr(sender, "to_e164_us", lambda p: p)
+        completed = mock.Mock(returncode=0, stdout="", stderr="")
+        with mock.patch(
+            "clapcheeks.imessage.sender.subprocess.run", return_value=completed,
+        ) as run_spy:
+            result = send_imessage("+5212345678901", "hola")
+
+        assert result.ok is True
+        run_spy.assert_called_once()
+        script = run_spy.call_args.args[0][2]
+        assert "of account 2" in script
+        assert 'participant "+5212345678901"' in script
+
+    def test_handles_file_overrides_to_sms(self, monkeypatch, tmp_path):
+        """US number in sms-handles.txt routes via SMS account."""
+        self._force_osascript_path(monkeypatch, tmp_path)
+        handles_file = tmp_path / "sms-handles.txt"
+        handles_file.write_text("+15551234567\n")
+        monkeypatch.setattr(sender, "SMS_HANDLES_FILE", handles_file)
+
+        completed = mock.Mock(returncode=0, stdout="", stderr="")
+        with mock.patch(
+            "clapcheeks.imessage.sender.subprocess.run", return_value=completed,
+        ) as run_spy:
+            result = send_imessage("+15551234567", "hi")
+
+        assert result.ok is True
+        script = run_spy.call_args.args[0][2]
+        assert "of account 2" in script


### PR DESCRIPTION
## Summary
- **P3 (AI-8737):** Pre-send `chat.db` recheck — abort with `SendResult(error='double_text_aborted')` if `is_from_me=1` on the LAST message for the handle (operator typed manually since draft was generated). Fail-open on missing/corrupt DB.
- **P4 (AI-8738):** Replace `service "iMessage"` AppleScript with explicit `of account N` routing. New `_is_sms_handle()` decides SMS-vs-iMessage based on country-code prefix (`+52`, `+91`) plus an operator allow-list at `~/.clapcheeks/sms-handles.txt`. Indices env-overridable via `IMESSAGE_ACCOUNT_INDEX` / `SMS_ACCOUNT_INDEX`.
- Both patches land in a single file: `agent/clapcheeks/imessage/sender.py`.

## Test plan
- [x] `agent/tests/test_sender_p3_p4.py` — 17 new tests, all pass
  - 6 unit tests on `_recheck_no_double_text` (last-from-me, last-from-her, empty db, missing file, other-handle isolation, corrupt db fail-open)
  - 2 integration tests on `send_imessage` (abort path never invokes subprocess; safe path does)
  - 6 unit tests on `_is_sms_handle` (Mexico, India, US, missing override file, file overrides, whitespace stripping)
  - 3 integration tests on osascript routing (US handle → account 5, +52 → account 2, US-overridden-via-file → account 2)
- [x] Full test suite: 615 passed, 3 pre-existing `test_vision` failures unrelated to this change (missing `_process_match_vision` in `daemon.py`)
- [x] Import smoke test: `python3 -c "from clapcheeks.imessage.sender import send_imessage"` works

## Linear
- AI-8737 — chat.db pre-send recheck
- AI-8738 — account-index AppleScript routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)