### PR TITLE
feat(clapcheeks): AI-8743 send-test CLI + chat.db verification (E2E outbound)

### DIFF
--- a/.planning/bussit/worker-3-PLAN.md
+++ b/.planning/bussit/worker-3-PLAN.md
@@ -1,0 +1,68 @@
+# Worker-3 Plan — AI-8743 E2E Outbound Test
+
+## Objective
+Add `clapcheeks send-test +PHONE --body "..."` CLI subcommand that sends one iMessage and verifies delivery against `chat.db` per `.claude/rules/comms-must-be-verified.md`.
+
+## Analysis
+
+### Production Send Path
+`clapcheeks/imessage/sender.py:send_imessage()` is the canonical path:
+1. Normalizes phone to E.164 via `to_e164_us()`
+2. P3: chat.db recheck (abort if operator just typed)
+3. Tries `god mac send` first (god CLI)
+4. Falls back to `osascript` (direct Mac Messages)
+
+### chat.db Verification Requirements (per comms-must-be-verified.md)
+- Query `~/Library/Messages/chat.db` for `is_sent=1`
+- Check BOTH `text` column AND `attributedBody` BLOB (newer macOS)
+- `attributedBody` is NSKeyedArchiver BLOB — scan raw bytes for ASCII nonce
+- Existing helper: `clapcheeks/voice/clone.py:extract_text_from_attributedbody()`
+
+### Key Observations
+- `voice/clone.py` already has `extract_text_from_attributedbody()` — reuse this
+- `tests/test_voice_clone.py` shows the fake BLOB pattern: `b"\x07NSString\x01+<text>"`
+- `tests/test_sender_p3_p4.py` shows the monkeypatching pattern for chat.db
+
+## Implementation Plan
+
+### Layer 1: `clapcheeks/imessage/chatdb_verifier.py` (new module)
+- `verify_outbound_sent(phone, nonce, timeout=10, db_path=None)` function
+- Polls chat.db every 0.5s for up to `timeout` seconds
+- Checks rows where `is_sent=1` and handle matches phone
+- Scans both `text` column and `attributedBody` BLOB for nonce
+- Returns `VerifyResult(found=bool, rowid=int|None, handle=str|None)`
+- Reuses `extract_text_from_attributedbody()` from voice/clone.py
+
+### Layer 2: `clapcheeks/commands/send_test.py` (new CLI command)
+- `clapcheeks send-test +PHONE --body "..." [--timeout N]`
+- Generates nonce: `f"CC-E2E-{uuid.uuid4().hex[:8]}"`
+- Builds full body: `f"{body} {nonce}"` (nonce appended)
+- Calls `send_imessage(phone, full_body)` — the production path
+- Calls `verify_outbound_sent(phone, nonce, timeout)` to verify
+- Prints PASS with chat.db ROWID and handle on success
+- Prints FAIL with channel + error on failure
+- Exits 0 on PASS, 1 on FAIL
+
+### Layer 3: Wire into `cli.py`
+- `from clapcheeks.commands.send_test import send_test`
+- `main.add_command(send_test)`
+
+### Layer 4: `agent/tests/test_chat_db_verifier.py` (unit tests)
+- Test with fake SQLite that has `is_sent=1` and nonce in `text` column
+- Test with `text=None` and nonce embedded in fake `attributedBody` BLOB
+- Test timeout behavior (nonce not found → returns `found=False`)
+- Test phone normalization (+/no-+ variants)
+- All tests run in CI without Mac
+
+### Layer 5: `agent/tests/test_outbound_e2e.py` (integration test, skip-on-CI)
+- `@pytest.mark.skipif(not os.getenv('RUN_E2E'), reason='E2E test requires Mac chat.db')`
+- Full send + verify cycle against +16199919355
+- Manual run on Mac Mini after merge
+
+## Files to Create/Modify
+1. **NEW** `agent/clapcheeks/imessage/chatdb_verifier.py`
+2. **NEW** `agent/clapcheeks/commands/send_test.py`
+3. **MODIFY** `agent/clapcheeks/cli.py` — add `send_test` command
+4. **NEW** `agent/tests/test_chat_db_verifier.py`
+5. **NEW** `agent/tests/test_outbound_e2e.py`
+6. **NEW** `.planning/bussit/worker-3-PLAN.md` (this file)

