### PR TITLE
feat(clapcheeks-dashboard): conversation thread + memo viewer on /matches/[id]

### DIFF
--- a/supabase/migrations/20260427180000_clapcheeks_memos.sql
+++ b/supabase/migrations/20260427180000_clapcheeks_memos.sql
@@ -1,0 +1,50 @@
+-- Per-contact memo storage for the operator-trust dashboard.
+--
+-- The local agent writes per-contact memos to ~/.clapcheeks/memos/+E164.md on
+-- the operator's Mac. sync.py mirrors the markdown content into this table so
+-- the dashboard can render + edit them without depending on the operator's
+-- local filesystem.
+--
+-- contact_handle is normalised to E.164 phone format (e.g. "+15551234567")
+-- when the contact is known. For platform matches that haven't exchanged a
+-- phone yet, the platform external_id is used (e.g. "tinder:abc123").
+--
+-- Idempotent.
+
+CREATE TABLE IF NOT EXISTS public.clapcheeks_memos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  contact_handle text NOT NULL,
+  content text NOT NULL DEFAULT '',
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, contact_handle)
+);
+
+ALTER TABLE public.clapcheeks_memos ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+     WHERE schemaname = 'public'
+       AND tablename = 'clapcheeks_memos'
+       AND policyname = 'users own memos select'
+  ) THEN
+    CREATE POLICY "users own memos select" ON public.clapcheeks_memos
+      FOR SELECT USING (auth.uid() = user_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+     WHERE schemaname = 'public'
+       AND tablename = 'clapcheeks_memos'
+       AND policyname = 'users own memos write'
+  ) THEN
+    CREATE POLICY "users own memos write" ON public.clapcheeks_memos
+      FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_clapcheeks_memos_user_handle
+  ON public.clapcheeks_memos(user_id, contact_handle);

