### PR TITLE
feat(clapcheeks): P5+P8+infra - presence gate, fcntl daemon lock, ai/ always-warm

### DIFF
--- a/agent/clapcheeks/daemon.py
+++ b/agent/clapcheeks/daemon.py
@@ -4,6 +4,7 @@ Manages per-platform swipe sessions, conversation loops, metric sync,
 and heartbeat on independent threads with configurable intervals and
 active-hours gating.
 """
+import fcntl
 import logging
 import logging.handlers
 import os
@@ -34,8 +35,32 @@ from clapcheeks.events import EventEmitter
 from clapcheeks.session.ban_detector import BanDetector
 
 LOG_FILE = CONFIG_DIR / "daemon.log"
+LOCK_FILE = "/tmp/clapcheeks-daemon.lock"
 
 log = logging.getLogger("clapcheeks.daemon")
+
+# Module-level lock file handle — must remain open for the lifetime of the
+# process so the fcntl lock is held. Closing or GC'ing this releases the lock.
+_lock_fp = None
+
+
+def _acquire_singleton_lock() -> None:
+    """Acquire fcntl exclusive lock so only one daemon can run at a time.
+
+    Exits process with code 1 if another instance already holds the lock.
+    """
+    global _lock_fp
+    _lock_fp = open(LOCK_FILE, "w")
+    try:
+        fcntl.flock(_lock_fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (IOError, OSError):
+        print(
+            "FATAL: another clapcheeks daemon is already running. Exiting.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    _lock_fp.write(str(os.getpid()))
+    _lock_fp.flush()
 
 # ---------------------------------------------------------------------------
 # Crash tracking for degraded status detection (AGENT-01)
@@ -348,11 +373,23 @@ def _platform_worker(
     log.info("Platform thread started: %s (every %dh, active %s)",
              platform, daemon_cfg["swipe_interval_hours"], active_hours)
 
+    from clapcheeks.safety.presence import should_be_active
+
     while not _shutdown.is_set():
         # Gate on active hours
         if not _in_active_hours(active_hours):
             log.info("[%s] Outside active hours %s, sleeping 15m", platform, active_hours)
             _shutdown.wait(900)
+            continue
+
+        # --- Presence gate (P5) ---
+        # Only run swipe / API loop when operator is home + iPhone present
+        # so the dating apps don't fingerprint auto-replies as off-network.
+        # iMessage replies are NOT gated by this — they're not fingerprinted.
+        active, reason = should_be_active()
+        if not active:
+            log.info("[%s] Presence gate blocked: %s — sleeping 5m", platform, reason)
+            _shutdown.wait(300)
             continue
 
         # --- Ban check ---
@@ -426,6 +463,7 @@ def _platform_worker(
 
 def run_daemon() -> None:
     """Main daemon entry point — launches all scheduling threads."""
+    _acquire_singleton_lock()
     _setup_logging()
     signal.signal(signal.SIGTERM, _handle_sigterm)
     signal.signal(signal.SIGINT, _handle_sigterm)

--- a/agent/clapcheeks/safety/__init__.py
+++ b/agent/clapcheeks/safety/__init__.py
@@ -12,6 +12,7 @@ from clapcheeks.safety.emergency_stop import emergency_stop as estop_singleton
 from clapcheeks.safety.human_delay import HumanDelayEngine
 from clapcheeks.safety.platform_limits import PlatformLimits, PLATFORM_SAFETY_LIMITS
 from clapcheeks.safety.ban_monitor import BanMonitor
+from clapcheeks.safety.presence import should_be_active
 
 __all__ = [
     "EmergencyStop",
@@ -20,4 +21,5 @@ __all__ = [
     "BanMonitor",
     "PlatformLimits",
     "PLATFORM_SAFETY_LIMITS",
+    "should_be_active",
 ]

--- a/agent/clapcheeks/safety/presence.py
+++ b/agent/clapcheeks/safety/presence.py
@@ -1,0 +1,78 @@
+"""Physical-world presence gate — bot only runs when operator is home + iPhone present + active hours.
+Prevents Tinder/Hinge from fingerprinting auto-replies as off-network.
+"""
+from __future__ import annotations
+import datetime
+import logging
+import os
+import subprocess
+
+logger = logging.getLogger("clapcheeks.safety.presence")
+
+IPHONE_LAN_IP = os.environ.get("MY_IPHONE_LAN_IP", "")
+HOME_SUBNET_PREFIX = os.environ.get("HOME_SUBNET_PREFIX", "")
+ACTIVE_HOURS_START = int(os.environ.get("CC_ACTIVE_HOURS_START", "7"))
+ACTIVE_HOURS_END = int(os.environ.get("CC_ACTIVE_HOURS_END", "23"))
+PAUSE_FLAG = "/tmp/clapcheeks-paused"
+FORCE_FLAG = "/tmp/clapcheeks-force-on"
+
+
+def _mac_on_home_subnet() -> bool:
+    if not HOME_SUBNET_PREFIX:
+        return True  # not configured — fail open
+    try:
+        out = subprocess.run(["ifconfig"], capture_output=True, text=True, timeout=2).stdout
+        return HOME_SUBNET_PREFIX in out
+    except Exception:
+        return True
+
+
+def _iphone_on_lan() -> bool:
+    """iPhone present if either ping responds OR ARP cache has it.
+    iOS WiFi sleeps when locked, killing ping but leaving ARP for ~20min.
+    """
+    if not IPHONE_LAN_IP:
+        return True  # not configured — fail open
+    try:
+        r = subprocess.run(["ping", "-c", "1", "-W", "800", IPHONE_LAN_IP],
+                          capture_output=True, timeout=3)
+        if r.returncode == 0:
+            return True
+    except Exception:
+        pass
+    try:
+        r = subprocess.run(["arp", "-n", IPHONE_LAN_IP],
+                          capture_output=True, text=True, timeout=2)
+        out = r.stdout + r.stderr
+        if "no entry" in out.lower() or "(incomplete)" in out.lower():
+            return False
+        if " at " in out and "ff:ff:ff:ff:ff:ff" not in out:
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _within_active_hours() -> bool:
+    h = datetime.datetime.now().hour
+    return ACTIVE_HOURS_START <= h <= ACTIVE_HOURS_END
+
+
+def should_be_active() -> tuple[bool, str]:
+    """Return (active, reason). Use this to gate Tinder/Hinge swipe + auto-reply loops."""
+    if os.path.exists(PAUSE_FLAG):
+        return False, "manual pause flag set"
+    if os.path.exists(FORCE_FLAG):
+        return True, "force-on flag set (bypassing gates)"
+    if not _within_active_hours():
+        return False, f"outside active hours {ACTIVE_HOURS_START}-{ACTIVE_HOURS_END}"
+    if not _mac_on_home_subnet():
+        return False, "mac not on home subnet"
+    if not _iphone_on_lan():
+        return False, f"iphone not reachable on LAN ({IPHONE_LAN_IP})"
+    return True, "ok: home + phone present + active hours"
+
+
+if __name__ == "__main__":
+    active, reason = should_be_active()
+    print(f"active={active}  reason={reason}")

--- a/agent/tests/test_daemon_lock.py
+++ b/agent/tests/test_daemon_lock.py
@@ -1,0 +1,92 @@
+"""Tests for clapcheeks.daemon fcntl singleton lock.
+
+Verifies:
+- _acquire_singleton_lock succeeds when no other holder
+- a second process attempting to acquire the lock exits with code 1
+"""
+from __future__ import annotations
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def test_lock_acquires_when_free(tmp_path, monkeypatch):
+    """Calling _acquire_singleton_lock directly succeeds when nothing holds the lock."""
+    lock_file = str(tmp_path / "test-daemon.lock")
+    # Patch the LOCK_FILE constant before import
+    import clapcheeks.daemon as daemon
+    monkeypatch.setattr(daemon, "LOCK_FILE", lock_file)
+    # Reset module-level fp so re-acquire doesn't error
+    monkeypatch.setattr(daemon, "_lock_fp", None)
+    daemon._acquire_singleton_lock()
+    assert os.path.exists(lock_file)
+    # PID written
+    with open(lock_file) as f:
+        pid_str = f.read().strip()
+    assert pid_str == str(os.getpid())
+    # Cleanup: release lock by closing the fp
+    daemon._lock_fp.close()
+    daemon._lock_fp = None
+
+
+def test_second_process_exits_when_lock_held(tmp_path):
+    """Spawn two subprocesses that both try to grab the lock; second one must exit 1."""
+    lock_file = str(tmp_path / "test-daemon-2.lock")
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    holder_script = textwrap.dedent(f"""
+        import sys, os, time
+        sys.path.insert(0, {repo_root!r})
+        import clapcheeks.daemon as d
+        d.LOCK_FILE = {lock_file!r}
+        d._lock_fp = None
+        d._acquire_singleton_lock()
+        # Hold the lock for a bit so the second process can attempt
+        sys.stdout.write("HELD\\n")
+        sys.stdout.flush()
+        time.sleep(5)
+    """)
+
+    challenger_script = textwrap.dedent(f"""
+        import sys, os
+        sys.path.insert(0, {repo_root!r})
+        import clapcheeks.daemon as d
+        d.LOCK_FILE = {lock_file!r}
+        d._lock_fp = None
+        d._acquire_singleton_lock()
+        sys.stdout.write("ACQUIRED\\n")
+    """)
+
+    # Start the holder
+    holder = subprocess.Popen(
+        [sys.executable, "-c", holder_script],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        # Wait for it to print HELD so we know the lock is taken
+        line = holder.stdout.readline()
+        assert "HELD" in line, f"holder did not acquire lock; got {line!r}"
+
+        # Now try to acquire from a second process — must fail with exit 1
+        challenger = subprocess.run(
+            [sys.executable, "-c", challenger_script],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert challenger.returncode == 1, (
+            f"challenger should have exited 1, got {challenger.returncode}; "
+            f"stdout={challenger.stdout!r} stderr={challenger.stderr!r}"
+        )
+        assert "already running" in challenger.stderr.lower()
+    finally:
+        holder.terminate()
+        try:
+            holder.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            holder.kill()

--- a/agent/tests/test_presence.py
+++ b/agent/tests/test_presence.py
@@ -1,0 +1,322 @@
+"""Tests for clapcheeks.safety.presence — physical-world presence gate.
+
+Verifies all branches:
+- pause flag → False
+- force flag → True (overrides everything else)
+- outside active hours → False
+- mac not on home subnet → False
+- iphone not on LAN (no ping, no ARP) → False
+- iphone present via ping → True
+- iphone present via ARP only → True
+- fail-open behavior when env vars empty
+"""
+from __future__ import annotations
+import os
+import subprocess
+from importlib import reload
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reload_presence(env: dict | None = None):
+    """Reload the presence module so module-level os.environ reads pick up overrides."""
+    import clapcheeks.safety.presence as p
+    if env is not None:
+        with patch.dict(os.environ, env, clear=False):
+            reload(p)
+    else:
+        reload(p)
+    return p
+
+
+def _mk_completed(stdout: str = "", stderr: str = "", returncode: int = 0):
+    cp = MagicMock(spec=subprocess.CompletedProcess)
+    cp.stdout = stdout
+    cp.stderr = stderr
+    cp.returncode = returncode
+    return cp
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_flags():
+    """Make sure flag files don't leak between tests."""
+    for f in ("/tmp/clapcheeks-paused", "/tmp/clapcheeks-force-on"):
+        try:
+            os.remove(f)
+        except FileNotFoundError:
+            pass
+    yield
+    for f in ("/tmp/clapcheeks-paused", "/tmp/clapcheeks-force-on"):
+        try:
+            os.remove(f)
+        except FileNotFoundError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Flag file gates
+# ---------------------------------------------------------------------------
+
+class TestFlagGates:
+    def test_pause_flag_blocks(self):
+        p = _reload_presence({
+            "MY_IPHONE_LAN_IP": "",
+            "HOME_SUBNET_PREFIX": "",
+            "CC_ACTIVE_HOURS_START": "0",
+            "CC_ACTIVE_HOURS_END": "23",
+        })
+        with open(p.PAUSE_FLAG, "w") as f:
+            f.write("paused")
+        active, reason = p.should_be_active()
+        assert active is False
+        assert "pause" in reason.lower()
+
+    def test_force_flag_overrides_everything(self):
+        p = _reload_presence({
+            "MY_IPHONE_LAN_IP": "10.0.0.99",
+            "HOME_SUBNET_PREFIX": "192.168.99.",
+            "CC_ACTIVE_HOURS_START": "23",
+            "CC_ACTIVE_HOURS_END": "23",
+        })
+        with open(p.FORCE_FLAG, "w") as f:
+            f.write("force")
+        active, reason = p.should_be_active()
+        assert active is True
+        assert "force" in reason.lower()
+
+    def test_pause_flag_takes_priority_over_force(self):
+        p = _reload_presence({})
+        with open(p.PAUSE_FLAG, "w") as f:
+            f.write("paused")
+        with open(p.FORCE_FLAG, "w") as f:
+            f.write("force")
+        active, reason = p.should_be_active()
+        assert active is False
+        assert "pause" in reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# Active hours
+# ---------------------------------------------------------------------------
+
+class TestActiveHours:
+    def test_within_active_hours(self):
+        p = _reload_presence({
+            "CC_ACTIVE_HOURS_START": "0",
+            "CC_ACTIVE_HOURS_END": "23",
+            "MY_IPHONE_LAN_IP": "",
+            "HOME_SUBNET_PREFIX": "",
+        })
+        assert p._within_active_hours() is True
+
+    def test_outside_active_hours_blocks(self):
+        import datetime as dt
+        now_hour = dt.datetime.now().hour
+        bad = (now_hour + 12) % 24
+        if now_hour == bad:
+            pytest.skip("Test hour collision; rerun")
+        p = _reload_presence({
+            "CC_ACTIVE_HOURS_START": str(bad),
+            "CC_ACTIVE_HOURS_END": str(bad),
+            "MY_IPHONE_LAN_IP": "",
+            "HOME_SUBNET_PREFIX": "",
+        })
+        active, reason = p.should_be_active()
+        assert active is False
+        assert "active hours" in reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# Subnet detection
+# ---------------------------------------------------------------------------
+
+class TestSubnet:
+    def test_subnet_unconfigured_fail_open(self):
+        p = _reload_presence({
+            "HOME_SUBNET_PREFIX": "",
+            "MY_IPHONE_LAN_IP": "",
+            "CC_ACTIVE_HOURS_START": "0",
+            "CC_ACTIVE_HOURS_END": "23",
+        })
+        assert p._mac_on_home_subnet() is True
+
+    def test_subnet_match(self):
+        p = _reload_presence({
+            "HOME_SUBNET_PREFIX": "192.168.1.",
+            "MY_IPHONE_LAN_IP": "",
+            "CC_ACTIVE_HOURS_START": "0",
+            "CC_ACTIVE_HOURS_END": "23",
+        })
+        with patch("clapcheeks.safety.presence.subprocess.run") as mock_run:
+            mock_run.return_value = _mk_completed(
+                stdout="inet 192.168.1.42 netmask 0xffffff00 broadcast 192.168.1.255",
+            )
+            assert p._mac_on_home_subnet() is True
+
+    def test_subnet_mismatch(self):
+        p = _reload_presence({
+            "HOME_SUBNET_PREFIX": "192.168.1.",
+            "MY_IPHONE_LAN_IP": "",
+            "CC_ACTIVE_HOURS_START": "0",
+            "CC_ACTIVE_HOURS_END": "23",
+        })
+        with patch("clapcheeks.safety.presence.subprocess.run") as mock_run:
+            mock_run.return_value = _mk_completed(
+                stdout="inet 10.0.0.5 netmask 0xff000000 broadcast 10.255.255.255",
+            )
+            assert p._mac_on_home_subnet() is False
+
+    def test_subnet_subprocess_exception_fail_open(self):
+        p = _reload_presence({
+            "HOME_SUBNET_PREFIX": "192.168.1.",
+            "MY_IPHONE_LAN_IP": "",
+            "CC_ACTIVE_HOURS_START": "0",
+            "CC_ACTIVE_HOURS_END": "23",
+        })
+        with patch(
+            "clapcheeks.safety.presence.subprocess.run",
+            side_effect=OSError("ifconfig missing"),
+        ):
+            assert p._mac_on_home_subnet() is True
+
+
+# ---------------------------------------------------------------------------
+# iPhone on LAN
+# ---------------------------------------------------------------------------
+
+class TestIPhoneOnLAN:
+    def test_iphone_unconfigured_fail_open(self):
+        p = _reload_presence({"MY_IPHONE_LAN_IP": ""})
+        assert p._iphone_on_lan() is True
+
+    def test_iphone_present_via_ping(self):
+        p = _reload_presence({"MY_IPHONE_LAN_IP": "192.168.1.55"})
+
+        def fake_run(cmd, *args, **kwargs):
+            if "ping" in cmd[0]:
+                return _mk_completed(returncode=0)
+            return _mk_completed(returncode=1)
+
+        with patch("clapcheeks.safety.presence.subprocess.run", side_effect=fake_run):
+            assert p._iphone_on_lan() is True
+
+    def test_iphone_present_via_arp_when_ping_fails(self):
+        p = _reload_presence({"MY_IPHONE_LAN_IP": "192.168.1.55"})
+
+        def fake_run(cmd, *args, **kwargs):
+            if "ping" in cmd[0]:
+                return _mk_completed(returncode=1)
+            if "arp" in cmd[0]:
+                return _mk_completed(
+                    stdout="? (192.168.1.55) at aa:bb:cc:dd:ee:ff on en0 [ethernet]",
+                )
+            return _mk_completed(returncode=1)
+
+        with patch("clapcheeks.safety.presence.subprocess.run", side_effect=fake_run):
+            assert p._iphone_on_lan() is True
+
+    def test_iphone_absent_no_ping_no_arp(self):
+        p = _reload_presence({"MY_IPHONE_LAN_IP": "192.168.1.55"})
+
+        def fake_run(cmd, *args, **kwargs):
+            if "ping" in cmd[0]:
+                return _mk_completed(returncode=1)
+            if "arp" in cmd[0]:
+                return _mk_completed(stdout="192.168.1.55 (no entry)")
+            return _mk_completed(returncode=1)
+
+        with patch("clapcheeks.safety.presence.subprocess.run", side_effect=fake_run):
+            assert p._iphone_on_lan() is False
+
+    def test_iphone_absent_arp_incomplete(self):
+        p = _reload_presence({"MY_IPHONE_LAN_IP": "192.168.1.55"})
+
+        def fake_run(cmd, *args, **kwargs):
+            if "ping" in cmd[0]:
+                return _mk_completed(returncode=1)
+            if "arp" in cmd[0]:
+                return _mk_completed(
+                    stdout="? (192.168.1.55) at (incomplete) on en0 [ethernet]",
+                )
+            return _mk_completed(returncode=1)
+
+        with patch("clapcheeks.safety.presence.subprocess.run", side_effect=fake_run):
+            assert p._iphone_on_lan() is False
+
+    def test_iphone_arp_broadcast_mac_rejected(self):
+        p = _reload_presence({"MY_IPHONE_LAN_IP": "192.168.1.55"})
+
+        def fake_run(cmd, *args, **kwargs):
+            if "ping" in cmd[0]:
+                return _mk_completed(returncode=1)
+            if "arp" in cmd[0]:
+                return _mk_completed(
+                    stdout="? (192.168.1.55) at ff:ff:ff:ff:ff:ff on en0 [ethernet]",
+                )
+            return _mk_completed(returncode=1)
+
+        with patch("clapcheeks.safety.presence.subprocess.run", side_effect=fake_run):
+            assert p._iphone_on_lan() is False
+
+    def test_iphone_subprocess_exception_handled(self):
+        p = _reload_presence({"MY_IPHONE_LAN_IP": "192.168.1.55"})
+        with patch(
+            "clapcheeks.safety.presence.subprocess.run",
+            side_effect=OSError("ping missing"),
+        ):
+            assert p._iphone_on_lan() is False
+
+
+# ---------------------------------------------------------------------------
+# Top-level should_be_active integration
+# ---------------------------------------------------------------------------
+
+class TestShouldBeActive:
+    def test_all_clear_returns_active(self):
+        p = _reload_presence({
+            "MY_IPHONE_LAN_IP": "",
+            "HOME_SUBNET_PREFIX": "",
+            "CC_ACTIVE_HOURS_START": "0",
+            "CC_ACTIVE_HOURS_END": "23",
+        })
+        active, reason = p.should_be_active()
+        assert active is True
+        assert "ok" in reason.lower()
+
+    def test_subnet_failure_blocks(self):
+        p = _reload_presence({
+            "MY_IPHONE_LAN_IP": "",
+            "HOME_SUBNET_PREFIX": "192.168.99.",
+            "CC_ACTIVE_HOURS_START": "0",
+            "CC_ACTIVE_HOURS_END": "23",
+        })
+        with patch("clapcheeks.safety.presence.subprocess.run") as mock_run:
+            mock_run.return_value = _mk_completed(stdout="inet 10.0.0.1")
+            active, reason = p.should_be_active()
+            assert active is False
+            assert "subnet" in reason.lower()
+
+    def test_iphone_failure_blocks(self):
+        p = _reload_presence({
+            "MY_IPHONE_LAN_IP": "192.168.1.55",
+            "HOME_SUBNET_PREFIX": "",
+            "CC_ACTIVE_HOURS_START": "0",
+            "CC_ACTIVE_HOURS_END": "23",
+        })
+
+        def fake_run(cmd, *args, **kwargs):
+            if "ping" in cmd[0]:
+                return _mk_completed(returncode=1)
+            if "arp" in cmd[0]:
+                return _mk_completed(stdout="(no entry)")
+            return _mk_completed(returncode=1)
+
+        with patch("clapcheeks.safety.presence.subprocess.run", side_effect=fake_run):
+            active, reason = p.should_be_active()
+            assert active is False
+            assert "iphone" in reason.lower()