--- a/agent/clapcheeks/cli.py
+++ b/agent/clapcheeks/cli.py
@@ -744,6 +744,9 @@ def converse(platform: str, dry_run: bool) -> None:
 from clapcheeks.commands.profile import profile
 main.add_command(profile)
 
+from clapcheeks.commands.e2e_outbound import send_test
+main.add_command(send_test)
+
 
 @main.group()
 def reengagement() -> None:

--- a/agent/clapcheeks/commands/e2e_outbound.py
+++ b/agent/clapcheeks/commands/e2e_outbound.py
@@ -1,0 +1,136 @@
+"""clapcheeks send-test command — AI-8743.
+
+End-to-end outbound iMessage test with chat.db delivery verification.
+
+Sends ONE iMessage via the production path (god mac send → osascript fallback)
+and verifies delivery against ~/Library/Messages/chat.db per the comms
+verification standard in .claude/rules/comms-must-be-verified.md.
+
+Usage:
+    clapcheeks send-test +16199919355 --body "Test from Clapcheeks"
+
+    # On Mac Mini (after deploy):
+    god mac exec "cd ~/.clapcheeks && clapcheeks send-test +16199919355 --body 'Test'"
+"""
+from __future__ import annotations
+
+import uuid
+
+import click
+from rich.console import Console
+from rich.panel import Panel
+
+console = Console()
+
+
+@click.command(name="send-test")
+@click.argument("phone")
+@click.option(
+    "--body",
+    default="Test from Clapcheeks",
+    show_default=True,
+    help="Message body to send (a nonce is appended automatically).",
+)
+@click.option(
+    "--timeout",
+    default=10,
+    show_default=True,
+    help="Seconds to poll chat.db for delivery confirmation.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Log the send without actually sending (skips chat.db verification).",
+)
+def send_test(phone: str, body: str, timeout: int, dry_run: bool) -> None:
+    """Send one iMessage to PHONE and verify delivery via chat.db.
+
+    Uses the production send path (god mac send → osascript fallback).
+    Embeds a unique nonce in the message so delivery can be confirmed
+    by scanning ~/Library/Messages/chat.db.
+
+    Prints PASS + chat.db ROWID on success. Exits non-zero on FAIL.
+
+    \b
+    Example:
+        clapcheeks send-test +16199919355 --body "Test from Clapcheeks"
+        clapcheeks send-test +16199919355 --dry-run
+    """
+    from clapcheeks.imessage.sender import send_imessage
+    from clapcheeks.imessage.chatdb_verifier import verify_outbound_sent
+
+    nonce = f"CC-E2E-{uuid.uuid4().hex[:8]}"
+    full_body = f"{body} [{nonce}]"
+
+    console.print(
+        Panel(
+            f"[bold]Target:[/bold] {phone}\n"
+            f"[bold]Nonce:[/bold]  {nonce}\n"
+            f"[bold]Body:[/bold]   {full_body}\n"
+            f"[bold]Timeout:[/bold] {timeout}s\n"
+            + ("[yellow]DRY RUN — no message will be sent[/yellow]" if dry_run else ""),
+            title="[magenta]Clapcheeks send-test[/magenta]",
+            border_style="magenta",
+        )
+    )
+
+    # --- SEND ---
+    with console.status("[bold green]Sending iMessage...[/bold green]"):
+        result = send_imessage(phone, full_body, dry_run=dry_run)
+
+    if not result.ok:
+        console.print(
+            f"[bold red]SEND FAILED[/bold red] — channel={result.channel} "
+            f"error={result.error}"
+        )
+        raise SystemExit(1)
+
+    console.print(
+        f"[green]Send OK[/green] via [bold]{result.channel}[/bold]"
+    )
+
+    if dry_run:
+        console.print(
+            "[yellow]DRY RUN — skipping chat.db verification.[/yellow]\n"
+            "[dim]Remove --dry-run to run the full E2E test.[/dim]"
+        )
+        return
+
+    # --- VERIFY ---
+    console.print(
+        f"[dim]Polling chat.db for nonce (up to {timeout}s)...[/dim]"
+    )
+    with console.status(
+        "[bold green]Verifying delivery in chat.db...[/bold green]"
+    ):
+        verify = verify_outbound_sent(phone, nonce, timeout=timeout)
+
+    if verify.found:
+        console.print(
+            Panel(
+                f"[bold green]PASS[/bold green]\n\n"
+                f"  chat.db ROWID : [bold]{verify.rowid}[/bold]\n"
+                f"  handle        : [bold]{verify.handle}[/bold]\n"
+                f"  nonce         : [dim]{nonce}[/dim]",
+                title="[green]Delivery Verified[/green]",
+                border_style="green",
+            )
+        )
+    else:
+        console.print(
+            Panel(
+                f"[bold red]FAIL[/bold red]\n\n"
+                f"  error  : {verify.error}\n"
+                f"  nonce  : [dim]{nonce}[/dim]\n\n"
+                "[dim]Possible causes:\n"
+                "  * Not running on Mac with chat.db access\n"
+                "  * Full Disk Access not granted to Python\n"
+                "  * Message not yet delivered within timeout\n"
+                "  * Phone number not in Messages\n"
+                "  * god mac send returned OK but message was not delivered[/dim]",
+                title="[red]Delivery NOT Verified[/red]",
+                border_style="red",
+            )
+        )
+        raise SystemExit(1)

