### PR TITLE
feat(clapcheeks): AI-8807 unified cross-channel conversation thread

### DIFF
--- a/.planning/bussit/worker-4-PLAN.md
+++ b/.planning/bussit/worker-4-PLAN.md
@@ -1,0 +1,49 @@
+# AI-8807: Unified Cross-Channel Conversation Thread
+
+## Schema Investigation
+
+**Single table confirmed:** `clapcheeks_conversations` has:
+- `messages` JSONB array OR individual body/direction/sent_at columns
+- `channel` TEXT: 'platform' | 'imessage' (added by Phase F migration)
+- `match_id` TEXT linking to `clapcheeks_matches.external_id`
+
+**Match platform** stored in `clapcheeks_matches.platform`: 'tinder' | 'hinge' | 'bumble' | 'offline'
+
+**No separate Instagram message table** — all messages go through clapcheeks_conversations
+
+**No migration needed** — single unified table with channel column already exists.
+
+## Implementation Plan
+
+### 1. web/lib/matches/conversation.ts (NEW)
+- `getMatchConversationUnified(supabase, matchId, userId, platform?)` 
+- Queries clapcheeks_conversations for all rows matching user+match
+- Normalizes both message shapes (JSONB array vs row-per-message)
+- Enriches with per-message `channel` (derived from conversation row channel + match platform)
+- Dedupes by message id, sorts by sent_at, caps at 500
+
+### 2. web/lib/matches/types.ts (UPDATE)
+- Extend `ConversationChannel` to include specific platform channels
+- New type `UnifiedConversationMessage` with channel, platform, direction fields
+
+### 3. web/components/matches/ConversationThread.tsx (REWRITE)
+- Channel badges per message (Tinder=pink/flame, Hinge=purple, Bumble=yellow, IG=gradient, iMessage=blue)
+- Handoff markers: horizontal divider when channel changes between consecutive messages
+- Filter chips: All / Tinder / Hinge / Bumble / Instagram / iMessage
+- Day separators: midnight crossing
+- 60s direction grouping (no avatar repeat within same direction within 60s)
+
+### 4. web/app/(main)/matches/[id]/page.tsx (UPDATE)
+- Import and use `getMatchConversationUnified` 
+- Pass enriched messages to MatchProfileView
+- Also pass match platform for channel enrichment
+
+### 5. web/app/(main)/matches/[id]/conversation-thread.tsx (UPDATE)
+- Update ChatMessage type to include channel fields
+- The outer file owns the data type contract
+
+## Key Decisions
+- No migration needed (single unified table already)
+- ConversationThread.tsx (components/) is the shared component — update it
+- conversation-thread.tsx (app/) is the page-local "rich" version — update it  
+- The page.tsx loads data server-side and passes to client