--- a/ai/fly.toml
+++ b/ai/fly.toml
@@ -6,9 +6,13 @@ primary_region = "lax"
 [http_service]
   internal_port = 8000
   force_https = true
+  # Keep at least one warm machine — the live message reply loop hits this
+  # service on every inbound iMessage and cold-starts (~3-5s) hurt latency.
+  # auto_stop_machines stays true so excess scaled-out machines still recycle;
+  # min_machines_running=1 forces one always-warm baseline.
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
 [[vm]]
   memory = "512mb"


### PR DESCRIPTION
## Summary

Three patches that harden the Clapcheeks dating co-pilot against detection and operational failure modes. Linear: AI-8739 (P5/P8), AI-8742 (infra fix).

- **P5 - Presence gate** (`agent/clapcheeks/safety/presence.py`): bot only runs when operator is home + iPhone present + within active hours, so Tinder/Hinge can't fingerprint auto-replies as off-network. Wired into `daemon._platform_worker`. iMessage replies are intentionally NOT gated.
- **P8 - fcntl daemon lock**: `_acquire_singleton_lock()` uses `LOCK_EX | LOCK_NB` on `/tmp/clapcheeks-daemon.lock` to guarantee a single daemon process. Second instance prints fatal message and exits 1.
- **Infra** (`ai/fly.toml`): `min_machines_running` 0 -> 1 to eliminate ~3-5s cold-starts in the live iMessage reply loop. `auto_stop_machines` stays true so over-scaled instances still recycle.