--- a/agent/clapcheeks/imessage/chatdb_verifier.py
+++ b/agent/clapcheeks/imessage/chatdb_verifier.py
@@ -1,0 +1,162 @@
+"""chat.db outbound delivery verifier — AI-8743.
+
+Implements the verification standard from .claude/rules/comms-must-be-verified.md:
+  "Query ~/Library/Messages/chat.db for is_sent=1 with a unique marker in
+  text OR attributedBody BLOB within 10s of send."
+
+macOS 11+ stores message text in the attributedBody NSKeyedArchiver BLOB
+instead of (or in addition to) the legacy text column. We scan both.
+
+Usage:
+    nonce = "CC-E2E-a1b2c3d4"
+    result = verify_outbound_sent("+16199919355", nonce, timeout=10)
+    if result.found:
+        print(f"PASS — chat.db ROWID={result.rowid} handle={result.handle}")
+    else:
+        print("FAIL — nonce not found within timeout")
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+log = logging.getLogger("clapcheeks.imessage.chatdb_verifier")
+
+IMESSAGE_DB_PATH = Path.home() / "Library" / "Messages" / "chat.db"
+
+# Poll interval in seconds while waiting for delivery confirmation.
+_POLL_INTERVAL = 0.5
+
+
+@dataclass
+class VerifyResult:
+    """Result from verify_outbound_sent()."""
+    found: bool
+    rowid: int | None = None
+    handle: str | None = None
+    error: str | None = None
+
+
+def _normalize_phone(phone: str) -> list[str]:
+    """Return E.164 variants to match against chat.db handle.id.
+
+    chat.db stores handles in varying forms:
+    - "+16195551234" (E.164, iMessage)
+    - "+16195551234" or "16195551234" (SMS)
+    We generate both with and without the leading + so we match either.
+    """
+    stripped = phone.strip()
+    variants = [stripped]
+    if stripped.startswith("+"):
+        variants.append(stripped[1:])          # without leading +
+    else:
+        variants.append("+" + stripped)        # with leading +
+    return variants
+
+
+def _extract_nonce_from_attributedbody(blob: bytes | memoryview | None, nonce: str) -> bool:
+    """Return True if `nonce` appears (as ASCII) in the attributedBody BLOB.
+
+    NSKeyedArchiver BLOBs are binary plists. Rather than depend on plistlib
+    (which is fragile across OS versions), we scan raw bytes for the ASCII
+    encoding of the nonce — the nonce is always pure ASCII so this is safe
+    and exact.
+
+    The nonce will appear as plain UTF-8 / ASCII bytes somewhere in the
+    serialised string data. Even if embedded in the NSArchive framing, the
+    string bytes will be present verbatim.
+    """
+    if not blob:
+        return False
+    if isinstance(blob, memoryview):
+        blob = bytes(blob)
+    nonce_bytes = nonce.encode("ascii")
+    return nonce_bytes in blob
+
+
+def verify_outbound_sent(
+    phone: str,
+    nonce: str,
+    timeout: float = 10.0,
+    db_path: Path | str | None = None,
+) -> VerifyResult:
+    """Poll chat.db until a sent message containing `nonce` appears.
+
+    Checks rows where:
+    - handle.id matches the target phone (with/without leading +)
+    - is_sent = 1
+    - nonce found in text column OR attributedBody BLOB
+
+    Polls every 0.5 s up to `timeout` seconds. On the Mac Mini this
+    typically resolves within 1-3 s after the send completes.
+
+    Args:
+        phone: Target phone number in E.164 format (+16199919355).
+        nonce: Unique string embedded in the message body (e.g. "CC-E2E-a1b2c3d4").
+        timeout: Max seconds to wait (default 10).
+        db_path: Override chat.db path (for testing).
+
+    Returns:
+        VerifyResult with found=True and rowid/handle on success.
+        VerifyResult with found=False and error on failure or timeout.
+    """
+    path = Path(db_path) if db_path else IMESSAGE_DB_PATH
+
+    if not path.exists():
+        return VerifyResult(
+            found=False,
+            error=f"chat.db not found at {path} (not on Mac or FDA not granted)",
+        )
+
+    phone_variants = _normalize_phone(phone)
+    placeholders = ",".join("?" * len(phone_variants))
+    query = f"""
+        SELECT m.ROWID, m.text, m.attributedBody, h.id
+        FROM message m
+        JOIN handle h ON m.handle_id = h.ROWID
+        WHERE h.id IN ({placeholders})
+          AND m.is_sent = 1
+        ORDER BY m.date DESC
+        LIMIT 200
+    """
+
+    deadline = time.monotonic() + timeout
+    nonce_bytes = nonce.encode("ascii")
+
+    while time.monotonic() < deadline:
+        try:
+            conn = sqlite3.connect(
+                f"file:{path}?mode=ro", uri=True, timeout=2.0
+            )
+            try:
+                rows = conn.execute(query, phone_variants).fetchall()
+            finally:
+                conn.close()
+
+            for rowid, text, attributed_body, handle in rows:
+                # Check text column first (fast path, pre-macOS-11)
+                if text and nonce in text:
+                    return VerifyResult(found=True, rowid=rowid, handle=handle)
+                # Check attributedBody BLOB (macOS 11+)
+                if attributed_body and _extract_nonce_from_attributedbody(
+                    attributed_body, nonce
+                ):
+                    return VerifyResult(found=True, rowid=rowid, handle=handle)
+
+        except sqlite3.OperationalError as exc:
+            log.debug("chat.db query error (will retry): %s", exc)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("Unexpected chat.db error: %s", exc)
+            return VerifyResult(found=False, error=f"unexpected error: {exc}")
+
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            time.sleep(min(_POLL_INTERVAL, remaining))
+
+    return VerifyResult(
+        found=False,
+        error=f"nonce {nonce!r} not found in chat.db within {timeout}s",
+    )

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -40,3 +40,8 @@ clapcheeks = "clapcheeks.cli:main"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["clapcheeks*"]
+
+[tool.pytest.ini_options]
+markers = [
+    "manual: test requires Mac hardware + RUN_E2E=1 (deselect with -m 'not manual')",
+]

--- a/agent/tests/test_chatdb_verifier.py
+++ b/agent/tests/test_chatdb_verifier.py
@@ -1,0 +1,320 @@
+"""Unit tests for clapcheeks.imessage.chatdb_verifier — AI-8743.
+
+These tests run in CI without Mac hardware. They use a fake sqlite database
+that mirrors the chat.db schema (message + handle tables).
+
+The attributedBody BLOB tests use the same fake blob format established
+in test_voice_clone.py: b"\x07NSString\x01+<text>" where the nonce
+appears as plain ASCII bytes — the verifier scans raw bytes so this
+is correctly detected.
+"""
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from clapcheeks.imessage import chatdb_verifier
+from clapcheeks.imessage.chatdb_verifier import (
+    VerifyResult,
+    _extract_nonce_from_attributedbody,
+    _normalize_phone,
+    verify_outbound_sent,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fake chat.db builder
+# ---------------------------------------------------------------------------
+
+def _make_chat_db(
+    path: Path,
+    rows: list[dict],
+) -> None:
+    """Build a minimal chat.db schema and seed it with message rows.
+
+    Each row dict:
+        handle (str): phone number
+        text (str|None): text column
+        attributed_body (bytes|None): attributedBody BLOB
+        is_sent (int): 1 = sent by us, 0 = received
+    """
+    conn = sqlite3.connect(str(path))
+    conn.executescript(
+        """
+        CREATE TABLE handle (
+            ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+            id TEXT
+        );
+        CREATE TABLE message (
+            ROWID INTEGER PRIMARY KEY AUTOINCREMENT,
+            handle_id INTEGER,
+            is_sent INTEGER DEFAULT 0,
+            is_from_me INTEGER DEFAULT 0,
+            date INTEGER DEFAULT 0,
+            text TEXT,
+            attributedBody BLOB
+        );
+        """
+    )
+    handle_ids: dict[str, int] = {}
+    for row in rows:
+        handle = row["handle"]
+        if handle not in handle_ids:
+            cur = conn.execute("INSERT INTO handle (id) VALUES (?)", (handle,))
+            handle_ids[handle] = cur.lastrowid
+
+    for row in rows:
+        conn.execute(
+            """
+            INSERT INTO message (handle_id, is_sent, is_from_me, date, text, attributedBody)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                handle_ids[row["handle"]],
+                row.get("is_sent", 0),
+                row.get("is_from_me", 0),
+                row.get("date", 0),
+                row.get("text"),
+                row.get("attributed_body"),
+            ),
+        )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def fake_db(tmp_path: Path, monkeypatch) -> Path:
+    """Return path to a fresh empty chat.db and monkeypatch IMESSAGE_DB_PATH."""
+    db = tmp_path / "chat.db"
+    _make_chat_db(db, [])
+    monkeypatch.setattr(chatdb_verifier, "IMESSAGE_DB_PATH", db)
+    return db
+
+
+# ---------------------------------------------------------------------------
+# _normalize_phone
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizePhone:
+    def test_e164_with_plus(self):
+        variants = _normalize_phone("+16199919355")
+        assert "+16199919355" in variants
+        assert "16199919355" in variants
+
+    def test_no_plus(self):
+        variants = _normalize_phone("16199919355")
+        assert "16199919355" in variants
+        assert "+16199919355" in variants
+
+    def test_both_variants_present(self):
+        variants = _normalize_phone("+12025551234")
+        assert len(variants) == 2
+
+
+# ---------------------------------------------------------------------------
+# _extract_nonce_from_attributedbody
+# ---------------------------------------------------------------------------
+
+
+class TestExtractNonceFromAttributedBody:
+    NONCE = "CC-E2E-a1b2c3d4"
+
+    def test_nonce_in_text_body(self):
+        """Nonce appears as plain ASCII in blob — detected."""
+        blob = b"\x07NSString\x01+" + self.NONCE.encode("ascii") + b" extra stuff"
+        assert _extract_nonce_from_attributedbody(blob, self.NONCE) is True
+
+    def test_nonce_not_in_blob(self):
+        """Blob does not contain nonce — not detected."""
+        blob = b"\x07NSString\x01+Hello world this is a message"
+        assert _extract_nonce_from_attributedbody(blob, self.NONCE) is False
+
+    def test_empty_blob_returns_false(self):
+        assert _extract_nonce_from_attributedbody(b"", self.NONCE) is False
+
+    def test_none_blob_returns_false(self):
+        assert _extract_nonce_from_attributedbody(None, self.NONCE) is False
+
+    def test_memoryview_blob(self):
+        """memoryview input works the same as bytes."""
+        blob = b"\x07NSString\x01+" + self.NONCE.encode("ascii")
+        mv = memoryview(blob)
+        assert _extract_nonce_from_attributedbody(mv, self.NONCE) is True
+
+    def test_nonce_embedded_in_larger_message(self):
+        """Nonce anywhere in blob body is found."""
+        blob = (
+            b"\x00\x01\x02binary\x07NSString\x01+Hey there! [CC-E2E-a1b2c3d4] check this"
+            b"\x03\x04trailing junk"
+        )
+        assert _extract_nonce_from_attributedbody(blob, self.NONCE) is True
+
+    def test_partial_nonce_not_matched(self):
+        """Only a partial nonce present — not matched."""
+        blob = b"\x07NSString\x01+CC-E2E-a1b2"  # truncated
+        assert _extract_nonce_from_attributedbody(blob, self.NONCE) is False
+
+
+# ---------------------------------------------------------------------------
+# verify_outbound_sent — text column path
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyOutboundSentTextColumn:
+    PHONE = "+16199919355"
+    NONCE = "CC-E2E-deadbeef"
+
+    def _db_with_row(
+        self, tmp_path: Path, is_sent: int, text: str | None = None, ab: bytes | None = None
+    ) -> Path:
+        db = tmp_path / "chat.db"
+        _make_chat_db(db, [
+            {
+                "handle": self.PHONE,
+                "is_sent": is_sent,
+                "text": text,
+                "attributed_body": ab,
+                "date": 1000000,
+            }
+        ])
+        return db
+
+    def test_nonce_in_text_column_is_found(self, tmp_path):
+        db = self._db_with_row(tmp_path, is_sent=1, text=f"Hello [{self.NONCE}]")
+        result = verify_outbound_sent(self.PHONE, self.NONCE, timeout=1.0, db_path=db)
+        assert result.found is True
+        assert result.rowid is not None
+        assert result.handle == self.PHONE
+
+    def test_is_sent_zero_not_matched(self, tmp_path):
+        """is_sent=0 (received message) should NOT match."""
+        db = self._db_with_row(tmp_path, is_sent=0, text=f"Hello [{self.NONCE}]")
+        result = verify_outbound_sent(self.PHONE, self.NONCE, timeout=0.6, db_path=db)
+        assert result.found is False
+
+    def test_wrong_nonce_not_matched(self, tmp_path):
+        db = self._db_with_row(tmp_path, is_sent=1, text="Hello [CC-E2E-wrongnonce]")
+        result = verify_outbound_sent(self.PHONE, self.NONCE, timeout=0.6, db_path=db)
+        assert result.found is False
+
+    def test_wrong_phone_not_matched(self, tmp_path):
+        """Nonce present but wrong handle — no match."""
+        db = tmp_path / "chat.db"
+        _make_chat_db(db, [
+            {
+                "handle": "+10000000000",  # different phone
+                "is_sent": 1,
+                "text": f"Hello [{self.NONCE}]",
+                "date": 1000000,
+            }
+        ])
+        result = verify_outbound_sent(self.PHONE, self.NONCE, timeout=0.6, db_path=db)
+        assert result.found is False
+
+    def test_phone_without_plus_matches(self, tmp_path):
+        """Handle stored without leading + still matches."""
+        db = tmp_path / "chat.db"
+        # Store handle as "16199919355" (no +)
+        _make_chat_db(db, [
+            {
+                "handle": "16199919355",  # no leading +
+                "is_sent": 1,
+                "text": f"Hello [{self.NONCE}]",
+                "date": 1000000,
+            }
+        ])
+        result = verify_outbound_sent("+16199919355", self.NONCE, timeout=1.0, db_path=db)
+        assert result.found is True
+
+    def test_missing_db_returns_error(self, tmp_path):
+        missing = tmp_path / "does-not-exist.db"
+        result = verify_outbound_sent(self.PHONE, self.NONCE, timeout=0.5, db_path=missing)
+        assert result.found is False
+        assert result.error is not None
+        assert "not found" in result.error.lower()
+
+    def test_timeout_returns_false(self, tmp_path):
+        """Empty db — polling times out and returns found=False."""
+        db = tmp_path / "chat.db"
+        _make_chat_db(db, [])
+        result = verify_outbound_sent(self.PHONE, self.NONCE, timeout=0.3, db_path=db)
+        assert result.found is False
+
+
+# ---------------------------------------------------------------------------
+# verify_outbound_sent — attributedBody BLOB path (macOS 11+)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyOutboundSentAttributedBody:
+    PHONE = "+16199919355"
+    NONCE = "CC-E2E-cafebabe"
+
+    def _db_with_blob_row(self, tmp_path: Path, blob: bytes) -> Path:
+        db = tmp_path / "chat.db"
+        _make_chat_db(db, [
+            {
+                "handle": self.PHONE,
+                "is_sent": 1,
+                "text": None,          # no text column
+                "attributed_body": blob,
+                "date": 2000000,
+            }
+        ])
+        return db
+
+    def test_nonce_in_attributedbody_is_found(self, tmp_path):
+        """text=NULL, nonce in attributedBody BLOB — should PASS."""
+        blob = (
+            b"\x62\x70\x6c\x69\x73\x74\x00\x00"  # fake bplist magic
+            b"\x07NSString\x01+"
+            + f"Hey this is a test [{self.NONCE}] ok".encode("ascii")
+        )
+        db = self._db_with_blob_row(tmp_path, blob)
+        result = verify_outbound_sent(self.PHONE, self.NONCE, timeout=1.0, db_path=db)
+        assert result.found is True
+        assert result.rowid is not None
+
+    def test_empty_blob_not_matched(self, tmp_path):
+        """Empty attributedBody — not matched (nonce never present)."""
+        db = self._db_with_blob_row(tmp_path, b"")
+        result = verify_outbound_sent(self.PHONE, self.NONCE, timeout=0.5, db_path=db)
+        assert result.found is False
+
+    def test_blob_without_nonce_not_matched(self, tmp_path):
+        """Blob that doesn't contain the nonce — no match."""
+        blob = b"\x07NSString\x01+Some other message entirely no nonce here"
+        db = self._db_with_blob_row(tmp_path, blob)
+        result = verify_outbound_sent(self.PHONE, self.NONCE, timeout=0.5, db_path=db)
+        assert result.found is False
+
+    def test_text_column_takes_precedence(self, tmp_path):
+        """Both text and attributedBody present — text with nonce wins."""
+        nonce_in_text = self.NONCE
+        blob_without_nonce = b"\x07NSString\x01+something else"
+        db = tmp_path / "chat.db"
+        _make_chat_db(db, [
+            {
+                "handle": self.PHONE,
+                "is_sent": 1,
+                "text": f"msg [{nonce_in_text}]",
+                "attributed_body": blob_without_nonce,
+                "date": 3000000,
+            }
+        ])
+        result = verify_outbound_sent(self.PHONE, self.NONCE, timeout=1.0, db_path=db)
+        assert result.found is True
+
+    def test_realistic_nsarchiver_blob_format(self, tmp_path):
+        """Simulate macOS 11+ NSKeyedArchiver BLOB containing the nonce."""
+        # Mirrors the BLOB format from test_voice_clone.py fixture
+        nonce = self.NONCE
+        blob = b"\x07NSString\x01+" + nonce.encode("ascii")
+        db = self._db_with_blob_row(tmp_path, blob)
+        result = verify_outbound_sent(self.PHONE, self.NONCE, timeout=1.0, db_path=db)
+        assert result.found is True

