### PR TITLE
feat(clapcheeks): port /intelligence backend to Next.js API routes

### DIFF
--- a/web/app/(main)/intelligence/page.tsx
+++ b/web/app/(main)/intelligence/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
-import { createClient } from '@/lib/supabase/client'
 
 interface Stats {
   opener_reply_rate: number
@@ -12,6 +11,8 @@ interface Stats {
   best_send_time: { hour: number; day: string } | null
   trend: { this_week: number; last_week: number }
   heatmap: { day: number; hour: number; total: number; replied: number }[]
+  not_yet_available?: boolean
+  missing_tables?: string[]
 }
 
 // Derive a human-readable "communication persona" from match reply patterns
@@ -31,6 +32,8 @@ function getBestStyle(styles: { style: string; reply_rate: number }[]): string {
 interface ABResult {
   styles: { style: string; sent: number; reply_rate: number }[]
   winner: string | null
+  not_yet_available?: boolean
+  missing_tables?: string[]
 }
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
@@ -39,32 +42,47 @@ export default function IntelligencePage() {
   const [stats, setStats] = useState<Stats | null>(null)
   const [abTest, setAbTest] = useState<ABResult | null>(null)
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let cancelled = false
     async function fetchData() {
       try {
-        const supabase = createClient()
-        const { data: { session } } = await supabase.auth.getSession()
-        const token = session?.access_token
-        const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'
-
-        const headers: Record<string, string> = {}
-        if (token) headers['Authorization'] = `Bearer ${token}`
-
+        // Same-origin Next.js API routes — auth is handled via Supabase SSR
+        // cookies in the route handlers. No bearer token needed here.
         const [statsRes, abRes] = await Promise.all([
-          fetch(`${apiBase}/intelligence/stats`, { headers }),
-          fetch(`${apiBase}/intelligence/ab-test`, { headers }),
+          fetch('/api/intelligence/stats', { credentials: 'include' }),
+          fetch('/api/intelligence/ab-test', { credentials: 'include' }),
         ])
 
-        if (statsRes.ok) setStats(await statsRes.json())
-        if (abRes.ok) setAbTest(await abRes.json())
-      } catch {
-        // silent in production
+        if (cancelled) return
+
+        const errors: string[] = []
+        if (statsRes.ok) {
+          setStats(await statsRes.json())
+        } else {
+          errors.push(`stats (${statsRes.status})`)
+        }
+        if (abRes.ok) {
+          setAbTest(await abRes.json())
+        } else {
+          errors.push(`A/B test (${abRes.status})`)
+        }
+        if (errors.length > 0) {
+          setError(`Couldn't load ${errors.join(' and ')}. Try refreshing in a moment.`)
+        }
+      } catch (err) {
+        if (cancelled) return
+        const msg = err instanceof Error ? err.message : 'Unknown error'
+        setError(`Network error loading intelligence data: ${msg}`)
       } finally {
-        setLoading(false)
+        if (!cancelled) setLoading(false)
       }
     }
     fetchData()
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   if (loading) {
@@ -112,6 +130,35 @@ export default function IntelligencePage() {
             Back to Dashboard
           </Link>
         </div>
+
+        {/* Inline error toast — surfaced when API routes fail. We no longer
+            silent-swallow these errors: knowing the page is broken is better
+            than seeing all-zero data and assuming nothing's happening. */}
+        {error && (
+          <div
+            role="alert"
+            className="mb-6 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3"
+          >
+            <div className="text-red-300 text-sm font-medium">Couldn&apos;t load all data</div>
+            <div className="text-red-200/70 text-xs mt-1">{error}</div>
+          </div>
+        )}
+
+        {/* Banner shown when the underlying analytics tables haven't been
+            provisioned yet (Phase L migrations pending). We show zeros + this
+            banner instead of an error so the page still renders. */}
+        {(stats?.not_yet_available || abTest?.not_yet_available) && (
+          <div
+            role="status"
+            className="mb-6 rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3"
+          >
+            <div className="text-amber-200 text-sm font-medium">Data collection in progress</div>
+            <div className="text-amber-100/70 text-xs mt-1">
+              Once your agent is connected and openers start flowing, this page will fill in
+              automatically. No action needed.
+            </div>
+          </div>
+        )}
 
         {/* Section 1: Opener Performance */}
         <div className="bg-white/[0.03] border border-white/[0.08] rounded-xl p-6 mb-6">

--- a/web/app/api/intelligence/ab-test/route.ts
+++ b/web/app/api/intelligence/ab-test/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+// Shape consumed by web/app/(main)/intelligence/page.tsx (interface ABResult).
+type ABStyle = { style: string; sent: number; reply_rate: number }
+type ABResponse = {
+  styles: ABStyle[]
+  winner: string | null
+  not_yet_available?: boolean
+  missing_tables?: string[]
+}
+
+const isMissingTableError = (err: unknown): boolean => {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { code?: string; message?: string }
+  if (e.code === 'PGRST205' || e.code === 'PGRST116' || e.code === '42P01') return true
+  if (typeof e.message === 'string') {
+    const m = e.message.toLowerCase()
+    return m.includes('does not exist') || m.includes('not found in the schema cache')
+  }
+  return false
+}
+
+export async function GET() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const since = new Date()
+  since.setDate(since.getDate() - 30)
+
+  const { data, error } = await supabase
+    .from('clapcheeks_opener_log')
+    .select('opener_style, got_reply')
+    .eq('user_id', user.id)
+    .gte('created_at', since.toISOString())
+    .not('opener_style', 'is', null)
+
+  if (error) {
+    if (isMissingTableError(error)) {
+      return NextResponse.json<ABResponse>({
+        styles: [],
+        winner: null,
+        not_yet_available: true,
+        missing_tables: ['clapcheeks_opener_log'],
+      })
+    }
+    return NextResponse.json(
+      { error: error.message ?? 'Failed to load opener log' },
+      { status: 500 },
+    )
+  }
+
+  const styles: Record<string, { style: string; total: number; replied: number }> = {}
+  for (const row of data ?? []) {
+    const style = (row.opener_style ?? 'default').toString()
+    if (!styles[style]) styles[style] = { style, total: 0, replied: 0 }
+    styles[style].total++
+    if (row.got_reply) styles[style].replied++
+  }
+
+  const results: ABStyle[] = Object.values(styles)
+    .map((s) => ({
+      style: s.style,
+      sent: s.total,
+      reply_rate: s.total > 0 ? Math.round((s.replied / s.total) * 100) / 100 : 0,
+    }))
+    .sort((a, b) => b.reply_rate - a.reply_rate)
+
+  // Statistical significance: declare a winner only when we have at least 2
+  // styles, the leader has >= 10 sends, and the lead is at least 5 percentage
+  // points. Otherwise return winner=null so the UI shows "still gathering".
+  let winner: string | null = null
+  if (results.length >= 2) {
+    const [first, second] = results
+    if (first.sent >= 10 && first.reply_rate - second.reply_rate >= 0.05) {
+      winner = first.style
+    }
+  } else if (results.length === 1 && results[0].sent >= 10) {
+    winner = results[0].style
+  }
+
+  return NextResponse.json<ABResponse>({ styles: results, winner })
+}

--- a/web/app/api/intelligence/stats/route.ts
+++ b/web/app/api/intelligence/stats/route.ts
@@ -1,0 +1,233 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+
+// Shape consumed by web/app/(main)/intelligence/page.tsx (interface Stats).
+// Keep additions backwards-compatible; do not remove fields.
+type FunnelCounts = {
+  opened: number
+  replied: number
+  date_ready: number
+  booked: number
+}
+
+type StatsResponse = {
+  opener_reply_rate: number
+  by_platform: Record<string, number>
+  stage_funnel: FunnelCounts
+  top_openers: { text: string; reply_rate: number; platform: string }[]
+  best_send_time: { hour: number; day: string } | null
+  trend: { this_week: number; last_week: number }
+  heatmap: { day: number; hour: number; total: number; replied: number }[]
+  // Optional metadata so the UI can render a graceful empty state
+  // when the underlying tables haven't been provisioned yet.
+  not_yet_available?: boolean
+  missing_tables?: string[]
+}
+
+const EMPTY_STATS: StatsResponse = {
+  opener_reply_rate: 0,
+  by_platform: {},
+  stage_funnel: { opened: 0, replied: 0, date_ready: 0, booked: 0 },
+  top_openers: [],
+  best_send_time: null,
+  trend: { this_week: 0, last_week: 0 },
+  heatmap: [],
+}
+
+// PostgREST returns code "PGRST205" when a table is not exposed (e.g. missing
+// migration). We treat that as "data collection in progress" rather than 500.
+const isMissingTableError = (err: unknown): boolean => {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { code?: string; message?: string }
+  if (e.code === 'PGRST205' || e.code === 'PGRST116' || e.code === '42P01') return true
+  if (typeof e.message === 'string') {
+    const m = e.message.toLowerCase()
+    return m.includes('does not exist') || m.includes('not found in the schema cache')
+  }
+  return false
+}
+
+export async function GET() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const since = new Date()
+  since.setDate(since.getDate() - 30)
+  const sinceStr = since.toISOString()
+
+  const weekAgo = new Date()
+  weekAgo.setDate(weekAgo.getDate() - 7)
+
+  const [openerRes, eventRes] = await Promise.all([
+    supabase
+      .from('clapcheeks_opener_log')
+      .select('platform, opener_text, opener_style, got_reply, created_at')
+      .eq('user_id', user.id)
+      .gte('created_at', sinceStr),
+    supabase
+      .from('clapcheeks_conversation_events')
+      .select('to_stage, created_at')
+      .eq('user_id', user.id)
+      .gte('created_at', sinceStr),
+  ])
+
+  // Track tables that aren't deployed yet. If both source tables are missing
+  // we return an empty payload at HTTP 200 so the UI shows the "no data yet"
+  // copy instead of an error toast.
+  const missingTables: string[] = []
+  if (openerRes.error && isMissingTableError(openerRes.error)) {
+    missingTables.push('clapcheeks_opener_log')
+  } else if (openerRes.error) {
+    return NextResponse.json(
+      { error: openerRes.error.message ?? 'Failed to load opener log' },
+      { status: 500 },
+    )
+  }
+  if (eventRes.error && isMissingTableError(eventRes.error)) {
+    missingTables.push('clapcheeks_conversation_events')
+  } else if (eventRes.error) {
+    return NextResponse.json(
+      { error: eventRes.error.message ?? 'Failed to load conversation events' },
+      { status: 500 },
+    )
+  }
+
+  if (missingTables.length === 2) {
+    return NextResponse.json<StatsResponse>({
+      ...EMPTY_STATS,
+      not_yet_available: true,
+      missing_tables: missingTables,
+    })
+  }
+
+  const allOpeners = openerRes.data ?? []
+  const allEvents = eventRes.data ?? []
+
+  // Overall reply rate
+  const totalOpeners = allOpeners.length
+  const replied = allOpeners.filter((o) => o.got_reply).length
+  const openerReplyRate = totalOpeners > 0 ? replied / totalOpeners : 0
+
+  // Reply rate by platform
+  const byPlatformRaw: Record<string, { total: number; replied: number }> = {}
+  for (const o of allOpeners) {
+    const platform = o.platform ?? 'unknown'
+    if (!byPlatformRaw[platform]) byPlatformRaw[platform] = { total: 0, replied: 0 }
+    byPlatformRaw[platform].total++
+    if (o.got_reply) byPlatformRaw[platform].replied++
+  }
+  const platformRates: Record<string, number> = {}
+  for (const [p, v] of Object.entries(byPlatformRaw)) {
+    platformRates[p] = v.total > 0 ? Math.round((v.replied / v.total) * 100) / 100 : 0
+  }
+
+  // Stage funnel — opened from opener log, plus events for downstream stages.
+  const stageCounts: FunnelCounts = { opened: totalOpeners, replied: 0, date_ready: 0, booked: 0 }
+  for (const e of allEvents) {
+    const to = e.to_stage as keyof FunnelCounts | undefined
+    if (to && to in stageCounts) {
+      stageCounts[to]++
+    }
+  }
+  // Replied count also comes from opener got_reply (whichever is higher).
+  stageCounts.replied = Math.max(stageCounts.replied, replied)
+
+  // Top openers grouped by opener_text (require >= 2 sends for stability)
+  const openerStats: Record<
+    string,
+    { text: string; total: number; replied: number; platform: string }
+  > = {}
+  for (const o of allOpeners) {
+    const text = (o.opener_text ?? '').toString()
+    const key = text.substring(0, 100)
+    if (!key) continue
+    if (!openerStats[key]) {
+      openerStats[key] = { text, total: 0, replied: 0, platform: o.platform ?? 'unknown' }
+    }
+    openerStats[key].total++
+    if (o.got_reply) openerStats[key].replied++
+  }
+  const topOpeners = Object.values(openerStats)
+    .filter((o) => o.total >= 2)
+    .map((o) => ({
+      text: o.text,
+      reply_rate: Math.round((o.replied / o.total) * 100) / 100,
+      platform: o.platform,
+    }))
+    .sort((a, b) => b.reply_rate - a.reply_rate)
+    .slice(0, 5)
+
+  // Best send time — hour/day combo with the highest reply rate (>= 2 sends)
+  const hourDayMap: Record<
+    string,
+    { hour: number; day: string; total: number; replied: number }
+  > = {}
+  for (const o of allOpeners) {
+    if (!o.created_at) continue
+    const d = new Date(o.created_at)
+    const hour = d.getUTCHours()
+    const day = d.toLocaleDateString('en-US', { weekday: 'long', timeZone: 'UTC' })
+    const key = `${day}-${hour}`
+    if (!hourDayMap[key]) hourDayMap[key] = { hour, day, total: 0, replied: 0 }
+    hourDayMap[key].total++
+    if (o.got_reply) hourDayMap[key].replied++
+  }
+  const bestTime = Object.values(hourDayMap)
+    .filter((v) => v.total >= 2)
+    .sort((a, b) => b.replied / b.total - a.replied / a.total)[0]
+
+  // Week-over-week trend
+  const thisWeekOpeners = allOpeners.filter(
+    (o) => o.created_at && new Date(o.created_at) >= weekAgo,
+  )
+  const lastWeekOpeners = allOpeners.filter(
+    (o) => o.created_at && new Date(o.created_at) < weekAgo,
+  )
+  const thisWeekRate =
+    thisWeekOpeners.length > 0
+      ? thisWeekOpeners.filter((o) => o.got_reply).length / thisWeekOpeners.length
+      : 0
+  const lastWeekRate =
+    lastWeekOpeners.length > 0
+      ? lastWeekOpeners.filter((o) => o.got_reply).length / lastWeekOpeners.length
+      : 0
+
+  // Heatmap data — 7 days x 24 hours
+  const heatmapMap: Record<
+    string,
+    { day: number; hour: number; total: number; replied: number }
+  > = {}
+  for (const o of allOpeners) {
+    if (!o.created_at) continue
+    const d = new Date(o.created_at)
+    const dayOfWeek = d.getUTCDay()
+    const hour = d.getUTCHours()
+    const key = `${dayOfWeek}-${hour}`
+    if (!heatmapMap[key]) heatmapMap[key] = { day: dayOfWeek, hour, total: 0, replied: 0 }
+    heatmapMap[key].total++
+    if (o.got_reply) heatmapMap[key].replied++
+  }
+
+  const payload: StatsResponse = {
+    opener_reply_rate: Math.round(openerReplyRate * 100) / 100,
+    by_platform: platformRates,
+    stage_funnel: stageCounts,
+    top_openers: topOpeners,
+    best_send_time: bestTime ? { hour: bestTime.hour, day: bestTime.day } : null,
+    trend: {
+      this_week: Math.round(thisWeekRate * 100) / 100,
+      last_week: Math.round(lastWeekRate * 100) / 100,
+    },
+    heatmap: Object.values(heatmapMap),
+  }
+  if (missingTables.length > 0) {
+    payload.missing_tables = missingTables
+  }
+
+  return NextResponse.json(payload)
+}


### PR DESCRIPTION
## Summary

The `/intelligence` page was calling `${NEXT_PUBLIC_API_URL}/intelligence/stats` and `/intelligence/ab-test` against a separate Express backend that isn't deployed (env var unset on Vercel). The fetches failed silently inside a `try/catch` and the page rendered all-zero stub data, making it look like nothing was happening.

This PR ports the two endpoints to same-origin Next.js API routes that read directly from Supabase using the SSR cookie session, matching the existing `/analytics` -> `/api/analytics/summary` pattern. The page now hits `/api/intelligence/*` (no env var, no separate backend) and surfaces real errors via an inline toast instead of silent-swallowing.

### Changes

- `web/app/api/intelligence/stats/route.ts` (new) — overall reply rate, per-platform rates, stage funnel, top openers, best send time, weekly trend, heatmap. Auth via `createClient()` from `@/lib/supabase/server`.
- `web/app/api/intelligence/ab-test/route.ts` (new) — per-style sent + reply rate. Declares a winner only when the leader has at least 10 sends and a 5pp lead over the runner-up; otherwise returns `winner: null` so the UI shows "still gathering."
- `web/app/(main)/intelligence/page.tsx` — drop `NEXT_PUBLIC_API_URL` + `apiBase`, drop the manual bearer-token plumbing (SSR cookies cover it), surface fetch errors via a red inline toast, and show a separate amber "data collection in progress" banner when the source tables aren't deployed.

### Graceful degradation for missing tables

Routes detect `PGRST205` / `42P01` / "does not exist" / "not found in schema cache" errors and return HTTP 200 with `not_yet_available: true` + `missing_tables: [...]` instead of a 500. The page renders zeros + an amber banner so the UI still works while migrations are catching up.

### Source tables (already exist on prod)

- `clapcheeks_opener_log` — defined in `supabase/migrations/20240101000007_conversation_analytics.sql`, RLS by `user_id`. Tracks every AI-generated opener + `got_reply` outcome.
- `clapcheeks_conversation_events` — same migration, RLS by `user_id`. Tracks `from_stage` -> `to_stage` progressions (`opened`, `replied`, `date_ready`, `booked`).

If either is dropped in a future migration, the route returns the graceful-degradation payload instead of erroring.

### Tests

No test framework (Vitest/Jest) is currently configured in `web/package.json`, so I did not add a smoke test file. Once one is wired up (e.g. by a future PR adding the Stripe webhook tests RA-B3 mentioned), a `route.test.ts` next to each handler should assert that `GET` is exported and returns the expected shape under happy / unauthorized / missing-table inputs.

## Test plan

- [x] `cd web && npx tsc --noEmit` — zero errors for new files (only pre-existing `app/api/transcribe/route.ts` error remains, untouched by this PR)
- [x] `cd web && npx next build` — PASS; both `/api/intelligence/stats` and `/api/intelligence/ab-test` register as dynamic routes (`ƒ`)
- [ ] After merge: hit `https://clapcheeks-tech-<sha>.vercel.app/intelligence` while signed in, confirm the toast does NOT appear and stats render (zero is fine if the user has no openers logged)
- [ ] Hit `https://clapcheeks-tech-<sha>.vercel.app/api/intelligence/stats` directly while signed in, confirm JSON returns with the expected `Stats` shape (see `interface Stats` in `page.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)