--- a/web/app/(main)/matches/[id]/conversation-thread.tsx
+++ b/web/app/(main)/matches/[id]/conversation-thread.tsx
@@ -1,17 +1,18 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useRef, useState, useEffect } from 'react'
+import type { MessageChannel } from '@/lib/matches/conversation'
 
 /**
- * Conversation thread (iMessage-style) for a single match.
+ * Unified cross-channel conversation thread (AI-8807)
  *
- * Reads from clapcheeks_conversations via /api/matches/[id]/conversation
- * (server-side). Supports two storage shapes:
- *   1. Single row per (user_id, match_id, platform) with a `messages` JSONB
- *      array. Each entry: { is_from_me, text, sent_at, is_auto_sent? ... }.
+ * Shows messages from all platforms — Tinder, Hinge, Bumble, Instagram,
+ * iMessage — merged chronologically with channel badges and handoff markers.
+ *
+ * Reads from clapcheeks_conversations via server-side loadConversationMessages.
+ * Handles two storage shapes:
+ *   1. Single row per (user_id, match_id, platform) with a `messages` JSONB array.
  *   2. Many rows, one per message, with body/direction/sent_at/channel.
- *
- * We accept either shape and normalize into ChatMessage[] for rendering.
  */
 
 export type ChatMessage = {
@@ -20,13 +21,75 @@ export type ChatMessage = {
   is_from_me: boolean
   sent_at: string | null
   is_auto_sent?: boolean
-  channel?: string | null
+  channel?: MessageChannel | string | null
 }
 
-type Props = {
-  messages: ChatMessage[]
-  emptyHint?: string
+// ── Channel badge config ──────────────────────────────────────────────────────
+
+type BadgeConfig = {
+  label: string
+  // Tailwind classes for badge bg + text
+  badgeClass: string
+  // Tailwind classes for the outgoing bubble
+  bubbleClass: string
+  // Filter chip class
+  chipActiveClass: string
+  chipClass: string
 }
+
+const CHANNEL_CONFIG: Record<string, BadgeConfig> = {
+  tinder: {
+    label: 'Tinder',
+    badgeClass: 'bg-rose-500/20 text-rose-300 border-rose-500/30',
+    bubbleClass: 'bg-gradient-to-br from-rose-500 to-orange-500 text-white',
+    chipActiveClass: 'bg-rose-500/30 text-rose-200 border-rose-500/50',
+    chipClass: 'bg-white/5 text-white/50 border-white/10 hover:text-white/80',
+  },
+  hinge: {
+    label: 'Hinge',
+    badgeClass: 'bg-purple-500/20 text-purple-300 border-purple-500/30',
+    bubbleClass: 'bg-gradient-to-br from-purple-600 to-violet-700 text-white',
+    chipActiveClass: 'bg-purple-500/30 text-purple-200 border-purple-500/50',
+    chipClass: 'bg-white/5 text-white/50 border-white/10 hover:text-white/80',
+  },
+  bumble: {
+    label: 'Bumble',
+    badgeClass: 'bg-amber-500/20 text-amber-300 border-amber-500/30',
+    bubbleClass: 'bg-gradient-to-br from-amber-400 to-yellow-500 text-black',
+    chipActiveClass: 'bg-amber-500/30 text-amber-200 border-amber-500/50',
+    chipClass: 'bg-white/5 text-white/50 border-white/10 hover:text-white/80',
+  },
+  instagram: {
+    label: 'Instagram',
+    badgeClass: 'bg-pink-500/20 text-pink-300 border-pink-500/30',
+    bubbleClass: 'bg-gradient-to-br from-pink-500 via-red-500 to-orange-500 text-white',
+    chipActiveClass: 'bg-pink-500/30 text-pink-200 border-pink-500/50',
+    chipClass: 'bg-white/5 text-white/50 border-white/10 hover:text-white/80',
+  },
+  imessage: {
+    label: 'iMessage',
+    badgeClass: 'bg-blue-500/20 text-blue-300 border-blue-500/30',
+    bubbleClass: 'bg-gradient-to-br from-blue-500 to-blue-700 text-white',
+    chipActiveClass: 'bg-blue-500/30 text-blue-200 border-blue-500/50',
+    chipClass: 'bg-white/5 text-white/50 border-white/10 hover:text-white/80',
+  },
+  platform: {
+    label: 'App',
+    badgeClass: 'bg-white/10 text-white/60 border-white/15',
+    bubbleClass: 'bg-gradient-to-br from-pink-500 to-purple-600 text-white',
+    chipActiveClass: 'bg-white/20 text-white border-white/30',
+    chipClass: 'bg-white/5 text-white/50 border-white/10 hover:text-white/80',
+  },
+}
+
+const DEFAULT_BADGE: BadgeConfig = CHANNEL_CONFIG.platform
+
+function getChannelConfig(channel: string | null | undefined): BadgeConfig {
+  if (!channel) return DEFAULT_BADGE
+  return CHANNEL_CONFIG[channel.toLowerCase()] ?? DEFAULT_BADGE
+}
+
+// ── Date/time helpers ────────────────────────────────────────────────────────
 
 function formatDateDivider(d: Date): string {
   const today = new Date()
@@ -39,7 +102,7 @@ function formatDateDivider(d: Date): string {
   if (sameDay(d, today)) return 'Today'
   if (sameDay(d, yesterday)) return 'Yesterday'
   return d.toLocaleDateString(undefined, {
-    weekday: 'short',
+    weekday: 'long',
     month: 'short',
     day: 'numeric',
     year: d.getFullYear() === today.getFullYear() ? undefined : 'numeric',
@@ -59,10 +122,32 @@ function dayKey(d: Date): string {
   return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
 }
 
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type FilterChannel = 'all' | string
+
+type Props = {
+  messages: ChatMessage[]
+  emptyHint?: string
+}
+
+// ── Main component ───────────────────────────────────────────────────────────
+
 export default function ConversationThread({ messages, emptyHint }: Props) {
   const bottomRef = useRef<HTMLDivElement | null>(null)
   const [autoScroll, setAutoScroll] = useState(true)
+  const [activeFilter, setActiveFilter] = useState<FilterChannel>('all')
 
+  // Collect unique channels present in the conversation
+  const channelsPresent = useMemo(() => {
+    const seen = new Set<string>()
+    for (const m of messages) {
+      if (m.channel) seen.add(m.channel.toLowerCase())
+    }
+    return Array.from(seen).sort()
+  }, [messages])
+
+  // Sorted full list
   const sorted = useMemo(() => {
     return [...messages].sort((a, b) => {
       const aT = a.sent_at ? new Date(a.sent_at).getTime() : 0
@@ -70,6 +155,14 @@ export default function ConversationThread({ messages, emptyHint }: Props) {
       return aT - bT
     })
   }, [messages])
+
+  // Filtered list (for display)
+  const filtered = useMemo(() => {
+    if (activeFilter === 'all') return sorted
+    return sorted.filter(
+      (m) => (m.channel ?? 'platform').toLowerCase() === activeFilter,
+    )
+  }, [sorted, activeFilter])
 
   const summary = useMemo(() => {
     if (sorted.length === 0) return null
@@ -85,39 +178,28 @@ export default function ConversationThread({ messages, emptyHint }: Props) {
   useEffect(() => {
     if (!autoScroll) return
     bottomRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' })
-  }, [sorted.length, autoScroll])
+  }, [filtered.length, autoScroll])
 
   if (sorted.length === 0) {
     return (
       <div className="p-8 rounded-xl border border-white/10 bg-white/5 text-center">
-        <div className="text-3xl mb-2">{'\u{1F4AC}'}</div>
+        <div className="text-3xl mb-2">&#128172;</div>
         <p className="text-sm text-white/60">
           {emptyHint ??
-            'No conversation yet — drafts will appear here once exchanged.'}
+            'No conversation yet — messages will appear here once exchanged.'}
         </p>
       </div>
     )
   }
 
-  // Group consecutive messages by day for date dividers.
-  let lastKey: string | null = null
-  const groups: Array<{ key: string; date: Date; messages: ChatMessage[] }> = []
-  for (const msg of sorted) {
-    const d = msg.sent_at ? new Date(msg.sent_at) : new Date(0)
-    const k = dayKey(d)
-    if (k !== lastKey) {
-      groups.push({ key: k, date: d, messages: [msg] })
-      lastKey = k
-    } else {
-      groups[groups.length - 1].messages.push(msg)
-    }
-  }
+  // Build render groups: day groups containing render items (messages + handoff markers)
+  const renderItems = buildRenderItems(filtered)
 
   return (
     <div className="rounded-xl border border-white/10 bg-white/5 overflow-hidden">
       {/* Header summary */}
       {summary && (
-        <div className="px-4 py-3 border-b border-white/10 bg-black/30 text-[11px] text-white/60 flex flex-wrap gap-x-4 gap-y-1">
+        <div className="px-4 py-3 border-b border-white/10 bg-black/30 text-[11px] text-white/60 flex flex-wrap gap-x-4 gap-y-1 items-center">
           <span>
             <strong className="text-white/90">{summary.count}</strong>{' '}
             message{summary.count === 1 ? '' : 's'}
@@ -125,17 +207,13 @@ export default function ConversationThread({ messages, emptyHint }: Props) {
           {summary.first && (
             <span>
               First:{' '}
-              <span className="text-white/80">
-                {formatTimeStamp(summary.first)}
-              </span>
+              <span className="text-white/80">{formatTimeStamp(summary.first)}</span>
             </span>
           )}
           {summary.last && (
             <span>
               Latest:{' '}
-              <span className="text-white/80">
-                {formatTimeStamp(summary.last)}
-              </span>
+              <span className="text-white/80">{formatTimeStamp(summary.last)}</span>
             </span>
           )}
           <label className="ml-auto inline-flex items-center gap-1.5 cursor-pointer select-none text-white/50">
@@ -150,63 +228,284 @@ export default function ConversationThread({ messages, emptyHint }: Props) {
         </div>
       )}
 
+      {/* Channel filter chips */}
+      {channelsPresent.length > 1 && (
+        <div className="px-4 py-2 border-b border-white/10 flex gap-1.5 flex-wrap">
+          <FilterChip
+            label="All"
+            count={sorted.length}
+            active={activeFilter === 'all'}
+            onClick={() => setActiveFilter('all')}
+            activeClass="bg-white/20 text-white border-white/30"
+            inactiveClass="bg-white/5 text-white/50 border-white/10 hover:text-white/80"
+          />
+          {channelsPresent.map((ch) => {
+            const cfg = getChannelConfig(ch)
+            return (
+              <FilterChip
+                key={ch}
+                label={cfg.label}
+                count={sorted.filter((m) => (m.channel ?? 'platform').toLowerCase() === ch).length}
+                active={activeFilter === ch}
+                onClick={() => setActiveFilter(ch)}
+                activeClass={cfg.chipActiveClass}
+                inactiveClass={cfg.chipClass}
+              />
+            )
+          })}
+        </div>
+      )}
+
+      {/* Empty filtered state */}
+      {filtered.length === 0 && (
+        <div className="p-8 text-center text-sm text-white/50">
+          No messages on{' '}
+          {getChannelConfig(activeFilter !== 'all' ? activeFilter : null).label} yet.
+        </div>
+      )}
+
       {/* Scroll body */}
       <div className="max-h-[70vh] overflow-y-auto px-4 py-4 space-y-4">
-        {groups.map((group) => (
-          <div key={group.key}>
-            <div className="flex items-center gap-3 mb-3">
-              <div className="flex-1 h-px bg-white/10" />
-              <div className="text-[10px] uppercase tracking-wider text-white/40">
-                {group.date.getTime() === 0
-                  ? 'No date'
-                  : formatDateDivider(group.date)}
-              </div>
-              <div className="flex-1 h-px bg-white/10" />
-            </div>
-            <div className="space-y-1.5">
-              {group.messages.map((m) => (
-                <Bubble key={m.id} msg={m} />
-              ))}
-            </div>
-          </div>
-        ))}
+        {renderItems.map((item) => {
+          if (item.type === 'day') {
+            return (
+              <DayDivider key={item.key} label={formatDateDivider(item.date)} />
+            )
+          }
+          if (item.type === 'handoff') {
+            return (
+              <HandoffMarker
+                key={item.key}
+                fromChannel={item.fromChannel}
+                toChannel={item.toChannel}
+                date={item.date}
+              />
+            )
+          }
+          return (
+            <Bubble
+              key={item.msg.id}
+              msg={item.msg}
+              showBadge={item.showBadge}
+              groupedWithPrev={item.groupedWithPrev}
+            />
+          )
+        })}
         <div ref={bottomRef} />
       </div>
     </div>
   )
 }
 
-function Bubble({ msg }: { msg: ChatMessage }) {
+// ── Render item types ────────────────────────────────────────────────────────
+
+type RenderItem =
+  | { type: 'day'; key: string; date: Date }
+  | {
+      type: 'handoff'
+      key: string
+      fromChannel: string
+      toChannel: string
+      date: Date | null
+    }
+  | {
+      type: 'bubble'
+      key: string
+      msg: ChatMessage
+      showBadge: boolean
+      groupedWithPrev: boolean
+    }
+
+function buildRenderItems(msgs: ChatMessage[]): RenderItem[] {
+  const items: RenderItem[] = []
+  let lastDayKey: string | null = null
+  let prevChannel: string | null = null
+  let prevIsMe: boolean | null = null
+  let prevSentAt: number | null = null
+
+  for (let i = 0; i < msgs.length; i++) {
+    const m = msgs[i]
+    const d = m.sent_at ? new Date(m.sent_at) : null
+    const dk = d ? dayKey(d) : 'no-date'
+    const ch = (m.channel ?? 'platform').toLowerCase()
+
+    // Day separator
+    if (dk !== lastDayKey) {
+      items.push({
+        type: 'day',
+        key: `day-${dk}-${i}`,
+        date: d ?? new Date(0),
+      })
+      lastDayKey = dk
+    }
+
+    // Handoff marker: channel changed and consecutive messages on different channels
+    if (prevChannel !== null && ch !== prevChannel) {
+      items.push({
+        type: 'handoff',
+        key: `handoff-${i}-${prevChannel}-${ch}`,
+        fromChannel: prevChannel,
+        toChannel: ch,
+        date: d,
+      })
+    }
+
+    // 60s direction grouping: suppress badge/avatar if same direction within 60s
+    const thisTime = d ? d.getTime() : null
+    const groupedWithPrev =
+      prevIsMe === m.is_from_me &&
+      prevSentAt !== null &&
+      thisTime !== null &&
+      Math.abs(thisTime - prevSentAt) < 60_000 &&
+      prevChannel === ch
+
+    // Show channel badge on first message of a new channel block
+    const showBadge = prevChannel !== ch || i === 0
+
+    items.push({
+      type: 'bubble',
+      key: m.id,
+      msg: m,
+      showBadge,
+      groupedWithPrev,
+    })
+
+    prevChannel = ch
+    prevIsMe = m.is_from_me
+    prevSentAt = thisTime
+  }
+
+  return items
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+function DayDivider({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-3 py-1">
+      <div className="flex-1 h-px bg-white/10" />
+      <div className="text-[10px] uppercase tracking-wider text-white/40 whitespace-nowrap">
+        {label}
+      </div>
+      <div className="flex-1 h-px bg-white/10" />
+    </div>
+  )
+}
+
+function HandoffMarker({
+  fromChannel,
+  toChannel,
+  date,
+}: {
+  fromChannel: string
+  toChannel: string
+  date: Date | null
+}) {
+  const toCfg = getChannelConfig(toChannel)
+  const dateStr = date ? formatTimeStamp(date) : null
+  return (
+    <div className="flex items-center gap-3 py-2">
+      <div className="flex-1 h-px bg-white/10" />
+      <div
+        className={`px-3 py-1 rounded-full border text-[10px] font-medium tracking-wide ${toCfg.badgeClass}`}
+      >
+        Moved to {toCfg.label}
+        {dateStr ? ` · ${dateStr}` : ''}
+      </div>
+      <div className="flex-1 h-px bg-white/10" />
+    </div>
+  )
+}
+
+function Bubble({
+  msg,
+  showBadge,
+  groupedWithPrev,
+}: {
+  msg: ChatMessage
+  showBadge: boolean
+  groupedWithPrev: boolean
+}) {
   const isMe = msg.is_from_me
+  const ch = (msg.channel ?? 'platform').toLowerCase()
+  const cfg = getChannelConfig(ch)
   const stamp = msg.sent_at ? new Date(msg.sent_at) : null
   const tooltip = stamp
-    ? `${formatTimeStamp(stamp)}${msg.channel ? ` · ${msg.channel}` : ''}`
+    ? `${formatTimeStamp(stamp)}${msg.channel ? ` · ${cfg.label}` : ''}`
     : msg.channel ?? ''
 
   return (
     <div
-      className={`flex ${isMe ? 'justify-end' : 'justify-start'} group`}
+      className={`flex ${isMe ? 'justify-end' : 'justify-start'} group ${groupedWithPrev ? 'mt-0.5' : 'mt-1.5'}`}
     >
       <div
         className={`max-w-[78%] px-3.5 py-2 rounded-2xl text-sm leading-snug whitespace-pre-wrap break-words shadow-sm ${
-          isMe
-            ? 'bg-gradient-to-br from-pink-500 to-purple-600 text-white rounded-br-md'
-            : 'bg-white/10 text-white/90 rounded-bl-md'
+          isMe ? `${cfg.bubbleClass} rounded-br-md` : 'bg-white/10 text-white/90 rounded-bl-md'
         }`}
         title={tooltip}
       >
         {msg.text || (
           <span className="italic text-white/50">[empty message]</span>
         )}
-        {(msg.is_auto_sent || msg.channel === 'imessage') && isMe && (
-          <span className="ml-2 text-[10px] uppercase tracking-wider opacity-75">
-            {msg.is_auto_sent ? '\u{1F916} auto' : 'iMessage'}
-          </span>
-        )}
+
+        {/* Channel badge + auto indicator */}
+        <div className={`flex items-center gap-1 mt-1 ${isMe ? 'justify-end' : 'justify-start'}`}>
+          {showBadge && (
+            <span
+              className={`text-[9px] px-1.5 py-px rounded border uppercase tracking-wide ${
+                isMe
+                  ? 'bg-black/20 text-white/60 border-white/20'
+                  : cfg.badgeClass
+              }`}
+            >
+              {cfg.label}
+            </span>
+          )}
+          {msg.is_auto_sent && isMe && (
+            <span className="text-[9px] uppercase tracking-wide opacity-75">
+              &#129302; auto
+            </span>
+          )}
+        </div>
+
+        {/* Hover timestamp */}
         <div className="opacity-0 group-hover:opacity-100 transition-opacity text-[10px] mt-0.5 text-white/70">
           {stamp ? formatTimeStamp(stamp) : ''}
         </div>
       </div>
     </div>
+  )
+}
+
+function FilterChip({
+  label,
+  count,
+  active,
+  onClick,
+  activeClass,
+  inactiveClass,
+}: {
+  label: string
+  count: number
+  active: boolean
+  onClick: () => void
+  activeClass: string
+  inactiveClass: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-2.5 py-1 rounded-full border text-[11px] font-medium transition-colors ${
+        active ? activeClass : inactiveClass
+      }`}
+    >
+      {label}
+      <span
+        className={`ml-1 text-[10px] ${active ? 'opacity-80' : 'opacity-50'}`}
+      >
+        {count}
+      </span>
+    </button>
   )
 }

--- a/web/app/(main)/matches/[id]/page.tsx
+++ b/web/app/(main)/matches/[id]/page.tsx
@@ -2,120 +2,12 @@ import type { Metadata } from 'next'
 import { createClient } from '@/lib/supabase/server'
 import { redirect, notFound } from 'next/navigation'
 import MatchProfileView from './match-profile-view'
+import { getMatchConversationUnified } from '@/lib/matches/conversation'
 import type { ChatMessage } from './conversation-thread'
 
 export const metadata: Metadata = {
   title: 'Match Profile - Clapcheeks',
   description: 'Photos, bio, interests, and conversation strategy.',
-}
-
-type RawMessageEntry = {
-  id?: string | number
-  text?: string | null
-  body?: string | null
-  message?: string | null
-  is_from_me?: boolean | number | null
-  from_me?: boolean | number | null
-  direction?: string | null
-  sender?: string | null
-  sent_at?: string | null
-  date?: string | null
-  created_at?: string | null
-  is_auto_sent?: boolean | null
-  is_auto?: boolean | null
-  is_bot?: boolean | null
-  channel?: string | null
-}
-
-function coerceBool(v: unknown): boolean {
-  if (typeof v === 'boolean') return v
-  if (typeof v === 'number') return v !== 0
-  if (typeof v === 'string') return ['1', 'true', 'yes', 'me'].includes(v.toLowerCase())
-  return false
-}
-
-function entryToMessage(
-  entry: RawMessageEntry,
-  fallbackId: string,
-  rowChannel?: string | null,
-): ChatMessage {
-  const text = entry.text ?? entry.body ?? entry.message ?? ''
-  let isFromMe: boolean
-  if (entry.is_from_me != null) {
-    isFromMe = coerceBool(entry.is_from_me)
-  } else if (entry.from_me != null) {
-    isFromMe = coerceBool(entry.from_me)
-  } else if (entry.direction) {
-    isFromMe = entry.direction === 'outgoing' || entry.direction === 'out'
-  } else if (entry.sender) {
-    const s = entry.sender.toLowerCase()
-    isFromMe = s === 'me' || s === 'self' || s === 'julian' || s === 'operator'
-  } else {
-    isFromMe = false
-  }
-  const sentAt = entry.sent_at ?? entry.date ?? entry.created_at ?? null
-  return {
-    id: String(entry.id ?? fallbackId),
-    text: typeof text === 'string' ? text : '',
-    is_from_me: isFromMe,
-    sent_at: sentAt,
-    is_auto_sent: coerceBool(entry.is_auto_sent ?? entry.is_auto ?? entry.is_bot),
-    channel: entry.channel ?? rowChannel ?? null,
-  }
-}
-
-async function loadConversationMessages(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  userId: string,
-  externalId: string | null | undefined,
-): Promise<ChatMessage[]> {
-  if (!externalId) return []
-  // Pull every conversation row for this match — there may be one per
-  // platform/channel (tinder + imessage etc).
-  const { data, error } = await (supabase as any)
-    .from('clapcheeks_conversations')
-    .select('*')
-    .eq('user_id', userId)
-    .eq('match_id', externalId)
-    .order('last_message_at', { ascending: true, nullsFirst: true })
-  if (error || !Array.isArray(data)) return []
-
-  const out: ChatMessage[] = []
-  for (let r = 0; r < data.length; r++) {
-    const row = data[r] as Record<string, unknown>
-    const channel = (row.channel as string | null | undefined) ?? null
-
-    // Shape A: row has a `messages` JSONB array of entries.
-    const msgs = row.messages
-    if (Array.isArray(msgs)) {
-      msgs.forEach((m, i) => {
-        if (!m || typeof m !== 'object') return
-        out.push(entryToMessage(m as RawMessageEntry, `${row.id}-${i}`, channel))
-      })
-    }
-
-    // Shape B: row IS a single message (body/direction/sent_at columns).
-    if (typeof row.body === 'string' && row.body) {
-      out.push(
-        entryToMessage(
-          {
-            id: row.id as string | undefined,
-            text: row.body as string,
-            direction: row.direction as string | null | undefined,
-            sent_at:
-              (row.sent_at as string | null | undefined) ??
-              (row.last_message_at as string | null | undefined) ??
-              (row.created_at as string | null | undefined) ??
-              null,
-            channel,
-          },
-          `${row.id ?? r}-row`,
-          channel,
-        ),
-      )
-    }
-  }
-  return out
 }
 
 export default async function MatchDetailPage({
@@ -149,11 +41,23 @@ export default async function MatchDetailPage({
   if (herPhone) memoHandle = herPhone
   else if (externalId) memoHandle = platform ? `${platform}:${externalId}` : externalId
 
-  const conversation = await loadConversationMessages(
-    supabase,
+  // Unified cross-channel conversation fetch (AI-8807)
+  const unifiedMessages = await getMatchConversationUnified(
+    supabase as any,
     user.id,
     externalId,
+    platform,
   )
+
+  // Map UnifiedMessage -> ChatMessage (compatible type)
+  const conversation: ChatMessage[] = unifiedMessages.map((m) => ({
+    id: m.id,
+    text: m.text,
+    is_from_me: m.is_from_me,
+    sent_at: m.sent_at,
+    is_auto_sent: m.is_auto_sent,
+    channel: m.channel,
+  }))
 
   // Server-side initial memo fetch (best-effort; client refetches if needed).
   let memoInitial: { content: string; updated_at: string | null } | null = null

--- a/web/components/matches/ConversationThread.tsx
+++ b/web/components/matches/ConversationThread.tsx
@@ -2,6 +2,33 @@
 
 import { ConversationMessage, formatTimeAgo } from '@/lib/matches/types'
 
+// Channel badge styles for all supported platforms (AI-8807)
+const CHANNEL_BADGES: Record<string, string> = {
+  tinder:    'bg-rose-500/20 text-rose-300 border-rose-500/30',
+  hinge:     'bg-purple-500/20 text-purple-300 border-purple-500/30',
+  bumble:    'bg-amber-500/20 text-amber-300 border-amber-500/30',
+  instagram: 'bg-pink-500/20 text-pink-300 border-pink-500/30',
+  imessage:  'bg-blue-500/20 text-blue-300 border-blue-500/30',
+  platform:  'bg-white/10 text-white/60 border-white/15',
+}
+
+const CHANNEL_LABELS: Record<string, string> = {
+  tinder:    'Tinder',
+  hinge:     'Hinge',
+  bumble:    'Bumble',
+  instagram: 'Instagram',
+  imessage:  'iMessage',
+  platform:  'App',
+}
+
+function getChannelBadge(channel: string | null | undefined) {
+  const key = (channel ?? 'platform').toLowerCase()
+  return {
+    cls: CHANNEL_BADGES[key] ?? CHANNEL_BADGES.platform,
+    label: CHANNEL_LABELS[key] ?? channel ?? 'App',
+  }
+}
+
 type Props = {
   messages: ConversationMessage[]
   matchName?: string | null
@@ -23,6 +50,7 @@ export default function ConversationThread({ messages, matchName }: Props) {
     <div className="bg-white/[0.03] border border-white/10 rounded-xl p-4 space-y-3 max-h-[600px] overflow-y-auto">
       {messages.map((msg, i) => {
         const isOut = msg.direction === 'outgoing'
+        const badge = getChannelBadge(msg.channel)
         return (
           <div
             key={msg.id ?? i}
@@ -42,14 +70,11 @@ export default function ConversationThread({ messages, matchName }: Props) {
                 }`}
               >
                 <span>{isOut ? 'You' : matchName ?? 'Her'} · {formatTimeAgo(msg.sent_at)}</span>
-                {msg.channel === 'imessage' && (
-                  <span className="px-1.5 py-px rounded bg-blue-500/20 text-blue-300 border border-blue-500/30 text-[9px] uppercase">
-                    iMessage
-                  </span>
-                )}
-                {msg.channel === 'platform' && msg.platform && (
-                  <span className="px-1.5 py-px rounded bg-white/10 text-white/60 border border-white/15 text-[9px] uppercase">
-                    {msg.platform}
+                {msg.channel && (
+                  <span
+                    className={`px-1.5 py-px rounded border text-[9px] uppercase ${badge.cls}`}
+                  >
+                    {badge.label}
                   </span>
                 )}
               </div>

--- a/web/lib/matches/conversation.ts
+++ b/web/lib/matches/conversation.ts
@@ -1,0 +1,187 @@
+/**
+ * Unified cross-channel conversation fetcher (AI-8807)
+ *
+ * Merges messages from clapcheeks_conversations across all channels
+ * (tinder, hinge, bumble, instagram, imessage) into a single sorted,
+ * deduped list. Handles two storage shapes:
+ *   1. Row has a `messages` JSONB array of { text, is_from_me, sent_at, ... }
+ *   2. Row IS a single message with body/direction/sent_at columns
+ */
+
+// All possible channel labels emitted by the unified fetcher
+export type MessageChannel =
+  | 'tinder'
+  | 'hinge'
+  | 'bumble'
+  | 'instagram'
+  | 'imessage'
+  | 'platform'  // legacy / unknown platform
+
+export type UnifiedMessage = {
+  id: string
+  text: string
+  is_from_me: boolean
+  sent_at: string | null
+  is_auto_sent?: boolean
+  channel: MessageChannel
+}
+
+type RawMessageEntry = {
+  id?: string | number
+  text?: string | null
+  body?: string | null
+  message?: string | null
+  is_from_me?: boolean | number | null
+  from_me?: boolean | number | null
+  direction?: string | null
+  sender?: string | null
+  sent_at?: string | null
+  date?: string | null
+  created_at?: string | null
+  is_auto_sent?: boolean | null
+  is_auto?: boolean | null
+  is_bot?: boolean | null
+  channel?: string | null
+}
+
+function coerceBool(v: unknown): boolean {
+  if (typeof v === 'boolean') return v
+  if (typeof v === 'number') return v !== 0
+  if (typeof v === 'string') return ['1', 'true', 'yes', 'me'].includes(v.toLowerCase())
+  return false
+}
+
+/**
+ * Map a conversation row's channel + match platform to a typed MessageChannel.
+ * If the conversation channel is 'imessage', always return 'imessage'.
+ * Otherwise use the match's platform (tinder/hinge/bumble/instagram).
+ */
+function resolveChannel(
+  rowChannel: string | null | undefined,
+  matchPlatform: string | null | undefined,
+): MessageChannel {
+  if (rowChannel === 'imessage') return 'imessage'
+  if (rowChannel === 'instagram') return 'instagram'
+  const p = (matchPlatform ?? '').toLowerCase()
+  if (p === 'tinder') return 'tinder'
+  if (p === 'hinge') return 'hinge'
+  if (p === 'bumble') return 'bumble'
+  if (p === 'instagram') return 'instagram'
+  // Platform messages from a match that has no specific platform mapping
+  return 'platform'
+}
+
+function entryToMessage(
+  entry: RawMessageEntry,
+  fallbackId: string,
+  channel: MessageChannel,
+): UnifiedMessage {
+  const text = entry.text ?? entry.body ?? entry.message ?? ''
+  let isFromMe: boolean
+  if (entry.is_from_me != null) {
+    isFromMe = coerceBool(entry.is_from_me)
+  } else if (entry.from_me != null) {
+    isFromMe = coerceBool(entry.from_me)
+  } else if (entry.direction) {
+    isFromMe = entry.direction === 'outgoing' || entry.direction === 'out'
+  } else if (entry.sender) {
+    const s = entry.sender.toLowerCase()
+    isFromMe = s === 'me' || s === 'self' || s === 'julian' || s === 'operator'
+  } else {
+    isFromMe = false
+  }
+  const sentAt = entry.sent_at ?? entry.date ?? entry.created_at ?? null
+  return {
+    id: String(entry.id ?? fallbackId),
+    text: typeof text === 'string' ? text : '',
+    is_from_me: isFromMe,
+    sent_at: sentAt,
+    is_auto_sent: coerceBool(entry.is_auto_sent ?? entry.is_auto ?? entry.is_bot),
+    channel,
+  }
+}
+
+/**
+ * Fetch + normalize all conversation messages for a match across all channels.
+ * @param supabase  Supabase client (server or browser)
+ * @param matchId   The match's UUID (clapcheeks_matches.id)
+ * @param userId    Auth user UUID
+ * @param externalId  The match's external_id (used by clapcheeks_conversations)
+ * @param matchPlatform  The match's platform ('tinder'|'hinge'|'bumble'|...)
+ * @returns Sorted, deduped list of up to 500 messages
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function getMatchConversationUnified(
+  supabase: any,
+  userId: string,
+  externalId: string | null | undefined,
+  matchPlatform?: string | null,
+): Promise<UnifiedMessage[]> {
+  if (!externalId) return []
+
+  const { data, error } = await supabase
+    .from('clapcheeks_conversations')
+    .select('*')
+    .eq('user_id', userId)
+    .eq('match_id', externalId)
+    .order('last_message_at', { ascending: true, nullsFirst: true })
+
+  if (error || !Array.isArray(data)) return []
+
+  const out: UnifiedMessage[] = []
+  const seen = new Set<string>()
+
+  for (let r = 0; r < data.length; r++) {
+    const row = data[r] as Record<string, unknown>
+    const rowChannel = (row.channel as string | null | undefined) ?? null
+    const channel = resolveChannel(rowChannel, matchPlatform)
+
+    // Shape A: row has a `messages` JSONB array
+    const msgs = row.messages
+    if (Array.isArray(msgs)) {
+      msgs.forEach((m, i) => {
+        if (!m || typeof m !== 'object') return
+        const msg = entryToMessage(m as RawMessageEntry, `${row.id}-${i}`, channel)
+        if (!seen.has(msg.id)) {
+          seen.add(msg.id)
+          out.push(msg)
+        }
+      })
+    }
+
+    // Shape B: row IS a single message (body/direction/sent_at columns)
+    if (typeof row.body === 'string' && row.body) {
+      const rowId = String(row.id ?? `${r}-row`)
+      if (!seen.has(rowId)) {
+        seen.add(rowId)
+        out.push(
+          entryToMessage(
+            {
+              id: row.id as string | undefined,
+              text: row.body as string,
+              direction: row.direction as string | null | undefined,
+              sent_at:
+                (row.sent_at as string | null | undefined) ??
+                (row.last_message_at as string | null | undefined) ??
+                (row.created_at as string | null | undefined) ??
+                null,
+              channel: rowChannel,
+            },
+            `${rowId}`,
+            channel,
+          ),
+        )
+      }
+    }
+  }
+
+  // Sort chronologically; messages with no date go to front
+  out.sort((a, b) => {
+    const aT = a.sent_at ? new Date(a.sent_at).getTime() : 0
+    const bT = b.sent_at ? new Date(b.sent_at).getTime() : 0
+    return aT - bT
+  })
+
+  // Cap at 500 (most recent)
+  return out.length > 500 ? out.slice(out.length - 500) : out
+}

--- a/web/lib/matches/types.ts
+++ b/web/lib/matches/types.ts
@@ -138,7 +138,8 @@ export type MatchListFilters = {
   minScore: number
 }
 
-export type ConversationChannel = 'platform' | 'imessage'
+// Unified channel type — includes specific platform names (AI-8807)
+export type ConversationChannel = 'platform' | 'imessage' | 'tinder' | 'hinge' | 'bumble' | 'instagram'
 
 export type ConversationMessage = {
   id?: string


### PR DESCRIPTION
## Summary

- **Schema decision:** Single unified table — `clapcheeks_conversations` already has a `channel` column ('platform' | 'imessage'). No migration needed. The match's `platform` column (tinder/hinge/bumble) is used to resolve the channel for platform-type conversations.
- **New fetcher** `web/lib/matches/conversation.ts`: `getMatchConversationUnified()` — handles JSONB-array and row-per-message shapes, dedupes by ID, sorts chronologically, caps at 500 messages
- **Rewritten ConversationThread** `web/app/(main)/matches/[id]/conversation-thread.tsx`:
  - Channel badges: Tinder (rose), Hinge (purple), Bumble (amber), Instagram (pink gradient), iMessage (blue)
  - Handoff markers: horizontal divider with channel-tinted label when consecutive messages switch channels
  - Filter chips: All / Tinder / Hinge / Bumble / Instagram / iMessage (only shows channels with messages)
  - Day separators: midnight crossings (e.g. "Tuesday, Apr 27")
  - 60s direction grouping: no badge repeat for same-direction messages within 60s on same channel
- **Updated** `web/app/(main)/matches/[id]/page.tsx` to use unified fetcher
- **Updated** `web/components/matches/ConversationThread.tsx` with full badge support for all platforms

## Acceptance Criteria

- [x] Messages from all channels merged chronologically
- [x] Channel badges per message (platform-colored)
- [x] Handoff marker when channel changes between consecutive messages
- [x] Filter chips above thread (All + per-channel, only if >1 channel present)
- [x] Day separators on midnight crossings
- [x] 60s direction grouping (no badge repeat)
- [x] `tsc --noEmit` — no NEW errors from our files
- [x] Build pre-existing failures unchanged (49 errors from missing packages, existed before this PR)
- [x] No migration needed (single unified table)

## Notes for Reviewer

- Out of scope per spec: reactions/tapbacks (AI-8808), AI on/off toggle (AI-8809), realtime live-append (AI-8809)
- `web/components/matches/ConversationThread.tsx` (shared component) also updated with channel badges for backward compatibility with MatchDetail.tsx
- Screenshot placeholder: [needs live test data to screenshot]

🤖 Generated with [Claude Code](https://claude.com/claude-code)