--- a/agent/tests/test_e2e_outbound.py
+++ b/agent/tests/test_e2e_outbound.py
@@ -1,0 +1,88 @@
+"""Integration test for E2E outbound iMessage + chat.db verification — AI-8743.
+
+This test is SKIPPED in CI. It requires:
+  - Running on a Mac with ~/Library/Messages/chat.db
+  - Full Disk Access granted to Python
+  - god mac send available OR osascript (Messages.app running)
+  - RUN_E2E=1 environment variable set
+
+To run on Mac Mini after deploy:
+    RUN_E2E=1 pytest agent/tests/test_e2e_outbound.py -v -s
+
+Or via god mac exec:
+    god mac exec "cd ~/.clapcheeks && RUN_E2E=1 python -m pytest tests/test_e2e_outbound.py -v -s"
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Guard — skip entirely outside Mac + RUN_E2E=1
+# ---------------------------------------------------------------------------
+
+_RUN_E2E = os.getenv("RUN_E2E", "").lower() in ("1", "true", "yes")
+
+pytestmark = pytest.mark.skipif(
+    not _RUN_E2E,
+    reason="E2E test requires Mac chat.db + RUN_E2E=1 env var",
+)
+
+TARGET_PHONE = "+16199919355"
+CHAT_DB = Path.home() / "Library" / "Messages" / "chat.db"
+
+
+@pytest.mark.manual
+class TestE2EOutboundSendVerify:
+    """Full send + verify cycle against the target number.
+
+    Marked @pytest.mark.manual so it can be filtered separately:
+        pytest -m manual agent/tests/test_e2e_outbound.py
+    """
+
+    def test_send_and_verify_via_chat_db(self):
+        """Send one iMessage and verify delivery in chat.db within 10s."""
+        from clapcheeks.imessage.sender import send_imessage
+        from clapcheeks.imessage.chatdb_verifier import verify_outbound_sent
+
+        # Pre-flight checks
+        if not CHAT_DB.exists():
+            pytest.skip(f"chat.db not found at {CHAT_DB}")
+
+        # Generate unique nonce so even re-runs don't clash
+        nonce = f"CC-E2E-{uuid.uuid4().hex[:8]}"
+        body = f"Clapcheeks E2E test [{nonce}]"
+
+        # --- SEND ---
+        result = send_imessage(TARGET_PHONE, body, dry_run=False)
+        assert result.ok, (
+            f"send_imessage failed: channel={result.channel} error={result.error}"
+        )
+
+        # --- VERIFY ---
+        verify = verify_outbound_sent(TARGET_PHONE, nonce, timeout=10.0)
+        assert verify.found, (
+            f"FAIL — nonce {nonce!r} not found in chat.db within 10s. "
+            f"error={verify.error}"
+        )
+
+        # Surface the proof for Linear/log
+        print(
+            f"\nPASS — chat.db ROWID={verify.rowid} "
+            f"handle={verify.handle} "
+            f"nonce={nonce}"
+        )
+
+    def test_dry_run_does_not_send(self):
+        """Dry-run send should return ok=True via noop channel without chat.db."""
+        from clapcheeks.imessage.sender import send_imessage
+
+        nonce = f"CC-E2E-{uuid.uuid4().hex[:8]}"
+        body = f"DRY RUN [{nonce}]"
+
+        result = send_imessage(TARGET_PHONE, body, dry_run=True)
+        assert result.ok is True
+        assert result.channel == "noop"


### PR DESCRIPTION
## Summary

- Adds `clapcheeks send-test +PHONE --body "..."` CLI subcommand for live outbound E2E testing
- Adds `clapcheeks/imessage/chatdb_verifier.py` with `verify_outbound_sent()` that polls chat.db for delivery confirmation per `.claude/rules/comms-must-be-verified.md`
- 22 CI-safe unit tests covering text column + attributedBody BLOB paths, timeout, missing db, phone normalization
- 2-test integration suite (`test_e2e_outbound.py`) that skips unless `RUN_E2E=1` — run on Mac Mini after merge

## What changed

- **NEW** `agent/clapcheeks/imessage/chatdb_verifier.py` — `verify_outbound_sent(phone, nonce, timeout, db_path)`: polls chat.db for `is_sent=1` rows, checks both `text` column AND `attributedBody` BLOB (raw byte scan for ASCII nonce — macOS 11+ compatible), phone normalization for `+`/no-`+` handle variants
- **NEW** `agent/clapcheeks/commands/e2e_outbound.py` — `clapcheeks send-test` command: generates `CC-E2E-<hex8>` nonce, calls production `send_imessage()`, verifies via chat.db, exits 0/1 for scripting
- **MODIFY** `agent/clapcheeks/cli.py` — wires `send_test` command into main group
- **MODIFY** `agent/pyproject.toml` — registers `manual` pytest mark
- **NEW** `agent/tests/test_chatdb_verifier.py` — 22 unit tests (all CI-safe, fake SQLite)
- **NEW** `agent/tests/test_e2e_outbound.py` — manual integration test (CI-skipped)

## How to run on Mac Mini after merge

```bash
god mac exec "cd ~/.clapcheeks && clapcheeks send-test +16199919355 --body 'Test from Clapcheeks'"
```

Or with the full integration test:

```bash
god mac exec "cd ~/.clapcheeks && RUN_E2E=1 python -m pytest tests/test_e2e_outbound.py -v -s"
```

## Test plan

- [x] `pytest agent/tests/test_chatdb_verifier.py` — 22 passed (unit, fake BLOB)
- [x] `pytest agent/tests/test_e2e_outbound.py` — 2 skipped in CI (correct)
- [ ] Manual: run `clapcheeks send-test +16199919355` on Mac Mini after merge, confirm PASS + ROWID + iPhone receives
- [ ] If FAIL: rollback the deploy

## Refs

- Verification standard: `.claude/rules/comms-must-be-verified.md`
- Existing sender: `agent/clapcheeks/imessage/sender.py` (production path, unchanged)
- Existing attributedBody decode: `agent/clapcheeks/voice/clone.py` (pattern reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)