### PR TITLE
feat(clapcheeks-dashboard): briefing card + sidebar approval badge

### DIFF
--- a/web/app/(main)/dashboard/components/briefing-card.tsx
+++ b/web/app/(main)/dashboard/components/briefing-card.tsx
@@ -1,0 +1,148 @@
+import Link from 'next/link'
+import { ArrowRight } from 'lucide-react'
+import { createClient } from '@/lib/supabase/server'
+
+/**
+ * Operator briefing card — top-of-dashboard glanceable counts that point to
+ * the page the operator should open next. Server component so the counts are
+ * fresh on every navigation; the badge in the sidebar handles realtime delta.
+ *
+ * Metrics:
+ *   - Drafts to Approve  (clapcheeks_approval_queue, status='pending')
+ *   - Stale Convos       (clapcheeks_conversations, last_message_at < now-48h
+ *                         AND stage IN active stages, capped at 50)
+ *   - Tokens Expiring    (skipped — schema has *_updated_at, not *_expires_at)
+ *   - Dates This Week    (clapcheeks_dates, scheduled_at within next 7d)
+ *
+ * Each metric degrades gracefully: a query error becomes 0, never a crash.
+ */
+export default async function BriefingCard() {
+  const supabase = await createClient()
+  const { data: userRes } = await supabase.auth.getUser()
+  const userId = userRes.user?.id
+  if (!userId) return null
+
+  const fortyEightHoursAgo = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString()
+  const nowIso = new Date().toISOString()
+  const sevenDaysFromNow = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
+
+  // The roster pipeline uses these "still warm" stages. Anything else (ghosted,
+  // archived, hooked_up, recurring, etc.) is intentionally excluded — we only
+  // want stale convos the operator can still salvage.
+  //
+  // Note: clapcheeks_conversations.stage default is 'opened' (legacy); the
+  // newer clapcheeks_matches.stage uses 'chatting' / 'chatting_phone' /
+  // 'date_proposed'. We query the conversations table because that's where
+  // last_message_at lives, and we union both vocabularies.
+  const ACTIVE_STAGES = [
+    'opened',
+    'replying',
+    'chatting',
+    'chatting_phone',
+    'date_proposed',
+  ]
+
+  const [approvalsRes, staleRes, datesRes] = await Promise.all([
+    supabase
+      .from('clapcheeks_approval_queue')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .eq('status', 'pending'),
+    supabase
+      .from('clapcheeks_conversations')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .lt('last_message_at', fortyEightHoursAgo)
+      .in('stage', ACTIVE_STAGES)
+      .limit(50),
+    supabase
+      .from('clapcheeks_dates')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .gte('scheduled_at', nowIso)
+      .lte('scheduled_at', sevenDaysFromNow),
+  ])
+
+  const approvals = approvalsRes.count ?? 0
+  const stale = staleRes.count ?? 0
+  const dates = datesRes.count ?? 0
+
+  // TODO(token-expiry): clapcheeks_user_settings has tinder_auth_token /
+  // hinge_auth_token plus *_updated_at, but no *_expires_at column. When the
+  // schema gains an explicit expiry timestamp, add a 4th metric here that
+  // counts tokens expiring within the next 7 days and links to /device.
+
+  const cards: Array<{
+    label: string
+    count: number
+    href: string
+    /** "alert" tone if exceeded — matches the urgency model from the sidebar */
+    redAt?: number
+  }> = [
+    { label: 'Drafts to Approve', count: approvals, href: '/autonomy', redAt: 5 },
+    { label: 'Stale Convos', count: stale, href: '/matches?filter=stale', redAt: 5 },
+    { label: 'Dates This Week', count: dates, href: '/scheduled' },
+  ]
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-white/60 text-xs uppercase tracking-widest font-mono">
+          Today&apos;s Briefing
+        </h2>
+        <span className="text-white/30 text-[10px] font-mono">
+          live · server-rendered
+        </span>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        {cards.map((c) => (
+          <BriefingTile
+            key={c.label}
+            label={c.label}
+            count={c.count}
+            href={c.href}
+            redAt={c.redAt}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function BriefingTile({
+  label,
+  count,
+  href,
+  redAt,
+}: {
+  label: string
+  count: number
+  href: string
+  redAt?: number
+}) {
+  // Tone matches sidebar badge urgency model so visual language is consistent.
+  let tone = 'border-white/10 hover:border-white/20'
+  let valueTone = 'text-white/40'
+  if (count > 0) {
+    if (redAt !== undefined && count > redAt) {
+      tone = 'border-red-500/40 hover:border-red-500/70 bg-red-500/[0.04]'
+      valueTone = 'text-red-300'
+    } else {
+      tone = 'border-amber-400/40 hover:border-amber-400/70 bg-amber-400/[0.04]'
+      valueTone = 'text-amber-200'
+    }
+  }
+
+  return (
+    <Link
+      href={href}
+      className={`group bg-white/5 border ${tone} rounded-xl p-4 transition-all flex flex-col gap-1 relative`}
+    >
+      <div className="flex items-baseline justify-between">
+        <div className={`text-3xl font-bold tabular-nums ${valueTone}`}>{count}</div>
+        <ArrowRight className="w-4 h-4 text-white/30 group-hover:text-white/70 transition-colors" />
+      </div>
+      <div className="text-white/60 text-xs leading-tight">{label}</div>
+    </Link>
+  )
+}

--- a/web/app/(main)/dashboard/page.tsx
+++ b/web/app/(main)/dashboard/page.tsx
@@ -10,6 +10,7 @@ import CoachingSection from './components/coaching-section'
 import DashboardLive from './components/dashboard-live'
 import AgentStatusBadge from './components/agent-status-badge'
 import IMessageTestPanel from './components/imessage-test-panel'
+import BriefingCard from './components/briefing-card'
 import { getLatestCoaching } from '@/lib/coaching/generate'
 import { TrendCard } from './components/trend-card'
 import { DashboardCharts } from './components/dashboard-charts'
@@ -395,6 +396,9 @@ export default async function Dashboard() {
         <p className="font-body text-white/40 text-sm mb-8">
           {hasAgent ? 'Last 30 days of activity — your agent is closing.' : 'Install the agent to start dominating your dating life.'}
         </p>
+
+        {/* Operator briefing — actionable counts pointing to the next page to open */}
+        <BriefingCard />
 
         {/* Stats row -- 5 cards with trend arrows */}
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-3 mb-8">

--- a/web/components/layout/app-sidebar.tsx
+++ b/web/components/layout/app-sidebar.tsx
@@ -11,6 +11,12 @@ type NavItem = {
   label: string
   icon: React.ReactNode
   badge?: string
+  /**
+   * If set, the nav item shows a live count badge keyed by this id. The
+   * sidebar maintains a per-key count map and renders a colored circle when
+   * the count is > 0.
+   */
+  countKey?: 'approvals'
 }
 
 const PRIMARY: NavItem[] = [
@@ -29,7 +35,7 @@ const PRIMARY: NavItem[] = [
 ]
 
 const SECONDARY: NavItem[] = [
-  { href: '/autonomy', label: 'Autonomy', icon: <SparkIcon /> },
+  { href: '/autonomy', label: 'Autonomy', icon: <SparkIcon />, countKey: 'approvals' },
   { href: '/referrals', label: 'Referrals', icon: <GiftIcon />, badge: 'new' },
   { href: '/settings/ai', label: 'AI Settings', icon: <GearIcon />, badge: 'new' },
   { href: '/settings', label: 'Weekly Reports', icon: <BellIcon /> },
@@ -42,12 +48,89 @@ export default function AppSidebar() {
   const pathname = usePathname() ?? '/'
   const [email, setEmail] = useState<string>('')
   const [mobileOpen, setMobileOpen] = useState(false)
+  const [counts, setCounts] = useState<Record<NonNullable<NavItem['countKey']>, number>>({
+    approvals: 0,
+  })
 
   useEffect(() => {
     const supabase = createClient()
     supabase.auth.getUser().then(({ data }) => {
       setEmail(data.user?.email ?? '')
     })
+  }, [])
+
+  // Live approval-queue badge: count of pending items for the current user.
+  // Subscribes to Supabase Realtime postgres_changes; falls back to 30s polling
+  // if the realtime channel never reaches SUBSCRIBED.
+  useEffect(() => {
+    const supabase = createClient()
+    let cancelled = false
+    let userId: string | null = null
+    let pollHandle: ReturnType<typeof setInterval> | null = null
+    let realtimeOk = false
+
+    async function refreshApprovals() {
+      if (!userId || cancelled) return
+      const { count, error } = await supabase
+        .from('clapcheeks_approval_queue')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', userId)
+        .eq('status', 'pending')
+      if (cancelled) return
+      if (error) {
+        // Table may not be reachable for unauthenticated/preview users.
+        // Silently keep zero rather than spam the UI.
+        return
+      }
+      setCounts((c) => ({ ...c, approvals: count ?? 0 }))
+    }
+
+    const channel = supabase.channel('sidebar-approval-queue')
+
+    ;(async () => {
+      const { data } = await supabase.auth.getUser()
+      userId = data.user?.id ?? null
+      if (!userId) return
+
+      await refreshApprovals()
+
+      channel
+        .on(
+          'postgres_changes',
+          {
+            event: '*',
+            schema: 'public',
+            table: 'clapcheeks_approval_queue',
+            filter: `user_id=eq.${userId}`,
+          },
+          () => {
+            // Any insert/update/delete on this user's rows -> recount.
+            refreshApprovals()
+          },
+        )
+        .subscribe((status) => {
+          if (status === 'SUBSCRIBED') {
+            realtimeOk = true
+            // Stop polling — realtime is live.
+            if (pollHandle) {
+              clearInterval(pollHandle)
+              pollHandle = null
+            }
+          }
+        })
+
+      // Poll fallback: kick off a 30s interval. If realtime SUBSCRIBES first,
+      // the callback above clears it.
+      pollHandle = setInterval(() => {
+        if (!realtimeOk) refreshApprovals()
+      }, 30_000)
+    })()
+
+    return () => {
+      cancelled = true
+      if (pollHandle) clearInterval(pollHandle)
+      supabase.removeChannel(channel)
+    }
   }, [])
 
   function isActive(href: string) {
@@ -104,14 +187,26 @@ export default function AppSidebar() {
           <SectionLabel>Workflow</SectionLabel>
           <ul className="space-y-0.5 mb-6">
             {PRIMARY.map((item) => (
-              <NavLink key={item.href} item={item} active={isActive(item.href)} onClick={() => setMobileOpen(false)} />
+              <NavLink
+                key={item.href}
+                item={item}
+                active={isActive(item.href)}
+                count={item.countKey ? counts[item.countKey] : 0}
+                onClick={() => setMobileOpen(false)}
+              />
             ))}
           </ul>
 
           <SectionLabel>Configuration</SectionLabel>
           <ul className="space-y-0.5">
             {SECONDARY.map((item) => (
-              <NavLink key={item.href} item={item} active={isActive(item.href)} onClick={() => setMobileOpen(false)} />
+              <NavLink
+                key={item.href}
+                item={item}
+                active={isActive(item.href)}
+                count={item.countKey ? counts[item.countKey] : 0}
+                onClick={() => setMobileOpen(false)}
+              />
             ))}
           </ul>
         </nav>
@@ -163,12 +258,23 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
 function NavLink({
   item,
   active,
+  count,
   onClick,
 }: {
   item: NavItem
   active: boolean
+  count?: number
   onClick?: () => void
 }) {
+  // Color the live count badge by urgency:
+  //   >5  -> red   (operator needs to clear backlog)
+  //   1-5 -> amber (gentle nudge)
+  const showCount = !!item.countKey && (count ?? 0) > 0
+  const countTone =
+    (count ?? 0) > 5
+      ? 'bg-red-500/90 text-white'
+      : 'bg-amber-400/90 text-black'
+
   return (
     <li>
       <Link
@@ -186,7 +292,15 @@ function NavLink({
           {item.icon}
         </span>
         <span className="flex-1">{item.label}</span>
-        {item.badge && (
+        {showCount && (
+          <span
+            aria-label={`${count} pending`}
+            className={`min-w-[18px] h-[18px] inline-flex items-center justify-center text-[10px] font-bold rounded-full px-1.5 ${countTone}`}
+          >
+            {count! > 99 ? '99+' : count}
+          </span>
+        )}
+        {item.badge && !showCount && (
           <span className="text-[9px] px-1.5 py-0.5 rounded-full bg-gradient-to-r from-yellow-500 to-red-600 text-black font-bold uppercase tracking-wider">
             {item.badge}
           </span>


### PR DESCRIPTION
## Summary

Two operator-workflow surfaces for the Clapcheeks dashboard, per `visual-plan-20260427-1810.md`:

1. **Sidebar approval-queue badge** on the Autonomy nav item: live count of pending items in `clapcheeks_approval_queue` for the current user. Subscribes to Supabase Realtime `postgres_changes` and falls back to a 30-second poll if the channel never reaches `SUBSCRIBED`. Color-coded by urgency (>5 red, 1-5 amber). Hidden at zero.
2. **Daily briefing card** rendered server-side at the top of `/dashboard` with three glanceable counts that link to the page the operator should open next:
   - **Drafts to Approve** -> `/autonomy` (`clapcheeks_approval_queue`, `status='pending'`)
   - **Stale Convos** -> `/matches?filter=stale` (`clapcheeks_conversations`, `last_message_at < now-48h` AND `stage IN active`, capped at 50)
   - **Dates This Week** -> `/scheduled` (`clapcheeks_dates`, `scheduled_at` within next 7d)

### Schema notes

The spec called for a fourth tile, "Tokens Expiring." `clapcheeks_user_settings` has `tinder_auth_token` / `hinge_auth_token` plus `*_updated_at`, but **no `*_expires_at`** column exists in any migration. Rather than ship a misleading metric or fail the build, the tile is omitted and a `TODO(token-expiry)` comment marks the spot for when the schema gains a real expiry timestamp.

The conversation `stage` enum has historically used both `'opened' / 'replying'` (legacy `outward_conversations`) and the newer `'chatting' / 'chatting_phone' / 'date_proposed'` (`clapcheeks_matches`). The Stale Convos query unions both vocabularies so it works regardless of which writer touched the row last.

## Files

- `web/components/layout/app-sidebar.tsx` — adds `countKey` field, realtime/poll hook, urgency-colored badge in `NavLink`
- `web/app/(main)/dashboard/components/briefing-card.tsx` (new) — server component rendering 3 tiles
- `web/app/(main)/dashboard/page.tsx` — wires `<BriefingCard />` above the trend-card stats row

## Test plan

- [x] `npx tsc --noEmit` — zero new errors (one pre-existing error in `app/api/transcribe/route.ts` unrelated to this PR)
- [x] `npx next build` — compiled successfully, `/dashboard` route emitted
- [ ] Visual: open `/dashboard` in dark mode, verify briefing tiles render with proper spacing above the trend cards
- [ ] Visual: navigate to `/autonomy`, queue a pending approval, watch the sidebar badge appear in real time without a page refresh
- [ ] Visual: with realtime disabled in supabase config, confirm the badge still updates within ~30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)