--- a/web/app/(main)/matches/[id]/conversation-thread.tsx
+++ b/web/app/(main)/matches/[id]/conversation-thread.tsx
@@ -1,0 +1,212 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+/**
+ * Conversation thread (iMessage-style) for a single match.
+ *
+ * Reads from clapcheeks_conversations via /api/matches/[id]/conversation
+ * (server-side). Supports two storage shapes:
+ *   1. Single row per (user_id, match_id, platform) with a `messages` JSONB
+ *      array. Each entry: { is_from_me, text, sent_at, is_auto_sent? ... }.
+ *   2. Many rows, one per message, with body/direction/sent_at/channel.
+ *
+ * We accept either shape and normalize into ChatMessage[] for rendering.
+ */
+
+export type ChatMessage = {
+  id: string
+  text: string
+  is_from_me: boolean
+  sent_at: string | null
+  is_auto_sent?: boolean
+  channel?: string | null
+}
+
+type Props = {
+  messages: ChatMessage[]
+  emptyHint?: string
+}
+
+function formatDateDivider(d: Date): string {
+  const today = new Date()
+  const yesterday = new Date()
+  yesterday.setDate(today.getDate() - 1)
+  const sameDay = (a: Date, b: Date) =>
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  if (sameDay(d, today)) return 'Today'
+  if (sameDay(d, yesterday)) return 'Yesterday'
+  return d.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: d.getFullYear() === today.getFullYear() ? undefined : 'numeric',
+  })
+}
+
+function formatTimeStamp(d: Date): string {
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+function dayKey(d: Date): string {
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
+}
+
+export default function ConversationThread({ messages, emptyHint }: Props) {
+  const bottomRef = useRef<HTMLDivElement | null>(null)
+  const [autoScroll, setAutoScroll] = useState(true)
+
+  const sorted = useMemo(() => {
+    return [...messages].sort((a, b) => {
+      const aT = a.sent_at ? new Date(a.sent_at).getTime() : 0
+      const bT = b.sent_at ? new Date(b.sent_at).getTime() : 0
+      return aT - bT
+    })
+  }, [messages])
+
+  const summary = useMemo(() => {
+    if (sorted.length === 0) return null
+    const first = sorted.find((m) => m.sent_at)
+    const last = [...sorted].reverse().find((m) => m.sent_at)
+    return {
+      count: sorted.length,
+      first: first?.sent_at ? new Date(first.sent_at) : null,
+      last: last?.sent_at ? new Date(last.sent_at) : null,
+    }
+  }, [sorted])
+
+  useEffect(() => {
+    if (!autoScroll) return
+    bottomRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' })
+  }, [sorted.length, autoScroll])
+
+  if (sorted.length === 0) {
+    return (
+      <div className="p-8 rounded-xl border border-white/10 bg-white/5 text-center">
+        <div className="text-3xl mb-2">{'\u{1F4AC}'}</div>
+        <p className="text-sm text-white/60">
+          {emptyHint ??
+            'No conversation yet — drafts will appear here once exchanged.'}
+        </p>
+      </div>
+    )
+  }
+
+  // Group consecutive messages by day for date dividers.
+  let lastKey: string | null = null
+  const groups: Array<{ key: string; date: Date; messages: ChatMessage[] }> = []
+  for (const msg of sorted) {
+    const d = msg.sent_at ? new Date(msg.sent_at) : new Date(0)
+    const k = dayKey(d)
+    if (k !== lastKey) {
+      groups.push({ key: k, date: d, messages: [msg] })
+      lastKey = k
+    } else {
+      groups[groups.length - 1].messages.push(msg)
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/5 overflow-hidden">
+      {/* Header summary */}
+      {summary && (
+        <div className="px-4 py-3 border-b border-white/10 bg-black/30 text-[11px] text-white/60 flex flex-wrap gap-x-4 gap-y-1">
+          <span>
+            <strong className="text-white/90">{summary.count}</strong>{' '}
+            message{summary.count === 1 ? '' : 's'}
+          </span>
+          {summary.first && (
+            <span>
+              First:{' '}
+              <span className="text-white/80">
+                {formatTimeStamp(summary.first)}
+              </span>
+            </span>
+          )}
+          {summary.last && (
+            <span>
+              Latest:{' '}
+              <span className="text-white/80">
+                {formatTimeStamp(summary.last)}
+              </span>
+            </span>
+          )}
+          <label className="ml-auto inline-flex items-center gap-1.5 cursor-pointer select-none text-white/50">
+            <input
+              type="checkbox"
+              checked={autoScroll}
+              onChange={(e) => setAutoScroll(e.target.checked)}
+              className="accent-pink-500"
+            />
+            auto-scroll
+          </label>
+        </div>
+      )}
+
+      {/* Scroll body */}
+      <div className="max-h-[70vh] overflow-y-auto px-4 py-4 space-y-4">
+        {groups.map((group) => (
+          <div key={group.key}>
+            <div className="flex items-center gap-3 mb-3">
+              <div className="flex-1 h-px bg-white/10" />
+              <div className="text-[10px] uppercase tracking-wider text-white/40">
+                {group.date.getTime() === 0
+                  ? 'No date'
+                  : formatDateDivider(group.date)}
+              </div>
+              <div className="flex-1 h-px bg-white/10" />
+            </div>
+            <div className="space-y-1.5">
+              {group.messages.map((m) => (
+                <Bubble key={m.id} msg={m} />
+              ))}
+            </div>
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  )
+}
+
+function Bubble({ msg }: { msg: ChatMessage }) {
+  const isMe = msg.is_from_me
+  const stamp = msg.sent_at ? new Date(msg.sent_at) : null
+  const tooltip = stamp
+    ? `${formatTimeStamp(stamp)}${msg.channel ? ` · ${msg.channel}` : ''}`
+    : msg.channel ?? ''
+
+  return (
+    <div
+      className={`flex ${isMe ? 'justify-end' : 'justify-start'} group`}
+    >
+      <div
+        className={`max-w-[78%] px-3.5 py-2 rounded-2xl text-sm leading-snug whitespace-pre-wrap break-words shadow-sm ${
+          isMe
+            ? 'bg-gradient-to-br from-pink-500 to-purple-600 text-white rounded-br-md'
+            : 'bg-white/10 text-white/90 rounded-bl-md'
+        }`}
+        title={tooltip}
+      >
+        {msg.text || (
+          <span className="italic text-white/50">[empty message]</span>
+        )}
+        {(msg.is_auto_sent || msg.channel === 'imessage') && isMe && (
+          <span className="ml-2 text-[10px] uppercase tracking-wider opacity-75">
+            {msg.is_auto_sent ? '\u{1F916} auto' : 'iMessage'}
+          </span>
+        )}
+        <div className="opacity-0 group-hover:opacity-100 transition-opacity text-[10px] mt-0.5 text-white/70">
+          {stamp ? formatTimeStamp(stamp) : ''}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/app/(main)/matches/[id]/match-profile-view.tsx
+++ b/web/app/(main)/matches/[id]/match-profile-view.tsx
@@ -5,6 +5,17 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { VoiceInput, VoiceTextarea } from '@/components/voice'
+import ConversationThread, { type ChatMessage } from './conversation-thread'
+import MemoViewer from './memo-viewer'
+
+type TabKey = 'profile' | 'conversation' | 'memo' | 'intel'
+
+const TABS: { key: TabKey; label: string }[] = [
+  { key: 'profile', label: 'Profile' },
+  { key: 'conversation', label: 'Conversation' },
+  { key: 'memo', label: 'Memo' },
+  { key: 'intel', label: 'Intel' },
+]
 
 type Photo = {
   url: string
@@ -83,10 +94,21 @@ type PatchBody = {
   match_intel_patch?: Record<string, unknown>
 }
 
-export default function MatchProfileView({ match: initial }: { match: MatchRow }) {
+export default function MatchProfileView({
+  match: initial,
+  conversation = [],
+  memoHandle = null,
+  memoInitial = null,
+}: {
+  match: MatchRow
+  conversation?: ChatMessage[]
+  memoHandle?: string | null
+  memoInitial?: { content: string; updated_at: string | null } | null
+}) {
   const router = useRouter()
   const [m, setM] = useState<MatchRow>(initial)
   const [active, setActive] = useState(0)
+  const [tab, setTab] = useState<TabKey>('profile')
 
   const displayName = m.name || m.match_name || 'Unknown'
   const photos = (m.photos_jsonb ?? []).filter((p): p is Photo => !!p?.url)
@@ -229,7 +251,76 @@ export default function MatchProfileView({ match: initial }: { match: MatchRow }
         onCopyOpener={handleCopyOpener}
       />
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
+      {/* Tabs */}
+      <div className="mb-6 border-b border-white/10 flex gap-1 overflow-x-auto">
+        {TABS.map((t) => {
+          const isActive = tab === t.key
+          const badge =
+            t.key === 'conversation' && conversation.length > 0
+              ? conversation.length
+              : null
+          return (
+            <button
+              key={t.key}
+              type="button"
+              onClick={() => setTab(t.key)}
+              className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors -mb-px ${
+                isActive
+                  ? 'border-pink-500 text-white'
+                  : 'border-transparent text-white/50 hover:text-white/80 hover:border-white/20'
+              }`}
+            >
+              {t.label}
+              {badge != null && (
+                <span
+                  className={`ml-2 text-[10px] px-1.5 py-0.5 rounded-full ${
+                    isActive
+                      ? 'bg-pink-500/30 text-pink-100'
+                      : 'bg-white/10 text-white/60'
+                  }`}
+                >
+                  {badge}
+                </span>
+              )}
+            </button>
+          )
+        })}
+      </div>
+
+      {tab === 'conversation' && (
+        <div className="mb-6">
+          <ConversationThread messages={conversation} />
+        </div>
+      )}
+
+      {tab === 'memo' && (
+        <div className="mb-6">
+          <MemoViewer
+            handle={memoHandle}
+            initialContent={memoInitial?.content}
+            initialUpdatedAt={memoInitial?.updated_at}
+          />
+        </div>
+      )}
+
+      {tab === 'intel' && (
+        <IntelTab
+          prompts={prompts}
+          intelInterests={intelInterests}
+          intelTopics={intelTopics}
+          intelGreen={intelGreen}
+          intelRed={intelRed}
+          spotifyArtists={spotifyArtists}
+          dealbreakers={m.dealbreaker_flags ?? []}
+          visionSummary={m.vision_summary}
+        />
+      )}
+
+      <div
+        className={`grid grid-cols-1 md:grid-cols-2 gap-8 mb-8 ${
+          tab === 'profile' ? '' : 'hidden'
+        }`}
+      >
         {/* Photo carousel */}
         <div>
           <div className="relative aspect-[4/5] rounded-2xl overflow-hidden bg-gradient-to-br from-pink-900/40 to-purple-900/40 border border-white/10">
@@ -380,8 +471,8 @@ export default function MatchProfileView({ match: initial }: { match: MatchRow }
         </div>
       </div>
 
-      {/* Notes + Tags block */}
-      <div className="mb-8">
+      {/* Notes + Tags block (profile tab only) */}
+      <div className={`mb-8 ${tab === 'profile' ? '' : 'hidden'}`}>
         <NotesBlock
           matchId={m.id}
           initialNotes={existingNotes}
@@ -389,118 +480,162 @@ export default function MatchProfileView({ match: initial }: { match: MatchRow }
           onPatch={patch}
         />
       </div>
+    </div>
+  )
+}
 
-      {/* Secondary grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {prompts.length > 0 && (
-          <Section title="Prompts">
-            <div className="space-y-3">
-              {prompts.map((p, i) => (
-                <div
-                  key={i}
-                  className="p-3 rounded-lg bg-black/30 border border-white/10"
-                >
-                  {(p.question || p.prompt) && (
-                    <div className="text-[11px] text-white/50 uppercase tracking-wide mb-1">
-                      {p.question || p.prompt}
-                    </div>
-                  )}
-                  <div className="text-sm">{p.answer || p.text}</div>
-                </div>
-              ))}
-            </div>
-          </Section>
-        )}
+/* --------------------------------- Intel Tab --------------------------------- */
 
-        {intelInterests.length > 0 && (
-          <Section title="Interests">
-            <div className="flex flex-wrap gap-1.5">
-              {intelInterests.map((t, i) => (
-                <Chip key={i} tone="pink">
-                  {t}
-                </Chip>
-              ))}
-            </div>
-          </Section>
-        )}
+function IntelTab({
+  prompts,
+  intelInterests,
+  intelTopics,
+  intelGreen,
+  intelRed,
+  spotifyArtists,
+  dealbreakers,
+  visionSummary,
+}: {
+  prompts: Prompt[]
+  intelInterests: string[]
+  intelTopics: string[]
+  intelGreen: string[]
+  intelRed: string[]
+  spotifyArtists: string[]
+  dealbreakers: string[]
+  visionSummary: string | null
+}) {
+  const hasAny =
+    prompts.length > 0 ||
+    intelInterests.length > 0 ||
+    intelTopics.length > 0 ||
+    intelGreen.length > 0 ||
+    intelRed.length > 0 ||
+    spotifyArtists.length > 0 ||
+    dealbreakers.length > 0 ||
+    !!visionSummary
 
-        {intelTopics.length > 0 && (
-          <Section title="Conversation Topics">
-            <div className="flex flex-wrap gap-1.5">
-              {intelTopics.map((t, i) => (
-                <Chip key={i} tone="purple">
-                  {t}
-                </Chip>
-              ))}
-            </div>
-          </Section>
-        )}
-
-        {(intelGreen.length > 0 || intelRed.length > 0) && (
-          <Section title="Signals">
-            {intelGreen.length > 0 && (
-              <div className="mb-3">
-                <div className="text-[11px] text-green-400 font-semibold uppercase tracking-wide mb-1">
-                  Green flags
-                </div>
-                <div className="flex flex-wrap gap-1">
-                  {intelGreen.map((t, i) => (
-                    <Chip key={i} tone="green">
-                      {t}
-                    </Chip>
-                  ))}
-                </div>
-              </div>
-            )}
-            {intelRed.length > 0 && (
-              <div>
-                <div className="text-[11px] text-red-400 font-semibold uppercase tracking-wide mb-1">
-                  Red flags
-                </div>
-                <div className="flex flex-wrap gap-1">
-                  {intelRed.map((t, i) => (
-                    <Chip key={i} tone="red">
-                      {t}
-                    </Chip>
-                  ))}
-                </div>
-              </div>
-            )}
-          </Section>
-        )}
-
-        {spotifyArtists.length > 0 && (
-          <Section title="Spotify">
-            <div className="flex flex-wrap gap-1.5">
-              {spotifyArtists.slice(0, 20).map((t, i) => (
-                <Chip key={i} tone="green">
-                  {t}
-                </Chip>
-              ))}
-            </div>
-          </Section>
-        )}
-
-        {(m.dealbreaker_flags?.length ?? 0) > 0 && (
-          <Section title="Dealbreakers">
-            <div className="flex flex-wrap gap-1.5">
-              {m.dealbreaker_flags!.map((t, i) => (
-                <Chip key={i} tone="red">
-                  {t}
-                </Chip>
-              ))}
-            </div>
-          </Section>
-        )}
-
-        {m.vision_summary && (
-          <Section title="Photo Vision Summary">
-            <p className="text-sm text-white/70 whitespace-pre-wrap">
-              {m.vision_summary}
-            </p>
-          </Section>
-        )}
+  if (!hasAny) {
+    return (
+      <div className="mb-6 p-8 rounded-xl border border-white/10 bg-white/5 text-center">
+        <p className="text-sm text-white/60">
+          No intel collected yet — interests, prompts, signals, and Spotify
+          artists appear here as the agent enriches the profile.
+        </p>
       </div>
+    )
+  }
+
+  return (
+    <div className="mb-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+      {prompts.length > 0 && (
+        <Section title="Prompts">
+          <div className="space-y-3">
+            {prompts.map((p, i) => (
+              <div
+                key={i}
+                className="p-3 rounded-lg bg-black/30 border border-white/10"
+              >
+                {(p.question || p.prompt) && (
+                  <div className="text-[11px] text-white/50 uppercase tracking-wide mb-1">
+                    {p.question || p.prompt}
+                  </div>
+                )}
+                <div className="text-sm">{p.answer || p.text}</div>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {intelInterests.length > 0 && (
+        <Section title="Interests">
+          <div className="flex flex-wrap gap-1.5">
+            {intelInterests.map((t, i) => (
+              <Chip key={i} tone="pink">
+                {t}
+              </Chip>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {intelTopics.length > 0 && (
+        <Section title="Conversation Topics">
+          <div className="flex flex-wrap gap-1.5">
+            {intelTopics.map((t, i) => (
+              <Chip key={i} tone="purple">
+                {t}
+              </Chip>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {(intelGreen.length > 0 || intelRed.length > 0) && (
+        <Section title="Signals">
+          {intelGreen.length > 0 && (
+            <div className="mb-3">
+              <div className="text-[11px] text-green-400 font-semibold uppercase tracking-wide mb-1">
+                Green flags
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {intelGreen.map((t, i) => (
+                  <Chip key={i} tone="green">
+                    {t}
+                  </Chip>
+                ))}
+              </div>
+            </div>
+          )}
+          {intelRed.length > 0 && (
+            <div>
+              <div className="text-[11px] text-red-400 font-semibold uppercase tracking-wide mb-1">
+                Red flags
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {intelRed.map((t, i) => (
+                  <Chip key={i} tone="red">
+                    {t}
+                  </Chip>
+                ))}
+              </div>
+            </div>
+          )}
+        </Section>
+      )}
+
+      {spotifyArtists.length > 0 && (
+        <Section title="Spotify">
+          <div className="flex flex-wrap gap-1.5">
+            {spotifyArtists.slice(0, 20).map((t, i) => (
+              <Chip key={i} tone="green">
+                {t}
+              </Chip>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {dealbreakers.length > 0 && (
+        <Section title="Dealbreakers">
+          <div className="flex flex-wrap gap-1.5">
+            {dealbreakers.map((t, i) => (
+              <Chip key={i} tone="red">
+                {t}
+              </Chip>
+            ))}
+          </div>
+        </Section>
+      )}
+
+      {visionSummary && (
+        <Section title="Photo Vision Summary">
+          <p className="text-sm text-white/70 whitespace-pre-wrap">
+            {visionSummary}
+          </p>
+        </Section>
+      )}
     </div>
   )
 }

--- a/web/app/(main)/matches/[id]/memo-viewer.tsx
+++ b/web/app/(main)/matches/[id]/memo-viewer.tsx
@@ -1,0 +1,218 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+
+/**
+ * Memo viewer/editor — surfaces the per-contact memo file content with
+ * edit-and-save capability.
+ *
+ * The local agent writes per-contact memos to ~/.clapcheeks/memos/+E164.md on
+ * the operator's Mac. sync.py mirrors content into clapcheeks_memos via the
+ * /api/memo/[handle] route. This component reads + writes through that API.
+ *
+ * `handle` should be the E.164 phone if available, otherwise the platform
+ * external_id (e.g. "tinder:abc123").
+ */
+
+type Props = {
+  handle: string | null
+  // Optional initial content from server-side fetch; if omitted, fetched on mount.
+  initialContent?: string
+  initialUpdatedAt?: string | null
+}
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return ''
+  const then = new Date(iso).getTime()
+  if (Number.isNaN(then)) return ''
+  const diff = Date.now() - then
+  const sec = Math.round(diff / 1000)
+  if (sec < 60) return `${sec}s ago`
+  const min = Math.round(sec / 60)
+  if (min < 60) return `${min}m ago`
+  const hr = Math.round(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  const day = Math.round(hr / 24)
+  if (day < 30) return `${day}d ago`
+  return new Date(iso).toLocaleDateString()
+}
+
+export default function MemoViewer({
+  handle,
+  initialContent,
+  initialUpdatedAt,
+}: Props) {
+  const [content, setContent] = useState(initialContent ?? '')
+  const [updatedAt, setUpdatedAt] = useState<string | null>(
+    initialUpdatedAt ?? null,
+  )
+  const [loading, setLoading] = useState(initialContent === undefined)
+  const [saving, setSaving] = useState(false)
+  const [previewOn, setPreviewOn] = useState(false)
+  const lastSaved = useRef(initialContent ?? '')
+
+  // Fetch on mount unless we already have initial content.
+  useEffect(() => {
+    if (!handle) {
+      setLoading(false)
+      return
+    }
+    if (initialContent !== undefined) {
+      lastSaved.current = initialContent
+      return
+    }
+    let cancelled = false
+    ;(async () => {
+      setLoading(true)
+      try {
+        const res = await fetch(`/api/memo/${encodeURIComponent(handle)}`, {
+          cache: 'no-store',
+        })
+        if (!res.ok) throw new Error(`Load failed (${res.status})`)
+        const json = (await res.json()) as {
+          content: string
+          updated_at: string | null
+        }
+        if (cancelled) return
+        setContent(json.content ?? '')
+        setUpdatedAt(json.updated_at ?? null)
+        lastSaved.current = json.content ?? ''
+      } catch (err) {
+        if (!cancelled) toast.error(`Memo load failed: ${(err as Error).message}`)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [handle, initialContent])
+
+  const save = useCallback(async () => {
+    if (!handle) {
+      toast.error('No contact handle — cannot save memo')
+      return
+    }
+    if (content === lastSaved.current) return
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/memo/${encodeURIComponent(handle)}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j.error || `Save failed (${res.status})`)
+      }
+      const json = (await res.json()) as {
+        content: string
+        updated_at: string
+      }
+      lastSaved.current = json.content
+      setUpdatedAt(json.updated_at)
+      toast.success('Memo saved')
+    } catch (err) {
+      toast.error((err as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }, [content, handle])
+
+  // Cmd/Ctrl-S to save
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's') {
+        e.preventDefault()
+        void save()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [save])
+
+  if (!handle) {
+    return (
+      <div className="p-8 rounded-xl border border-white/10 bg-white/5 text-center">
+        <div className="text-3xl mb-2">{'\u{1F4DD}'}</div>
+        <p className="text-sm text-white/60 mb-1">
+          No contact handle for this match.
+        </p>
+        <p className="text-xs text-white/40">
+          Memos auto-generate when a phone number is exchanged on Tinder/Hinge.
+        </p>
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="p-6 rounded-xl border border-white/10 bg-white/5 text-sm text-white/60">
+        Loading memo...
+      </div>
+    )
+  }
+
+  const dirty = content !== lastSaved.current
+  const isEmpty = content.trim().length === 0
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/5 overflow-hidden">
+      <div className="px-4 py-3 border-b border-white/10 bg-black/30 flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2 text-xs text-white/60">
+          <span className="font-mono text-white/80">{handle}</span>
+          {updatedAt && (
+            <span className="text-white/40">
+              &middot; updated {relativeTime(updatedAt)}
+            </span>
+          )}
+          {dirty && (
+            <span className="text-amber-400 text-[11px] uppercase tracking-wider">
+              unsaved
+            </span>
+          )}
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setPreviewOn((v) => !v)}
+            className="px-2.5 py-1 rounded-md bg-white/5 hover:bg-white/10 border border-white/10 text-xs text-white/80 hover:text-white transition-colors"
+          >
+            {previewOn ? 'Edit' : 'Preview'}
+          </button>
+          <button
+            type="button"
+            onClick={() => void save()}
+            disabled={saving || !dirty}
+            className="px-3 py-1 rounded-md bg-pink-600 hover:bg-pink-500 text-xs font-medium text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </div>
+
+      {isEmpty && !previewOn && (
+        <div className="px-4 pt-4 text-xs text-white/50">
+          No memo yet for this contact. Memos auto-generate when a phone number
+          is exchanged on Tinder/Hinge — or you can write one here.
+        </div>
+      )}
+
+      {previewOn ? (
+        <pre className="p-4 text-sm text-white/85 whitespace-pre-wrap break-words font-sans min-h-[200px] max-h-[60vh] overflow-y-auto">
+          {content || '(empty)'}
+        </pre>
+      ) : (
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          onBlur={() => void save()}
+          placeholder={`# Memo for ${handle}\n\n- Vibes:\n- Conversation hooks:\n- Follow-ups:\n- Logistics:\n`}
+          spellCheck={false}
+          className="w-full min-h-[300px] max-h-[60vh] bg-black/30 border-0 px-4 py-4 text-sm text-white placeholder:text-white/30 focus:outline-none resize-y font-mono"
+        />
+      )}
+    </div>
+  )
+}

--- a/web/app/(main)/matches/[id]/page.tsx
+++ b/web/app/(main)/matches/[id]/page.tsx
@@ -2,10 +2,120 @@ import type { Metadata } from 'next'
 import { createClient } from '@/lib/supabase/server'
 import { redirect, notFound } from 'next/navigation'
 import MatchProfileView from './match-profile-view'
+import type { ChatMessage } from './conversation-thread'
 
 export const metadata: Metadata = {
   title: 'Match Profile - Clapcheeks',
   description: 'Photos, bio, interests, and conversation strategy.',
+}
+
+type RawMessageEntry = {
+  id?: string | number
+  text?: string | null
+  body?: string | null
+  message?: string | null
+  is_from_me?: boolean | number | null
+  from_me?: boolean | number | null
+  direction?: string | null
+  sender?: string | null
+  sent_at?: string | null
+  date?: string | null
+  created_at?: string | null
+  is_auto_sent?: boolean | null
+  is_auto?: boolean | null
+  is_bot?: boolean | null
+  channel?: string | null
+}
+
+function coerceBool(v: unknown): boolean {
+  if (typeof v === 'boolean') return v
+  if (typeof v === 'number') return v !== 0
+  if (typeof v === 'string') return ['1', 'true', 'yes', 'me'].includes(v.toLowerCase())
+  return false
+}
+
+function entryToMessage(
+  entry: RawMessageEntry,
+  fallbackId: string,
+  rowChannel?: string | null,
+): ChatMessage {
+  const text = entry.text ?? entry.body ?? entry.message ?? ''
+  let isFromMe: boolean
+  if (entry.is_from_me != null) {
+    isFromMe = coerceBool(entry.is_from_me)
+  } else if (entry.from_me != null) {
+    isFromMe = coerceBool(entry.from_me)
+  } else if (entry.direction) {
+    isFromMe = entry.direction === 'outgoing' || entry.direction === 'out'
+  } else if (entry.sender) {
+    const s = entry.sender.toLowerCase()
+    isFromMe = s === 'me' || s === 'self' || s === 'julian' || s === 'operator'
+  } else {
+    isFromMe = false
+  }
+  const sentAt = entry.sent_at ?? entry.date ?? entry.created_at ?? null
+  return {
+    id: String(entry.id ?? fallbackId),
+    text: typeof text === 'string' ? text : '',
+    is_from_me: isFromMe,
+    sent_at: sentAt,
+    is_auto_sent: coerceBool(entry.is_auto_sent ?? entry.is_auto ?? entry.is_bot),
+    channel: entry.channel ?? rowChannel ?? null,
+  }
+}
+
+async function loadConversationMessages(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  userId: string,
+  externalId: string | null | undefined,
+): Promise<ChatMessage[]> {
+  if (!externalId) return []
+  // Pull every conversation row for this match — there may be one per
+  // platform/channel (tinder + imessage etc).
+  const { data, error } = await (supabase as any)
+    .from('clapcheeks_conversations')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('match_id', externalId)
+    .order('last_message_at', { ascending: true, nullsFirst: true })
+  if (error || !Array.isArray(data)) return []
+
+  const out: ChatMessage[] = []
+  for (let r = 0; r < data.length; r++) {
+    const row = data[r] as Record<string, unknown>
+    const channel = (row.channel as string | null | undefined) ?? null
+
+    // Shape A: row has a `messages` JSONB array of entries.
+    const msgs = row.messages
+    if (Array.isArray(msgs)) {
+      msgs.forEach((m, i) => {
+        if (!m || typeof m !== 'object') return
+        out.push(entryToMessage(m as RawMessageEntry, `${row.id}-${i}`, channel))
+      })
+    }
+
+    // Shape B: row IS a single message (body/direction/sent_at columns).
+    if (typeof row.body === 'string' && row.body) {
+      out.push(
+        entryToMessage(
+          {
+            id: row.id as string | undefined,
+            text: row.body as string,
+            direction: row.direction as string | null | undefined,
+            sent_at:
+              (row.sent_at as string | null | undefined) ??
+              (row.last_message_at as string | null | undefined) ??
+              (row.created_at as string | null | undefined) ??
+              null,
+            channel,
+          },
+          `${row.id ?? r}-row`,
+          channel,
+        ),
+      )
+    }
+  }
+  return out
 }
 
 export default async function MatchDetailPage({
@@ -29,10 +139,52 @@ export default async function MatchDetailPage({
 
   if (error || !match) notFound()
 
+  const externalId =
+    (match as { external_id?: string | null }).external_id ?? null
+  const herPhone = (match as { her_phone?: string | null }).her_phone ?? null
+  const platform = (match as { platform?: string | null }).platform ?? null
+
+  // Memo handle prefers E.164 phone, falls back to platform:external_id.
+  let memoHandle: string | null = null
+  if (herPhone) memoHandle = herPhone
+  else if (externalId) memoHandle = platform ? `${platform}:${externalId}` : externalId
+
+  const conversation = await loadConversationMessages(
+    supabase,
+    user.id,
+    externalId,
+  )
+
+  // Server-side initial memo fetch (best-effort; client refetches if needed).
+  let memoInitial: { content: string; updated_at: string | null } | null = null
+  if (memoHandle) {
+    try {
+      const { data: memoRow } = await (supabase as any)
+        .from('clapcheeks_memos')
+        .select('content, updated_at')
+        .eq('user_id', user.id)
+        .eq('contact_handle', memoHandle)
+        .maybeSingle()
+      memoInitial = memoRow
+        ? {
+            content: (memoRow.content as string) ?? '',
+            updated_at: (memoRow.updated_at as string | null) ?? null,
+          }
+        : { content: '', updated_at: null }
+    } catch {
+      memoInitial = null
+    }
+  }
+
   return (
     <div className="min-h-screen bg-black text-white p-4 md:p-8">
       <div className="max-w-5xl mx-auto">
-        <MatchProfileView match={match} />
+        <MatchProfileView
+          match={match}
+          conversation={conversation}
+          memoHandle={memoHandle}
+          memoInitial={memoInitial}
+        />
       </div>
     </div>
   )

--- a/web/app/api/memo/[handle]/route.ts
+++ b/web/app/api/memo/[handle]/route.ts
@@ -1,0 +1,131 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+/**
+ * GET  /api/memo/[handle]    — fetch the memo content for the current user + handle.
+ * PUT  /api/memo/[handle]    — upsert memo content. Body: { content: string }.
+ *
+ * `handle` is a URL-encoded contact identifier:
+ *   - E.164 phone (e.g. "+15551234567") for contacts that have exchanged a number
+ *   - platform external id (e.g. "tinder:abc123") otherwise
+ *
+ * RLS on clapcheeks_memos enforces ownership but we also pass user_id explicitly.
+ */
+
+const MAX_CONTENT_LENGTH = 200_000 // ~200 KB markdown ceiling
+
+function normalizeHandle(raw: string): string {
+  try {
+    return decodeURIComponent(raw).trim()
+  } catch {
+    return raw.trim()
+  }
+}
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ handle: string }> },
+) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { handle: rawHandle } = await ctx.params
+  const handle = normalizeHandle(rawHandle)
+  if (!handle) {
+    return NextResponse.json({ error: 'handle required' }, { status: 400 })
+  }
+
+  const { data, error } = await (supabase as any)
+    .from('clapcheeks_memos')
+    .select('content, updated_at')
+    .eq('user_id', user.id)
+    .eq('contact_handle', handle)
+    .maybeSingle()
+
+  if (error) {
+    return NextResponse.json(
+      { error: error.message || 'Failed to load memo' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({
+    handle,
+    content: data?.content ?? '',
+    updated_at: data?.updated_at ?? null,
+    exists: !!data,
+  })
+}
+
+export async function PUT(
+  req: Request,
+  ctx: { params: Promise<{ handle: string }> },
+) {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { handle: rawHandle } = await ctx.params
+  const handle = normalizeHandle(rawHandle)
+  if (!handle) {
+    return NextResponse.json({ error: 'handle required' }, { status: 400 })
+  }
+
+  let body: { content?: unknown }
+  try {
+    body = (await req.json()) as { content?: unknown }
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  if (typeof body.content !== 'string') {
+    return NextResponse.json(
+      { error: 'content must be a string' },
+      { status: 400 },
+    )
+  }
+  if (body.content.length > MAX_CONTENT_LENGTH) {
+    return NextResponse.json(
+      { error: `content exceeds ${MAX_CONTENT_LENGTH} character limit` },
+      { status: 400 },
+    )
+  }
+
+  const now = new Date().toISOString()
+
+  const { data, error } = await (supabase as any)
+    .from('clapcheeks_memos')
+    .upsert(
+      {
+        user_id: user.id,
+        contact_handle: handle,
+        content: body.content,
+        updated_at: now,
+      },
+      { onConflict: 'user_id,contact_handle' },
+    )
+    .select('content, updated_at')
+    .single()
+
+  if (error) {
+    return NextResponse.json(
+      { error: error.message || 'Failed to save memo' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({
+    handle,
+    content: data?.content ?? body.content,
+    updated_at: data?.updated_at ?? now,
+  })
+}


### PR DESCRIPTION
## Summary

Operator-trust dashboard surfaces — the operator currently can't see what the bot said, and per-girl memos live only on the local Mac. This PR adds:

- **Conversation tab** on `/matches/[id]` — full iMessage-style thread rendered from `clapcheeks_conversations` (handles both storage shapes: single-row JSONB `messages` array AND per-message rows with `body`/`direction`/`sent_at`/`channel`).
- **Memo tab** — viewer + editor backed by a new `clapcheeks_memos` table, mirrored from the agent's `~/.clapcheeks/memos/+E164.md` files via `sync.py`.
- **Tabs structure** — Profile | Conversation | Memo | Intel. Profile keeps photos/bio/notes; Intel groups prompts/interests/signals/Spotify off the main view.

## What's new

| Surface | Notes |
|---|---|
| Conversation thread | Right-aligned pink/purple gradient bubbles for `is_from_me`, gray for hers. Date dividers (Today/Yesterday/explicit), hover timestamps, auto-scroll toggle, message-count + first/latest summary, channel tag for iMessage / auto-bot. Empty state when no thread yet. |
| Memo viewer/editor | Textarea + preview toggle (markdown rendered as `<pre>` for now — `react-markdown` not installed yet). Cmd/Ctrl-S save, blur-save, dirty indicator, relative `updated_at`, 200KB cap. Empty-state copy explains memos auto-generate when phone is exchanged. |
| `GET /api/memo/[handle]` | Returns `{ handle, content, updated_at, exists }`. 401 if no auth. |
| `PUT /api/memo/[handle]` | Upsert with `{content: string}`. 400 on bad payload, 401 unauth. URL-encoded handle (E.164 phone or `platform:external_id`). |
| `clapcheeks_memos` migration | `(id, user_id, contact_handle, content, updated_at, created_at)` with `UNIQUE(user_id, contact_handle)`, RLS policies (idempotent CREATE POLICY guards), index on `(user_id, contact_handle)`. |

## Files

- `supabase/migrations/20260427180000_clapcheeks_memos.sql` (new)
- `web/app/(main)/matches/[id]/page.tsx` (server-side load conversation + memo)
- `web/app/(main)/matches/[id]/match-profile-view.tsx` (tabs + IntelTab)
- `web/app/(main)/matches/[id]/conversation-thread.tsx` (new)
- `web/app/(main)/matches/[id]/memo-viewer.tsx` (new)
- `web/app/api/memo/[handle]/route.ts` (new)

## Test plan

- [ ] `cd web && npx tsc --noEmit` — zero errors in changed files (PASS — only pre-existing `app/api/transcribe/route.ts` error remains)
- [ ] `cd web && npx next build` — PASS, `/matches/[id]` route compiles at 10.2 kB
- [ ] Apply migration in Supabase: `supabase/migrations/20260427180000_clapcheeks_memos.sql`
- [ ] Click into a match with conversation history and confirm bubbles render with date dividers
- [ ] Edit a memo, blur the textarea, confirm toast `Memo saved`, refresh page, content persists
- [ ] For a match with no thread / no phone, confirm empty states render

## Notes

- Did NOT touch sidebar or `/dashboard/page.tsx` per scope.
- The existing `clapcheeks_contact_memory_bank` table is for individual extracted memory entries (per-message classification with relevance scoring), not the markdown memo file content — hence a fresh `clapcheeks_memos` table.
- Branch was rebased off `origin/main` at start of work; concurrent commits to `main` were not pulled in (couldn't `git pull --rebase` due to unrelated working-tree changes from another agent). Rebase before merge if needed.