### PR TITLE
chore(clapcheeks): unify api/ Stripe SDK to v20 + pin apiVersion (AI-8770)

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15,7 +15,7 @@
         "express-rate-limit": "^8.2.1",
         "helmet": "^7.1.0",
         "jsonwebtoken": "^9.0.2",
-        "stripe": "^16.2.0"
+        "stripe": "^20.4.1"
       }
     },
     "node_modules/@supabase/auth-js": {
@@ -1088,16 +1088,20 @@
       }
     },
     "node_modules/stripe": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-16.12.0.tgz",
-      "integrity": "sha512-H7eFVLDxeTNNSn4JTRfL2//LzCbDrMSZ+2q1c7CanVWgK2qIW5TwS+0V7N9KcKZZNpYh/uCqK0PyZh/2UsaAtQ==",
+      "version": "20.4.1",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-20.4.1.tgz",
+      "integrity": "sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w==",
       "license": "MIT",
-      "dependencies": {
-        "@types/node": ">=8.1.0",
-        "qs": "^6.11.0"
-      },
       "engines": {
-        "node": ">=12.*"
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@types/node": ">=16"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/toidentifier": {

--- a/api/package.json
+++ b/api/package.json
@@ -14,6 +14,6 @@
     "express-rate-limit": "^8.2.1",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
-    "stripe": "^16.2.0"
+    "stripe": "^20.4.1"
   }
 }

--- a/api/routes/referral.js
+++ b/api/routes/referral.js
@@ -5,7 +5,11 @@ import { supabase } from '../server.js'
 export const router = Router()
 
 function getStripe() {
-  return new Stripe(process.env.STRIPE_SECRET_KEY || '')
+  // Pin apiVersion so api/ and web/ serialize identical request shapes.
+  // Must match web/lib/stripe.ts. Update both at the same time.
+  return new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+    apiVersion: '2026-02-25.clover',
+  })
 }
 
 async function requireAuth(req, res, next) {

--- a/api/routes/stripe.js
+++ b/api/routes/stripe.js
@@ -6,7 +6,11 @@ import { supabase } from '../server.js'
 export const router = Router()
 
 function getStripe() {
-  return new Stripe(process.env.STRIPE_SECRET_KEY || '')
+  // Pin apiVersion so api/ and web/ serialize identical webhook + request shapes.
+  // Must match web/lib/stripe.ts. Update both at the same time.
+  return new Stripe(process.env.STRIPE_SECRET_KEY || '', {
+    apiVersion: '2026-02-25.clover',
+  })
 }
 
 async function requireAuth(req, res, next) {

--- a/web/lib/stripe.ts
+++ b/web/lib/stripe.ts
@@ -9,7 +9,11 @@ if (process.env.NODE_ENV === 'production' && process.env.STRIPE_SECRET_KEY?.star
   console.warn('[WARN] Using Stripe test keys in production. Set a live STRIPE_SECRET_KEY before accepting real payments.')
 }
 
-export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!)
+// Pin apiVersion so web/ and api/ serialize identical webhook + request shapes.
+// Must match api/routes/stripe.js + api/routes/referral.js. Update all together.
+export const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: '2026-02-25.clover',
+})
 
 export function stripeLog(message: string) {
   console.log(`[Stripe] ${new Date().toISOString()} ${message}`)


### PR DESCRIPTION
## Summary

- Upgrade `api/` Stripe SDK from `^16.2.0` to `^20.4.1` so it matches `web/` (`^20.4.0`). Closes the 4-major-version gap where the two services could silently disagree on webhook event shapes.
- Pin `apiVersion: '2026-02-25.clover'` (the v20 SDK's `LatestApiVersion`) in all three `new Stripe(...)` call sites: `web/lib/stripe.ts`, `api/routes/stripe.js`, `api/routes/referral.js`. Both services now serialize identical webhook + request shapes.

Linear: AI-8770

## Audit: api/ Stripe call sites across v16 -> v20

| Method | v16 | v20 | Status |
|---|---|---|---|
| `stripe.webhooks.constructEvent` | available | available | unchanged - ports cleanly |
| `stripe.checkout.sessions.create` | available | available | unchanged - ports cleanly |
| `stripe.invoiceItems.create` (referral credit) | available | available | unchanged - ports cleanly |

**No code changes required at any call site.** All methods used in `api/` are stable across the v16 -> v20 SDK majors. The only delta is the constructor signature: in TS-strict consumers (`web/lib/stripe.ts`), the `apiVersion` option is now strictly typed to `LatestApiVersion`, so the explicit pin doubles as a type-safety check.

## Why apiVersion `2026-02-25.clover`

This is the v20 SDK's hard-coded default (`Stripe.API_VERSION` constant). Pinning it explicitly:
1. Makes the wire-version self-documenting in source.
2. Catches accidental SDK-default drift on future bumps - tsc fails if the literal doesn't match the upgraded SDK's `LatestApiVersion`.
3. Guarantees `api/` and `web/` send the same `Stripe-Version` header, so webhook event shapes Stripe sends back are identical.

## Smoke tests

### api/ runtime smoke (isolated)

```bash
$ STRIPE_SECRET_KEY=sk_test_dummy node --input-type=module -e \
    "import Stripe from 'stripe'; \
     const s=new Stripe(process.env.STRIPE_SECRET_KEY, {apiVersion:'2026-02-25.clover'}); \
     console.log(Stripe.PACKAGE_VERSION, s.getApiField('version'));"
20.4.1 2026-02-25.clover
```

All three methods used in api/ resolve as functions on the upgraded client.

### web/ typecheck

```bash
$ cd web && npx tsc --noEmit -p tsconfig.json
```

Zero Stripe-related errors. (One pre-existing unrelated error in `app/api/transcribe/route.ts` survives - not a Stripe regression.)

### Tests

`api/` has no test script (zero coverage today). If B3 ships first with Stripe webhook tests on the api/ side, this PR rebases cleanly - it only changes constructor calls, not handler logic.

## Future Stripe upgrades - migration path

When bumping the SDK again:
1. Bump both `api/` and `web/` package.json together (avoid the gap from re-opening).
2. Update the `apiVersion` literal in all three sites at once: `api/routes/stripe.js`, `api/routes/referral.js`, `web/lib/stripe.ts`. The strict TS type in v20+ will fail compile if the literal doesn't match the new SDK.
3. Re-run `npx tsc --noEmit` in `web/` to catch type drift on Stripe response shapes.
4. Re-audit api/ call sites for v20 -> vN breaking changes (Stripe maintains a per-major migration guide).

## Test plan

- [ ] `cd api && npm install` succeeds
- [ ] `cd web && npx tsc --noEmit` shows no Stripe errors
- [ ] Stripe webhook test event in dev (checkout.session.completed) round-trips through `api/routes/stripe.js` without signature error
- [ ] Stripe webhook test event in dev (customer.subscription.deleted) round-trips through `api/routes/stripe.js` and updates profile correctly
- [ ] Web checkout flow (`POST /api/stripe/checkout`) still creates a session against live Stripe test keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)