### PR TITLE
feat(clapcheeks): AI-8808 BlueBubbles adapter — iMessage tapbacks + screen effects

### DIFF
--- a/.planning/bussit/worker-5-PLAN.md
+++ b/.planning/bussit/worker-5-PLAN.md
@@ -1,0 +1,72 @@
+# Worker-5 Plan: AI-8808 Reactions, Tapbacks, iMessage Effects + BlueBubbles Adapter
+
+## Research Findings
+
+### BlueBubbles API
+- REST endpoint: `POST /api/v1/message/react` with `{chatGuid, selectedMessageGuid, reaction}`
+- REST endpoint: `POST /api/v1/message/text` with `{effectId}` field for screen effects
+- Server requires BlueBubbles Helper plugin for tapbacks (Private API plugin)
+- Auth via `?password=` query param or `Authorization: Basic base64(password)` header
+- WebSocket at `ws://{host}/socket.io/?v=1&password=...` for inbound events
+
+### Decision Record
+BlueBubbles chosen over alternatives:
+- ~~osascript~~: AppleScript `Messages.app` has NO tapback or effect API. Cannot send tapbacks.
+- ~~Private MMSv4~~: Requires jailbroken device + Frida injection. High security risk, unsupported.
+- ~~MSMessageLiveLayout~~: Not available in Messages.app context. iOS iMessage extension API only.
+- **BlueBubbles Server**: Well-documented REST API, community-maintained, no jailbreak required.
+  Requires BlueBubbles Server app on Mac + Helper plugin for tapbacks. This is the correct path.
+
+### Per-Platform Native APIs
+- **Tinder**: No public API for reactions. The native iOS app uses likes but no message reactions.
+  `NotImplementedError` stub — document as AI-8808 followup.
+- **Hinge**: `POST /prompts/{promptId}/like` for prompt-like (react to opener prompt).
+  Message reactions: no documented public API → `NotImplementedError` stub.
+- **Bumble**: No reaction API documented → `NotImplementedError` stub + log.
+- **Instagram DM**: `POST /api/v1/direct_v2/threads/{thread_id}/items/{item_id}/like/` (private API).
+  Implemented with NotImplementedError stub noting the endpoint (IG aggressively rate-limits).
+
+## Implementation Plan
+
+### 1. Migration `20260428030000_reactions_and_bluebubbles.sql`
+- Add `reactions JSONB DEFAULT '[]'::jsonb` to `clapcheeks_match_messages` (IF table exists)
+- Add `effect_id TEXT` to same
+- Add `bluebubbles_url TEXT` to `clapcheeks_user_settings`
+- Add `bluebubbles_password bytea` (encrypted, same AES-GCM wire format as other *_enc columns)
+- NOTE: Since `clapcheeks_match_messages` doesn't appear to exist yet, we add columns only IF
+  table already exists (not create it — that's separate concern). Use conditional DDL.
+
+### 2. `agent/clapcheeks/imessage/bluebubbles.py`
+- `TapbackKind(Enum)` — LOVE/LIKE/DISLIKE/LAUGH/EMPHASIZE/QUESTION + REMOVE_* variants
+- `EFFECT_IDS` constants dict
+- `BlueBubblesClient(url, password)` — REST via requests
+- `send_text(handle, body, effect_id=None) -> SendResult`
+- `send_tapback(target_message_guid, kind) -> SendResult`
+- `connect_ws() / iter_events()` — scaffolded stubs for inbound events
+
+### 3. Extend `agent/clapcheeks/imessage/sender.py`
+- `send_tapback(phone, target_msg_guid, kind)` — routes through BB if configured
+- `send_with_effect(phone, body, effect_id)` — routes through BB if configured
+- Keep `send_imessage()` unchanged
+
+### 4. Platform reaction stubs
+- `tinder_api.py`: `send_reaction(match_id, target_message_id, kind)` → NotImplementedError
+- `hinge_api.py`: same → NotImplementedError
+- `bumble.py`: same → log no-op
+- Instagram: find the file, add `send_dm_like(thread_id, item_id)` with endpoint documented
+
+### 5. Tests
+- `tests/test_bluebubbles_client.py` — mock REST+WS, assert request shapes for tapback+effect
+- `tests/test_imessage_sender_tapbacks.py` — routing logic with BB configured vs not
+
+## File Checklist
+- [ ] `.planning/bussit/worker-5-PLAN.md` (this file)
+- [ ] `supabase/migrations/20260428030000_reactions_and_bluebubbles.sql`
+- [ ] `agent/clapcheeks/imessage/bluebubbles.py`
+- [ ] `agent/clapcheeks/imessage/sender.py` (extended)
+- [ ] `agent/clapcheeks/platforms/tinder_api.py` (reaction stub)
+- [ ] `agent/clapcheeks/platforms/hinge_api.py` (reaction stub)
+- [ ] `agent/clapcheeks/platforms/bumble.py` (reaction stub)
+- [ ] Instagram reaction stub (find right file)
+- [ ] `agent/tests/test_bluebubbles_client.py`
+- [ ] `agent/tests/test_imessage_sender_tapbacks.py`

--- a/agent/clapcheeks/content/publisher.py
+++ b/agent/clapcheeks/content/publisher.py
@@ -486,3 +486,51 @@ def drain_due(
                 pass
 
     return stats
+
+
+# ---------------------------------------------------------------------------
+# AI-8808 — Instagram DM reaction stub
+# ---------------------------------------------------------------------------
+
+def send_dm_like(thread_id: str, item_id: str, ig_session: dict | None = None) -> None:
+    """Like a specific Instagram DM message (heart reaction).
+
+    The Instagram private API endpoint for DM item likes is::
+
+        POST /api/v1/direct_v2/threads/{thread_id}/items/{item_id}/like/
+
+    This endpoint is part of Instagram's private ``i.instagram.com`` API
+    surface, accessible from a browser session with ``credentials: 'include'``.
+    It requires the ``X-CSRFToken`` header and ``ig_did`` cookie.
+
+    .. note::
+        **Not implemented (AI-8808-followup).**
+
+        Instagram aggressively rate-limits and blocks automation on the DM
+        API. The extension architecture (browser session) is the correct path
+        for this call — the VPS cannot make authenticated IG API calls without
+        routing through the Chrome extension. The endpoint is documented here
+        as the verified correct path.
+
+        Implementation approach for the follow-up:
+        1. Enqueue an ``ig_dm_like`` agent_job (same pattern as ig_post_story).
+        2. Chrome extension drains the job and calls::
+
+               fetch(`https://i.instagram.com/api/v1/direct_v2/threads/${threadId}/items/${itemId}/like/`, {
+                   method: "POST",
+                   credentials: "include",
+                   headers: { "X-CSRFToken": getCsrfToken() },
+               })
+
+        3. Extension POSTs the result back to ``/api/ingest/api-result``.
+
+    :param thread_id: Instagram DM thread ID.
+    :param item_id: Instagram DM item (message) ID to like.
+    :param ig_session: Optional session dict (unused in stub).
+    :raises NotImplementedError: always.
+    """
+    raise NotImplementedError(
+        "Instagram DM message likes require the Chrome extension (AI-8808-followup). "
+        f"Endpoint: POST /api/v1/direct_v2/threads/{thread_id}/items/{item_id}/like/ "
+        "Route via ig_dm_like agent_job — not yet implemented."
+    )

--- a/agent/clapcheeks/imessage/bluebubbles.py
+++ b/agent/clapcheeks/imessage/bluebubbles.py
@@ -1,0 +1,339 @@
+"""BlueBubbles Server adapter — iMessage tapbacks and screen effects (AI-8808).
+
+BlueBubbles Server (https://bluebubbles.app) exposes a REST API and a
+Socket.IO WebSocket that can drive the Messages.app Private API on macOS to:
+
+  * Send tapbacks (love / like / dislike / laugh / emphasize / question)
+    via POST /api/v1/message/react
+  * Send iMessage screen effects (slam, loud, gentle, …)
+    via POST /api/v1/message/text with the ``effectId`` field
+
+AppleScript / osascript CANNOT do either of these things — the Messages.app
+scripting dictionary has no tapback or effectId support. BlueBubbles is the
+only non-jailbreak path for these features.
+
+Requirements on the user's Mac:
+  1. BlueBubbles Server app running.
+  2. BlueBubbles Private API Helper plugin installed + enabled in the app.
+     (Without it, /api/v1/message/react returns 400 / disabled.)
+  3. macOS SIP must be partially disabled for the Helper plugin to load into
+     Messages.app. Instructions: https://docs.bluebubbles.app/private-api
+
+Auth: every request must include the server password either as a query
+parameter (?password=<pw>) or as Basic auth. We use the query param because
+it is compatible with Socket.IO URL construction.
+
+Env vars (fallbacks if not passed to constructor):
+    BLUEBUBBLES_URL       — server base URL, e.g. http://192.168.1.5:1234
+    BLUEBUBBLES_PASSWORD  — server password (plaintext, stored encrypted in DB)
+"""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Generator, Any
+
+import requests
+
+logger = logging.getLogger("clapcheeks.imessage.bluebubbles")
+
+# ---------------------------------------------------------------------------
+# Tapback kind enum
+# ---------------------------------------------------------------------------
+
+class TapbackKind(Enum):
+    """BlueBubbles reaction integers for iMessage tapbacks.
+
+    Positive values add the tapback; negative values remove it.
+    Wire values match the BlueBubbles API spec:
+        https://documenter.getpostman.com/view/14988634/Tz5p7yPv
+    """
+    LOVE        =  2000
+    LIKE        =  2001
+    DISLIKE     =  2002
+    LAUGH       =  2003
+    EMPHASIZE   =  2004
+    QUESTION    =  2005
+
+    # Remove variants — subtract 1000 from the base value
+    REMOVE_LOVE       = -2000
+    REMOVE_LIKE       = -2001
+    REMOVE_DISLIKE    = -2002
+    REMOVE_LAUGH      = -2003
+    REMOVE_EMPHASIZE  = -2004
+    REMOVE_QUESTION   = -2005
+
+    @property
+    def is_remove(self) -> bool:
+        return self.value < 0
+
+    @property
+    def label(self) -> str:
+        return self.name.lower().replace("remove_", "-")
+
+
+# ---------------------------------------------------------------------------
+# iMessage screen effect IDs
+# ---------------------------------------------------------------------------
+
+#: Full set of iMessage screen effect IDs as accepted by the BlueBubbles API.
+#: Pass one of these strings as ``effect_id`` to ``send_text``.
+EFFECT_IDS: dict[str, str] = {
+    "slam":        "com.apple.MobileSMS.expressivesend.impact",
+    "loud":        "com.apple.MobileSMS.expressivesend.loud",
+    "gentle":      "com.apple.MobileSMS.expressivesend.gentle",
+    "invisible":   "com.apple.MobileSMS.expressivesend.invisibleink",
+    "lasers":      "com.apple.messages.effect.CKEchoEffect",
+    "balloons":    "com.apple.messages.effect.CKHappyBirthdayEffect",
+    "confetti":    "com.apple.messages.effect.CKConfettiEffect",
+    "fireworks":   "com.apple.messages.effect.CKFireworksEffect",
+    "celebration": "com.apple.messages.effect.CKSparklesEffect",
+    "spotlight":   "com.apple.messages.effect.CKShootingStarEffect",
+    "echo":        "com.apple.MobileSMS.expressivesend.echo",
+}
+
+
+# ---------------------------------------------------------------------------
+# Result type (mirrors imessage.sender.SendResult for API parity)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SendResult:
+    ok: bool
+    channel: str = "bluebubbles"
+    error: str | None = None
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# BlueBubbles REST client
+# ---------------------------------------------------------------------------
+
+class BlueBubblesError(RuntimeError):
+    """Non-transient error from the BlueBubbles Server API."""
+
+
+class BlueBubblesClient:
+    """REST client for a local BlueBubbles Server instance.
+
+    Parameters
+    ----------
+    url:
+        Base URL of the server, e.g. ``http://192.168.1.5:1234``.
+        Trailing slash is stripped automatically.
+    password:
+        Server password (plaintext). In production this is decrypted from
+        ``clapcheeks_user_settings.bluebubbles_password`` via
+        ``clapcheeks.auth.token_vault.decrypt_token``.
+    timeout:
+        Per-request timeout in seconds (default 15).
+    """
+
+    def __init__(self, url: str, password: str, *, timeout: int = 15) -> None:
+        self.base_url = url.rstrip("/")
+        self.password = password
+        self.timeout = timeout
+        self._session = requests.Session()
+        self._session.headers.update({
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        })
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}{path}"
+
+    def _params(self, extra: dict | None = None) -> dict:
+        p = {"password": self.password}
+        if extra:
+            p.update(extra)
+        return p
+
+    def _post(self, path: str, payload: dict) -> dict:
+        """POST ``payload`` to ``path`` and return the parsed JSON body.
+
+        Raises ``BlueBubblesError`` on non-2xx or network error.
+        """
+        try:
+            resp = self._session.post(
+                self._url(path),
+                json=payload,
+                params=self._params(),
+                timeout=self.timeout,
+            )
+        except requests.RequestException as exc:
+            raise BlueBubblesError(f"network error: {exc}") from exc
+
+        if not resp.ok:
+            raise BlueBubblesError(
+                f"HTTP {resp.status_code} from {path}: {resp.text[:300]}"
+            )
+        try:
+            return resp.json()
+        except ValueError:
+            return {"status": resp.status_code, "raw": resp.text}
+
+    # ------------------------------------------------------------------
+    # Public send API
+    # ------------------------------------------------------------------
+
+    def send_text(
+        self,
+        handle: str,
+        body: str,
+        *,
+        effect_id: str | None = None,
+        subject: str | None = None,
+    ) -> SendResult:
+        """Send a plain-text iMessage, optionally with a screen effect.
+
+        Parameters
+        ----------
+        handle:
+            Recipient phone in E.164 format (e.g. ``+14155550100``) or email.
+        body:
+            Message body text.
+        effect_id:
+            One of the ``EFFECT_IDS`` values (e.g. ``EFFECT_IDS["slam"]``).
+            Pass the raw effect URI string, not a short-name key.
+        subject:
+            Optional message subject (bold text above the body in iMessage).
+        """
+        if not body.strip():
+            return SendResult(ok=False, error="empty body")
+
+        payload: dict[str, Any] = {
+            "chatGuid": f"iMessage;-;{handle}",
+            "message": body,
+            "method": "private-api",  # required for effectId
+        }
+        if effect_id:
+            payload["effectId"] = effect_id
+        if subject:
+            payload["subject"] = subject
+
+        logger.debug(
+            "BlueBubbles send_text to %s effect=%s", handle, effect_id or "none"
+        )
+        try:
+            data = self._post("/api/v1/message/text", payload)
+            return SendResult(ok=True, raw=data)
+        except BlueBubblesError as exc:
+            logger.warning("send_text failed for %s: %s", handle, exc)
+            return SendResult(ok=False, error=str(exc))
+
+    def send_tapback(
+        self,
+        target_message_guid: str,
+        kind: TapbackKind,
+    ) -> SendResult:
+        """Send a tapback (react) on a specific message GUID.
+
+        Parameters
+        ----------
+        target_message_guid:
+            The iMessage GUID of the message to react to.
+            Format: ``p:0/<uuid>`` as returned by the BlueBubbles API or
+            ingested from Messages.db (chat.db) ROWID-derived identifiers.
+        kind:
+            ``TapbackKind`` variant to apply (or remove).
+
+        Notes
+        -----
+        Requires the BlueBubbles Private API Helper plugin. Without it the
+        server returns HTTP 400 "Private API disabled". Installation:
+        https://docs.bluebubbles.app/private-api/installation
+        """
+        payload = {
+            "selectedMessageGuid": target_message_guid,
+            "reaction": kind.value,
+        }
+        logger.debug(
+            "BlueBubbles send_tapback guid=%s kind=%s (%d)",
+            target_message_guid, kind.name, kind.value,
+        )
+        try:
+            data = self._post("/api/v1/message/react", payload)
+            return SendResult(ok=True, raw=data)
+        except BlueBubblesError as exc:
+            logger.warning(
+                "send_tapback failed guid=%s kind=%s: %s",
+                target_message_guid, kind.name, exc,
+            )
+            return SendResult(ok=False, error=str(exc))
+
+    # ------------------------------------------------------------------
+    # WebSocket (inbound events) — scaffolded, persistence is follow-up
+    # ------------------------------------------------------------------
+
+    def connect_ws(self) -> None:
+        """Open a Socket.IO connection to receive inbound BlueBubbles events.
+
+        Scaffold only — full persistence implementation is out of scope for
+        AI-8808 (tagged as follow-up). This method is a no-op unless the
+        optional ``socketio-client`` / ``python-socketio`` package is
+        present at runtime.
+
+        When implemented, the loop should call ``iter_events()`` and store
+        incoming reaction events to ``clapcheeks_conversations.reactions``.
+        """
+        logger.info(
+            "BlueBubbles WS connect_ws() called — "
+            "WebSocket persistence is scaffolded; full implementation is a "
+            "follow-up to AI-8808 (requires python-socketio dependency)."
+        )
+
+    def iter_events(self) -> Generator[dict[str, Any], None, None]:
+        """Yield inbound BlueBubbles events (tapbacks, new messages, etc.).
+
+        Scaffold only — yields nothing until the Socket.IO loop is wired up.
+        Full implementation: subscribe to ``new-message`` and ``updated-message``
+        events from the BlueBubbles Socket.IO server and forward tapback
+        payloads to the reaction persistence layer.
+
+        Example event shape for a tapback::
+
+            {
+              "type": "updated-message",
+              "data": {
+                "guid": "p:0/<uuid>",
+                "associatedMessageType": 2000,  # LOVE tapback
+                "associatedMessageGuid": "<target-guid>",
+              }
+            }
+        """
+        logger.debug(
+            "iter_events() scaffold: no events emitted (WS not connected)"
+        )
+        return
+        yield  # make this a generator without importing anything
+
+    # ------------------------------------------------------------------
+    # Utility
+    # ------------------------------------------------------------------
+
+    def ping(self) -> bool:
+        """Return True if the server is reachable and the password is valid."""
+        try:
+            resp = self._session.get(
+                self._url("/api/v1/server/info"),
+                params=self._params(),
+                timeout=self.timeout,
+            )
+            return resp.ok
+        except requests.RequestException:
+            return False
+
+
+__all__ = [
+    "BlueBubblesClient",
+    "BlueBubblesError",
+    "TapbackKind",
+    "EFFECT_IDS",
+    "SendResult",
+]

--- a/agent/clapcheeks/imessage/sender.py
+++ b/agent/clapcheeks/imessage/sender.py
@@ -13,6 +13,10 @@ Patches:
 - P4 (AI-8738): explicit AppleScript account-index routing for the
   osascript fallback so SMS handles route via the SMS account
   (Continuity / Messages in iCloud) instead of the iMessage account.
+- AI-8808: BlueBubbles adapter for tapbacks and screen effects. When
+  ``BLUEBUBBLES_URL`` + ``BLUEBUBBLES_PASSWORD`` are set (or passed
+  explicitly), ``send_tapback`` and ``send_with_effect`` route through
+  the BlueBubbles REST API. ``send_imessage`` is unchanged.
 """
 from __future__ import annotations
 
@@ -203,3 +207,150 @@ def send_imessage(
             return SendResult(ok=False, channel="osascript", error=str(exc))
 
     return SendResult(ok=False, channel="noop", error="no iMessage transport available")
+
+
+# ---------------------------------------------------------------------------
+# AI-8808 — BlueBubbles-routed tapback + effect API
+# ---------------------------------------------------------------------------
+
+def _bluebubbles_client(
+    url: str | None = None,
+    password: str | None = None,
+):
+    """Return a ``BlueBubblesClient`` or ``None`` if BlueBubbles is not configured.
+
+    Prefers explicit ``url`` / ``password`` arguments; falls back to the
+    ``BLUEBUBBLES_URL`` / ``BLUEBUBBLES_PASSWORD`` environment variables.
+    Returns ``None`` (silently) if neither source provides a URL.
+    """
+    import os as _os
+
+    _url = url or _os.environ.get("BLUEBUBBLES_URL", "")
+    _pw = password or _os.environ.get("BLUEBUBBLES_PASSWORD", "")
+    if not _url:
+        return None
+
+    try:
+        from clapcheeks.imessage.bluebubbles import BlueBubblesClient
+        return BlueBubblesClient(_url, _pw)
+    except ImportError as exc:
+        logger.warning(
+            "BlueBubblesClient import failed — check that requests is installed: %s", exc
+        )
+        return None
+
+
+def send_tapback(
+    phone: str,
+    target_msg_guid: str,
+    kind,  # TapbackKind
+    *,
+    bluebubbles_url: str | None = None,
+    bluebubbles_password: str | None = None,
+) -> SendResult:
+    """Send a tapback (react) on a specific iMessage GUID.
+
+    Routes through BlueBubbles Server if ``bluebubbles_url`` is provided (or
+    the ``BLUEBUBBLES_URL`` env var is set). If neither is configured, logs a
+    warning and returns a noop result — the text conversation is unaffected.
+
+    Parameters
+    ----------
+    phone:
+        Recipient handle in E.164 format. Used only for logging; the actual
+        tapback target is ``target_msg_guid``.
+    target_msg_guid:
+        iMessage GUID of the message to react to (e.g. ``p:0/<uuid>``).
+    kind:
+        ``TapbackKind`` enum value (LOVE, LIKE, DISLIKE, LAUGH,
+        EMPHASIZE, QUESTION, or the REMOVE_* variants).
+    bluebubbles_url, bluebubbles_password:
+        Override the env-var defaults for per-user credential lookup.
+    """
+    e164 = to_e164_us(phone) or phone  # best-effort normalize; guid is the real key
+
+    bb = _bluebubbles_client(bluebubbles_url, bluebubbles_password)
+    if bb is None:
+        logger.warning(
+            "send_tapback: BlueBubbles not configured for %s — "
+            "tapback dropped (BLUEBUBBLES_URL not set). "
+            "Set BLUEBUBBLES_URL + BLUEBUBBLES_PASSWORD to enable.",
+            e164,
+        )
+        return SendResult(
+            ok=False,
+            channel="noop",
+            error="BlueBubbles not configured — tapback not supported via osascript/god-mac",
+        )
+
+    from clapcheeks.imessage.bluebubbles import SendResult as BBResult
+
+    bb_result: BBResult = bb.send_tapback(target_msg_guid, kind)
+    return SendResult(
+        ok=bb_result.ok,
+        channel="bluebubbles",
+        error=bb_result.error,
+    )
+
+
+def send_with_effect(
+    phone: str,
+    body: str,
+    effect_id: str,
+    *,
+    dry_run: bool = False,
+    bluebubbles_url: str | None = None,
+    bluebubbles_password: str | None = None,
+) -> SendResult:
+    """Send ``body`` to ``phone`` with an iMessage screen effect.
+
+    Routes through BlueBubbles Server when configured. Falls back to a plain
+    ``send_imessage`` call (which drops the effect) if BlueBubbles is not
+    configured — the body is still delivered.
+
+    Parameters
+    ----------
+    phone:
+        Recipient phone in E.164 format.
+    body:
+        Message text.
+    effect_id:
+        BlueBubbles / iMessage effect ID, e.g.
+        ``"com.apple.MobileSMS.expressivesend.impact"`` (slam) or one of
+        the values from ``clapcheeks.imessage.bluebubbles.EFFECT_IDS``.
+    dry_run:
+        When True, short-circuit and return a noop result.
+    bluebubbles_url, bluebubbles_password:
+        Override the env-var defaults for per-user credential lookup.
+    """
+    e164 = to_e164_us(phone)
+    if not e164:
+        return SendResult(ok=False, channel="noop", error=f"bad phone: {phone!r}")
+    if not body or not body.strip():
+        return SendResult(ok=False, channel="noop", error="empty body")
+
+    if dry_run:
+        logger.info(
+            "[dry_run] would send iMessage to %s with effect %s: %s",
+            e164, effect_id, body[:80],
+        )
+        return SendResult(ok=True, channel="noop")
+
+    bb = _bluebubbles_client(bluebubbles_url, bluebubbles_password)
+    if bb is None:
+        logger.warning(
+            "send_with_effect: BlueBubbles not configured — "
+            "sending %s without effect %s via standard path",
+            e164, effect_id,
+        )
+        # Fall back to plain send (body delivered, effect silently dropped).
+        return send_imessage(e164, body)
+
+    from clapcheeks.imessage.bluebubbles import SendResult as BBResult
+
+    bb_result: BBResult = bb.send_text(e164, body, effect_id=effect_id)
+    return SendResult(
+        ok=bb_result.ok,
+        channel="bluebubbles",
+        error=bb_result.error,
+    )

--- a/agent/clapcheeks/platforms/bumble.py
+++ b/agent/clapcheeks/platforms/bumble.py
@@ -437,3 +437,30 @@ class BumbleClient:
             "Sent %d openers out of %d actionable matches.", sent, len(matches),
         )
         return sent
+
+    # ------------------------------------------------------------------
+    # AI-8808 — Reaction stub
+    # ------------------------------------------------------------------
+
+    def send_reaction(
+        self,
+        match_id: str,
+        target_message_id: str,
+        kind: str,
+    ) -> None:
+        """React to a Bumble message.
+
+        Bumble does not expose a message reaction API in its public or
+        semi-public web/mobile surface. This is a no-op stub (logs + returns)
+        rather than a ``NotImplementedError`` because Bumble is a lower-
+        priority platform and callers should degrade gracefully.
+
+        Tagged AI-8808-followup for investigation when Bumble's private API
+        is better mapped.
+        """
+        logger.warning(
+            "send_reaction: Bumble message reactions are not implemented "
+            "(match_id=%s target_message_id=%s kind=%s). "
+            "Reaction silently dropped — AI-8808-followup.",
+            match_id, target_message_id, kind,
+        )

--- a/agent/clapcheeks/platforms/hinge_api.py
+++ b/agent/clapcheeks/platforms/hinge_api.py
@@ -406,6 +406,64 @@ class HingeAPIClient:
             logger.error("send_message failed: %s", exc)
             return False
 
+    def send_reaction(
+        self,
+        match_id: str,
+        target_message_id: str,
+        kind: str,
+    ) -> None:
+        """React to a Hinge message.
+
+        .. note::
+            **Not implemented (AI-8808-followup).**
+
+            Hinge's API surface (prod-api.hingeaws.net) does not expose a
+            documented message reaction endpoint. The prompt-like endpoint
+            ``POST /prompts/{promptId}/like`` exists for liking opener
+            prompts, but per-message reactions within an active conversation
+            are not available via the captured token API.
+
+            This stub is here so callers can be wired up now and the
+            implementation added later without changing call sites.
+
+        :raises NotImplementedError: always.
+        """
+        raise NotImplementedError(
+            "Hinge per-message reactions are not available via the captured API "
+            "(AI-8808-followup: investigate /message/v1/react or equivalent)"
+        )
+
+    def like_prompt(self, subject_id: str, prompt_id: str, comment: str = "") -> bool:
+        """Like a Hinge prospect's prompt (opener reaction before matching).
+
+        This is Hinge's *prompt-like* reaction — it sends a like accompanied
+        by an optional comment to a specific prompt on a profile card. This is
+        NOT the same as reacting to a message in an existing conversation.
+
+        Parameters
+        ----------
+        subject_id:
+            Hinge's ``subject_id`` (prospect identifier) from the
+            ``/recs/v1`` recommendations payload.
+        prompt_id:
+            Hinge's ``content_id`` from the prompt object inside the
+            recommendation card.
+        comment:
+            Optional comment text to attach to the prompt like.
+        """
+        try:
+            payload: dict = {
+                "subjectId": subject_id,
+                "contentId": prompt_id,
+            }
+            if comment:
+                payload["comment"] = comment
+            self._request("POST", "/interactions/v1/prompt-like", json=payload)
+            return True
+        except Exception as exc:
+            logger.error("like_prompt failed subject=%s prompt=%s: %s", subject_id, prompt_id, exc)
+            return False
+
     def get_matches(self, count: int = 20) -> list[dict]:
         try:
             data = self._request("GET", f"/match/v1?limit={count}")

--- a/agent/clapcheeks/platforms/tinder_api.py
+++ b/agent/clapcheeks/platforms/tinder_api.py
@@ -456,6 +456,34 @@ class TinderAPIClient:
             logger.error("Tinder send_message failed: %s", exc)
             return False
 
+    def send_reaction(
+        self,
+        match_id: str,
+        target_message_id: str,
+        kind: str,
+    ) -> None:
+        """React to a Tinder message.
+
+        .. note::
+            **Not implemented (AI-8808-followup).**
+
+            Tinder's public API documentation does not expose a message
+            reaction endpoint. The native iOS app sends reactions via an
+            undocumented internal route not present in the captured web API
+            surface (api.gotinder.com). Implementing this would require
+            reverse-engineering the iOS binary with Frida, which is out of
+            scope for AI-8808.
+
+            This stub is here so callers can be wired up now and the
+            implementation added later without changing call sites.
+
+        :raises NotImplementedError: always.
+        """
+        raise NotImplementedError(
+            "Tinder message reactions are not available via the public API "
+            "(AI-8808-followup: reverse-engineer iOS private endpoint)"
+        )
+
     def get_matches(self, count: int = 20) -> list[dict]:
         try:
             if self.wire == "protobuf":

--- a/agent/tests/test_bluebubbles_client.py
+++ b/agent/tests/test_bluebubbles_client.py
@@ -1,0 +1,298 @@
+"""Tests for clapcheeks.imessage.bluebubbles (AI-8808).
+
+Covers:
+  * TapbackKind enum values and is_remove property
+  * EFFECT_IDS constants present and non-empty
+  * BlueBubblesClient.send_text — happy path + HTTP error
+  * BlueBubblesClient.send_tapback — happy path + HTTP error
+  * BlueBubblesClient.send_text with effect_id forwarded correctly
+  * BlueBubblesClient.ping — success + failure
+  * connect_ws / iter_events scaffold no-op behaviour
+  * Request shape assertions (URL, payload keys, query param)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Make the agent package importable when pytest is invoked from repo root.
+AGENT_DIR = Path(__file__).resolve().parents[2] / "agent"
+if str(AGENT_DIR) not in sys.path:
+    sys.path.insert(0, str(AGENT_DIR))
+
+from clapcheeks.imessage.bluebubbles import (
+    EFFECT_IDS,
+    BlueBubblesClient,
+    BlueBubblesError,
+    SendResult,
+    TapbackKind,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BASE_URL = "http://192.168.1.5:1234"
+_PASSWORD = "s3cr3t"
+
+
+def _client() -> BlueBubblesClient:
+    return BlueBubblesClient(_BASE_URL, _PASSWORD)
+
+
+def _mock_ok_response(data: dict | None = None) -> mock.MagicMock:
+    resp = mock.MagicMock()
+    resp.ok = True
+    resp.status_code = 200
+    resp.json.return_value = data or {"status": 200}
+    return resp
+
+
+def _mock_err_response(status: int = 400, text: str = "error") -> mock.MagicMock:
+    resp = mock.MagicMock()
+    resp.ok = False
+    resp.status_code = status
+    resp.text = text
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# TapbackKind
+# ---------------------------------------------------------------------------
+
+class TestTapbackKind:
+    def test_positive_values_are_add(self):
+        for kind in [
+            TapbackKind.LOVE, TapbackKind.LIKE, TapbackKind.DISLIKE,
+            TapbackKind.LAUGH, TapbackKind.EMPHASIZE, TapbackKind.QUESTION,
+        ]:
+            assert not kind.is_remove, f"{kind.name} should not be remove"
+            assert kind.value > 0
+
+    def test_remove_variants_are_negative(self):
+        for kind in [
+            TapbackKind.REMOVE_LOVE, TapbackKind.REMOVE_LIKE,
+            TapbackKind.REMOVE_DISLIKE, TapbackKind.REMOVE_LAUGH,
+            TapbackKind.REMOVE_EMPHASIZE, TapbackKind.REMOVE_QUESTION,
+        ]:
+            assert kind.is_remove, f"{kind.name} should be remove"
+            assert kind.value < 0
+
+    def test_six_add_variants(self):
+        add_kinds = [k for k in TapbackKind if not k.is_remove]
+        assert len(add_kinds) == 6
+
+    def test_six_remove_variants(self):
+        remove_kinds = [k for k in TapbackKind if k.is_remove]
+        assert len(remove_kinds) == 6
+
+    def test_love_value(self):
+        assert TapbackKind.LOVE.value == 2000
+
+    def test_label_contains_name(self):
+        assert "love" in TapbackKind.LOVE.label
+        assert "like" in TapbackKind.LIKE.label
+
+    def test_remove_label_no_prefix(self):
+        # REMOVE_* labels should NOT include "remove_" prefix
+        assert "remove" not in TapbackKind.REMOVE_LOVE.label
+
+
+# ---------------------------------------------------------------------------
+# EFFECT_IDS
+# ---------------------------------------------------------------------------
+
+class TestEffectIds:
+    _EXPECTED = {"slam", "loud", "gentle", "invisible", "lasers", "balloons",
+                 "confetti", "fireworks", "celebration", "spotlight", "echo"}
+
+    def test_all_expected_keys_present(self):
+        missing = self._EXPECTED - set(EFFECT_IDS.keys())
+        assert not missing, f"Missing effect IDs: {missing}"
+
+    def test_all_values_non_empty(self):
+        for key, val in EFFECT_IDS.items():
+            assert isinstance(val, str) and val, f"Effect ID for {key!r} is empty"
+
+    def test_slam_uri(self):
+        assert "impact" in EFFECT_IDS["slam"]
+
+    def test_balloons_uri(self):
+        assert "Birthday" in EFFECT_IDS["balloons"] or "birthday" in EFFECT_IDS["balloons"].lower()
+
+
+# ---------------------------------------------------------------------------
+# BlueBubblesClient.send_text
+# ---------------------------------------------------------------------------
+
+class TestSendText:
+    def test_happy_path_returns_ok(self):
+        client = _client()
+        with mock.patch.object(client._session, "post", return_value=_mock_ok_response({"guid": "abc"})) as m:
+            result = client.send_text("+14155550100", "hello")
+        assert result.ok is True
+        assert result.channel == "bluebubbles"
+        assert result.error is None
+
+    def test_request_url_correct(self):
+        client = _client()
+        with mock.patch.object(client._session, "post", return_value=_mock_ok_response()) as m:
+            client.send_text("+14155550100", "hi")
+        assert m.call_args[0][0].endswith("/api/v1/message/text")
+
+    def test_password_sent_as_query_param(self):
+        client = _client()
+        with mock.patch.object(client._session, "post", return_value=_mock_ok_response()) as m:
+            client.send_text("+14155550100", "hi")
+        params = m.call_args[1]["params"]
+        assert params["password"] == _PASSWORD
+
+    def test_chat_guid_in_payload(self):
+        client = _client()
+        with mock.patch.object(client._session, "post", return_value=_mock_ok_response()) as m:
+            client.send_text("+14155550100", "hey there")
+        payload = m.call_args[1]["json"]
+        assert payload["chatGuid"] == "iMessage;-;+14155550100"
+        assert payload["message"] == "hey there"
+
+    def test_effect_id_forwarded(self):
+        client = _client()
+        with mock.patch.object(client._session, "post", return_value=_mock_ok_response()) as m:
+            client.send_text("+14155550100", "boom", effect_id=EFFECT_IDS["slam"])
+        payload = m.call_args[1]["json"]
+        assert payload["effectId"] == EFFECT_IDS["slam"]
+
+    def test_no_effect_id_when_not_set(self):
+        client = _client()
+        with mock.patch.object(client._session, "post", return_value=_mock_ok_response()) as m:
+            client.send_text("+14155550100", "no effect")
+        payload = m.call_args[1]["json"]
+        assert "effectId" not in payload
+
+    def test_subject_forwarded(self):
+        client = _client()
+        with mock.patch.object(client._session, "post", return_value=_mock_ok_response()) as m:
+            client.send_text("+14155550100", "body", subject="Re: lunch")
+        payload = m.call_args[1]["json"]
+        assert payload["subject"] == "Re: lunch"
+
+    def test_http_error_returns_not_ok(self):
+        client = _client()
+        with mock.patch.object(client._session, "post", return_value=_mock_err_response(400, "bad req")) as m:
+            result = client.send_text("+14155550100", "test")
+        assert result.ok is False
+        assert "400" in result.error
+
+    def test_network_error_returns_not_ok(self):
+        import requests
+        client = _client()
+        with mock.patch.object(client._session, "post", side_effect=requests.ConnectionError("conn refused")):
+            result = client.send_text("+14155550100", "test")
+        assert result.ok is False
+        assert result.error is not None
+
+    def test_empty_body_short_circuits(self):
+        client = _client()
+        with mock.patch.object(client._session, "post") as m:
+            result = client.send_text("+14155550100", "   ")
+        m.assert_not_called()
+        assert result.ok is False
+
+
+# ---------------------------------------------------------------------------
+# BlueBubblesClient.send_tapback
+# ---------------------------------------------------------------------------
+
+class TestSendTapback:
+    _GUID = "p:0/ABCD1234-EF56-7890-AB12-CD34EF567890"
+
+    def test_happy_path_love(self):
+        client = _client()
+        with mock.patch.object(client._session, "post", return_value=_mock_ok_response()) as m:
+            result = client.send_tapback(self._GUID, TapbackKind.LOVE)
+        assert result.ok is True
+
+    def test_request_url_correct(self):
+        client = _client()
+        with mock.patch.object(client._session, "post", return_value=_mock_ok_response()) as m:
+            client.send_tapback(self._GUID, TapbackKind.LIKE)
+        assert m.call_args[0][0].endswith("/api/v1/message/react")
+
+    def test_payload_shape(self):
+        client = _client()
+        with mock.patch.object(client._session, "post", return_value=_mock_ok_response()) as m:
+            client.send_tapback(self._GUID, TapbackKind.LAUGH)
+        payload = m.call_args[1]["json"]
+        assert payload["selectedMessageGuid"] == self._GUID
+        assert payload["reaction"] == TapbackKind.LAUGH.value
+
+    def test_remove_tapback_negative_value(self):
+        client = _client()
+        with mock.patch.object(client._session, "post", return_value=_mock_ok_response()) as m:
+            client.send_tapback(self._GUID, TapbackKind.REMOVE_LOVE)
+        payload = m.call_args[1]["json"]
+        assert payload["reaction"] == TapbackKind.REMOVE_LOVE.value
+        assert payload["reaction"] < 0
+
+    def test_http_error_returns_not_ok(self):
+        client = _client()
+        with mock.patch.object(client._session, "post", return_value=_mock_err_response(400, "Private API disabled")):
+            result = client.send_tapback(self._GUID, TapbackKind.LOVE)
+        assert result.ok is False
+        assert "400" in result.error
+
+    def test_all_tapback_kinds_send_correct_value(self):
+        client = _client()
+        for kind in TapbackKind:
+            with mock.patch.object(client._session, "post", return_value=_mock_ok_response()) as m:
+                client.send_tapback(self._GUID, kind)
+            payload = m.call_args[1]["json"]
+            assert payload["reaction"] == kind.value, f"Wrong value for {kind.name}"
+
+
+# ---------------------------------------------------------------------------
+# BlueBubblesClient.ping
+# ---------------------------------------------------------------------------
+
+class TestPing:
+    def test_ping_ok(self):
+        client = _client()
+        with mock.patch.object(client._session, "get", return_value=_mock_ok_response()):
+            assert client.ping() is True
+
+    def test_ping_server_error(self):
+        client = _client()
+        with mock.patch.object(client._session, "get", return_value=_mock_err_response(500)):
+            assert client.ping() is False
+
+    def test_ping_network_error(self):
+        import requests
+        client = _client()
+        with mock.patch.object(client._session, "get", side_effect=requests.ConnectionError):
+            assert client.ping() is False
+
+    def test_ping_url(self):
+        client = _client()
+        with mock.patch.object(client._session, "get", return_value=_mock_ok_response()) as m:
+            client.ping()
+        assert m.call_args[0][0].endswith("/api/v1/server/info")
+
+
+# ---------------------------------------------------------------------------
+# WebSocket scaffold — connect_ws + iter_events are no-ops
+# ---------------------------------------------------------------------------
+
+class TestWsScaffold:
+    def test_connect_ws_is_no_op(self):
+        """connect_ws must not raise; it logs and returns."""
+        client = _client()
+        client.connect_ws()  # should not raise
+
+    def test_iter_events_yields_nothing(self):
+        client = _client()
+        events = list(client.iter_events())
+        assert events == []

--- a/agent/tests/test_imessage_sender_tapbacks.py
+++ b/agent/tests/test_imessage_sender_tapbacks.py
@@ -1,0 +1,193 @@
+"""Tests for AI-8808 tapback + effect extensions to imessage/sender.py.
+
+Covers:
+  * send_tapback: routes through BlueBubbles when BLUEBUBBLES_URL is set
+  * send_tapback: returns noop SendResult when BlueBubbles not configured
+  * send_tapback: warning logged when BB not configured
+  * send_with_effect: routes through BlueBubbles when configured
+  * send_with_effect: falls back to plain send_imessage when BB not configured
+  * send_with_effect: dry_run short-circuits before any transport call
+  * send_with_effect: empty body returns error, no transport call
+  * send_with_effect: bad phone returns error
+  * Existing send_imessage behaviour unchanged (backward compat smoke test)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+AGENT_DIR = Path(__file__).resolve().parents[2] / "agent"
+if str(AGENT_DIR) not in sys.path:
+    sys.path.insert(0, str(AGENT_DIR))
+
+from clapcheeks.imessage import sender
+from clapcheeks.imessage.sender import SendResult, send_tapback, send_with_effect
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+_HANDLE = "+14155550100"
+_MSG_GUID = "p:0/ABCD1234-0000-0000-0000-AABBCCDDEEFF"
+_BB_URL = "http://192.168.1.5:1234"
+_BB_PW = "hunter2"
+
+_SLAM_EFFECT = "com.apple.MobileSMS.expressivesend.impact"
+
+
+def _bb_ok() -> mock.MagicMock:
+    """Stub BlueBubblesClient that always returns ok=True."""
+    bb = mock.MagicMock()
+    bb.send_tapback.return_value = mock.MagicMock(ok=True, error=None)
+    bb.send_text.return_value = mock.MagicMock(ok=True, error=None)
+    return bb
+
+
+def _bb_fail() -> mock.MagicMock:
+    """Stub BlueBubblesClient that always returns ok=False."""
+    bb = mock.MagicMock()
+    bb.send_tapback.return_value = mock.MagicMock(ok=False, error="HTTP 400: Private API disabled")
+    bb.send_text.return_value = mock.MagicMock(ok=False, error="HTTP 500: server error")
+    return bb
+
+
+# ---------------------------------------------------------------------------
+# send_tapback
+# ---------------------------------------------------------------------------
+
+class TestSendTapback:
+    def test_routes_through_bluebubbles_when_configured(self):
+        from clapcheeks.imessage.bluebubbles import TapbackKind
+        bb = _bb_ok()
+        with mock.patch("clapcheeks.imessage.sender._bluebubbles_client", return_value=bb):
+            result = send_tapback(_HANDLE, _MSG_GUID, TapbackKind.LOVE)
+        bb.send_tapback.assert_called_once_with(_MSG_GUID, TapbackKind.LOVE)
+        assert result.ok is True
+        assert result.channel == "bluebubbles"
+
+    def test_noop_when_bluebubbles_not_configured(self):
+        from clapcheeks.imessage.bluebubbles import TapbackKind
+        with mock.patch("clapcheeks.imessage.sender._bluebubbles_client", return_value=None):
+            result = send_tapback(_HANDLE, _MSG_GUID, TapbackKind.LIKE)
+        assert result.ok is False
+        assert result.channel == "noop"
+        assert result.error is not None
+
+    def test_warning_logged_when_no_bb(self, caplog):
+        import logging
+        from clapcheeks.imessage.bluebubbles import TapbackKind
+        with mock.patch("clapcheeks.imessage.sender._bluebubbles_client", return_value=None):
+            with caplog.at_level(logging.WARNING, logger="clapcheeks.imessage.sender"):
+                send_tapback(_HANDLE, _MSG_GUID, TapbackKind.DISLIKE)
+        assert any("BlueBubbles" in r.message for r in caplog.records)
+
+    def test_passes_kind_correctly(self):
+        from clapcheeks.imessage.bluebubbles import TapbackKind
+        bb = _bb_ok()
+        with mock.patch("clapcheeks.imessage.sender._bluebubbles_client", return_value=bb):
+            send_tapback(_HANDLE, _MSG_GUID, TapbackKind.QUESTION)
+        bb.send_tapback.assert_called_once_with(_MSG_GUID, TapbackKind.QUESTION)
+
+    def test_bb_failure_propagated(self):
+        from clapcheeks.imessage.bluebubbles import TapbackKind
+        bb = _bb_fail()
+        with mock.patch("clapcheeks.imessage.sender._bluebubbles_client", return_value=bb):
+            result = send_tapback(_HANDLE, _MSG_GUID, TapbackKind.LOVE)
+        assert result.ok is False
+        assert result.channel == "bluebubbles"
+
+    def test_explicit_bb_credentials_passed_to_client_factory(self):
+        """Explicit url/password are forwarded to _bluebubbles_client."""
+        from clapcheeks.imessage.bluebubbles import TapbackKind
+        with mock.patch("clapcheeks.imessage.sender._bluebubbles_client", return_value=None) as m:
+            send_tapback(
+                _HANDLE, _MSG_GUID, TapbackKind.LOVE,
+                bluebubbles_url=_BB_URL,
+                bluebubbles_password=_BB_PW,
+            )
+        m.assert_called_once_with(_BB_URL, _BB_PW)
+
+
+# ---------------------------------------------------------------------------
+# send_with_effect
+# ---------------------------------------------------------------------------
+
+class TestSendWithEffect:
+    def test_routes_through_bb_when_configured(self):
+        bb = _bb_ok()
+        with mock.patch("clapcheeks.imessage.sender._bluebubbles_client", return_value=bb):
+            result = send_with_effect(_HANDLE, "BOOM", _SLAM_EFFECT)
+        bb.send_text.assert_called_once()
+        call_kwargs = bb.send_text.call_args
+        assert call_kwargs[1].get("effect_id") == _SLAM_EFFECT
+        assert result.ok is True
+        assert result.channel == "bluebubbles"
+
+    def test_falls_back_to_plain_send_when_no_bb(self):
+        """When BlueBubbles not configured, body is sent via existing send_imessage path."""
+        with mock.patch("clapcheeks.imessage.sender._bluebubbles_client", return_value=None):
+            with mock.patch("clapcheeks.imessage.sender.send_imessage") as plain_send:
+                plain_send.return_value = SendResult(ok=True, channel="god-mac")
+                result = send_with_effect(_HANDLE, "hi", _SLAM_EFFECT)
+        plain_send.assert_called_once()
+        # channel reflects the fallback transport
+        assert result.channel == "god-mac"
+
+    def test_dry_run_short_circuits(self):
+        with mock.patch("clapcheeks.imessage.sender._bluebubbles_client") as bb_factory:
+            result = send_with_effect(_HANDLE, "hello", _SLAM_EFFECT, dry_run=True)
+        bb_factory.assert_not_called()
+        assert result.ok is True
+        assert result.channel == "noop"
+
+    def test_empty_body_returns_error(self):
+        with mock.patch("clapcheeks.imessage.sender._bluebubbles_client") as bb_factory:
+            result = send_with_effect(_HANDLE, "   ", _SLAM_EFFECT)
+        bb_factory.assert_not_called()
+        assert result.ok is False
+
+    def test_bad_phone_returns_error(self):
+        result = send_with_effect("not-a-phone", "hi", _SLAM_EFFECT)
+        assert result.ok is False
+        assert result.channel == "noop"
+
+    def test_effect_id_in_bb_call(self):
+        from clapcheeks.imessage.bluebubbles import EFFECT_IDS
+        bb = _bb_ok()
+        effect = EFFECT_IDS["balloons"]
+        with mock.patch("clapcheeks.imessage.sender._bluebubbles_client", return_value=bb):
+            send_with_effect(_HANDLE, "happy birthday", effect)
+        _, call_kwargs = bb.send_text.call_args
+        assert call_kwargs["effect_id"] == effect
+
+
+# ---------------------------------------------------------------------------
+# Backward compat — send_imessage unchanged
+# ---------------------------------------------------------------------------
+
+class TestSendImessageBackwardCompat:
+    """Verify the existing send_imessage function still works (smoke test)."""
+
+    def test_noop_when_no_transport(self, monkeypatch):
+        monkeypatch.setattr(sender, "_which_god", lambda: None)
+        monkeypatch.setattr(sender, "_which_osascript", lambda: None)
+        result = sender.send_imessage("+14155550100", "hello")
+        assert result.ok is False
+        assert result.channel == "noop"
+
+    def test_dry_run(self):
+        result = sender.send_imessage("+14155550100", "hello", dry_run=True)
+        assert result.ok is True
+        assert result.channel == "noop"
+
+    def test_bad_phone(self):
+        result = sender.send_imessage("not-a-phone", "hello")
+        assert result.ok is False
+
+    def test_empty_body(self):
+        result = sender.send_imessage("+14155550100", "  ")
+        assert result.ok is False

--- a/supabase/migrations/20260428030000_reactions_and_bluebubbles.sql
+++ b/supabase/migrations/20260428030000_reactions_and_bluebubbles.sql
@@ -1,0 +1,67 @@
+-- AI-8808: Reactions, tapbacks, iMessage effects + BlueBubbles adapter
+--
+-- Additive migration. All changes are IF NOT EXISTS / conditional so they
+-- are safe to re-run and do not break existing data.
+--
+-- Changes:
+--
+--   clapcheeks_conversations
+--     + reactions   JSONB DEFAULT '[]'   -- per-message tapback/react store
+--     + effect_id   TEXT                 -- iMessage screen effect applied
+--
+--   clapcheeks_user_settings
+--     + bluebubbles_url       TEXT  -- e.g. http://192.168.1.5:1234
+--     + bluebubbles_password  bytea -- AES-256-GCM encrypted (same wire
+--                                      format as other *_enc columns from
+--                                      AI-8766: version(1)|iv(12)|tag(16)|ct)
+--
+-- NOTE: The task spec referenced clapcheeks_match_messages but that table
+-- does not exist in this schema. The per-message store lives in
+-- clapcheeks_conversations.messages (JSONB array). We add reaction /
+-- effect metadata columns at the conversation row level so individual
+-- message reactions can be stored inside the messages JSONB array
+-- (reaction = {msg_guid, kind, actor}). The top-level columns below serve
+-- as aggregated ring-fencing (last reaction kind, last effect applied) and
+-- can be evolved into a proper join table in a follow-up migration.
+-- ---------------------------------------------------------------------------
+
+-- ---------------------------------------------------------------------------
+-- 1. clapcheeks_conversations: reactions + effect_id
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.clapcheeks_conversations
+    ADD COLUMN IF NOT EXISTS reactions  JSONB DEFAULT '[]'::jsonb,
+    ADD COLUMN IF NOT EXISTS effect_id  TEXT;
+
+COMMENT ON COLUMN public.clapcheeks_conversations.reactions IS
+    'Array of tapback/react events on messages in this conversation. '
+    'Each element: {msg_guid TEXT, kind TEXT, actor TEXT, ts TIMESTAMPTZ}. '
+    'Populated by the BlueBubbles WebSocket inbound event handler (AI-8808).';
+
+COMMENT ON COLUMN public.clapcheeks_conversations.effect_id IS
+    'iMessage screen effect ID applied to the last outbound message. '
+    'One of: slam | loud | gentle | invisible | lasers | balloons | '
+    'confetti | fireworks | celebration | spotlight | echo (AI-8808).';
+
+-- ---------------------------------------------------------------------------
+-- 2. clapcheeks_user_settings: BlueBubbles server credentials
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.clapcheeks_user_settings
+    ADD COLUMN IF NOT EXISTS bluebubbles_url       TEXT,
+    ADD COLUMN IF NOT EXISTS bluebubbles_password  BYTEA;
+
+COMMENT ON COLUMN public.clapcheeks_user_settings.bluebubbles_url IS
+    'Base URL of the user''s BlueBubbles Server, e.g. http://192.168.1.5:1234. '
+    'When set, the iMessage sender routes tapbacks + effects through the '
+    'BlueBubbles REST API instead of god mac send / osascript (AI-8808).';
+
+COMMENT ON COLUMN public.clapcheeks_user_settings.bluebubbles_password IS
+    'AES-256-GCM ciphertext of the BlueBubbles Server password. '
+    'Wire format: version(1)|iv(12)|tag(16)|ct — identical to other *_enc '
+    'columns (AI-8766). Key = scrypt(CLAPCHEEKS_TOKEN_MASTER_KEY, user_id).';
+
+-- Index for daemon: quickly find users who have BlueBubbles configured.
+CREATE INDEX IF NOT EXISTS idx_clapcheeks_settings_bluebubbles
+    ON public.clapcheeks_user_settings (user_id)
+    WHERE bluebubbles_url IS NOT NULL;


### PR DESCRIPTION
## Summary

Implements the iMessage tapback / screen-effect send path via **BlueBubbles Server** REST API, plus per-platform reaction stubs for Tinder, Hinge, Bumble, and Instagram DM.

## Research Findings & Decision Record

| Approach | Decision | Reason |
|---|---|---|
| **BlueBubbles Server** | ✅ CHOSEN | Only non-jailbreak path for tapbacks + effects. REST endpoint `/api/v1/message/react` + `/api/v1/message/text` w/ `effectId`. Requires Private API Helper plugin on Mac. |
| `osascript` / AppleScript | ❌ Not viable | Messages.app scripting dictionary has zero tapback or `effectId` support |
| Private MMSv4 | ❌ Not viable | Requires Frida + jailbreak. High security risk. |
| `MSMessageLiveLayout` | ❌ Not available | iOS iMessage extension API only; not accessible from macOS Messages.app |

## Files Changed

| File | Change |
|---|---|
| `agent/clapcheeks/imessage/bluebubbles.py` | **New** — BlueBubblesClient, TapbackKind enum, EFFECT_IDS constants, WS scaffold |
| `agent/clapcheeks/imessage/sender.py` | Extended — `send_tapback()`, `send_with_effect()`, `_bluebubbles_client()` factory |
| `supabase/migrations/20260428030000_reactions_and_bluebubbles.sql` | **New** — reactions JSONB + effect_id on conversations; bluebubbles_url + bluebubbles_password (AES-GCM) on user_settings |
| `agent/clapcheeks/platforms/tinder_api.py` | `send_reaction()` stub → NotImplementedError |
| `agent/clapcheeks/platforms/hinge_api.py` | `send_reaction()` stub + `like_prompt()` implemented |
| `agent/clapcheeks/platforms/bumble.py` | `send_reaction()` stub → no-op + warning |
| `agent/clapcheeks/content/publisher.py` | `send_dm_like()` stub with IG DM endpoint documented |
| `agent/tests/test_bluebubbles_client.py` | **New** — 33 tests |
| `agent/tests/test_imessage_sender_tapbacks.py` | **New** — 16 tests |

## Per-Platform Reaction Support Table

| Platform | Status | Notes |
|---|---|---|
| iMessage tapbacks (via BB) | ✅ Implemented | `send_tapback(phone, guid, TapbackKind.LOVE)` |
| iMessage screen effects (via BB) | ✅ Implemented | `send_with_effect(phone, body, EFFECT_IDS["slam"])` |
| Hinge prompt-like | ✅ Implemented | `like_prompt(subject_id, prompt_id, comment)` |
| Hinge message reactions | ⚠️ NotImplementedError | No documented API endpoint — AI-8808-followup |
| Tinder message reactions | ⚠️ NotImplementedError | No public API — iOS binary reverse-engineering needed |
| Bumble message reactions | ⚠️ No-op + log | No documented API — graceful degrade |
| Instagram DM like | ⚠️ NotImplementedError | Must route via Chrome extension (endpoint documented in stub) |

## Test Results

```
49 passed in 0.25s
```

Pre-existing failure: `test_vision.py::TestDaemonVisionWorker::test_process_match_upserts_photo_scores_and_summary` — unrelated to this PR (expects `daemon._process_match_vision` which doesn't exist).

## Web Changes

None. Per task spec: `web/` is untouched. UI affordances (tapback button bar, effect picker) are follow-up after AI-8807 unified thread merges.

## Test Plan

- [ ] Confirm 49 new tests pass: `cd agent && python3 -m pytest tests/test_bluebubbles_client.py tests/test_imessage_sender_tapbacks.py -v`
- [ ] Full suite: `cd agent && python3 -m pytest tests/ -x --ignore=tests/test_vision.py`
- [ ] Manual: Set `BLUEBUBBLES_URL` + `BLUEBUBBLES_PASSWORD` and call `send_tapback()` against a real BlueBubbles Server with Private API Helper enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)