## Files changed

- `agent/clapcheeks/safety/presence.py` (new) - 78 lines
- `agent/clapcheeks/safety/__init__.py` - export `should_be_active`
- `agent/clapcheeks/daemon.py` - import fcntl, add `_acquire_singleton_lock()`, call it from `run_daemon()`, gate `_platform_worker` swipe loop on `should_be_active()`
- `ai/fly.toml` - `min_machines_running = 1`
- `agent/tests/test_presence.py` (new) - 19 tests
- `agent/tests/test_daemon_lock.py` (new) - 2 tests

## Test plan

- [x] `python3 -m clapcheeks.safety.presence` prints `active=...  reason=...` (manual smoke)
- [x] `pytest tests/test_presence.py tests/test_daemon_lock.py -v` -> 21 passed
- [x] `pytest tests/` -> 670 passed, 3 pre-existing failures in `test_vision.py` (missing `_process_match_vision`, also missing on `origin/main`, not introduced by this PR)
- [ ] Deploy `ai/` Fly app and confirm `min_machines_running=1` (separate deploy step)
- [ ] Set `MY_IPHONE_LAN_IP` + `HOME_SUBNET_PREFIX` env vars on operator's Mac and observe presence-gate skips in `daemon.log`

## Branch note

Original target branch `feat/clapcheeks-p5-p8-infra` was clobbered by concurrent worktree activity; this PR ships from `feat/clapcheeks-p5-p8-infra-v2` with identical content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)