### PR TITLE
docs(clapcheeks): AI-8815 reactivation playbook — teachable cross-domain methodology

### DIFF
--- a/.planning/bussit/worker-B-PLAN.md
+++ b/.planning/bussit/worker-B-PLAN.md
@@ -1,0 +1,22 @@
+# Worker-B Plan — AI-8815 Reactivation Playbook
+
+**Status:** In Progress  
+**Branch:** AI-8815-reactivation-playbook  
+
+## Files to Create
+
+1. `docs/playbooks/README.md` — playbook system overview
+2. `docs/playbooks/reactivation-campaign.md` — THE main playbook (3000+ words)
+3. `docs/playbooks/banned-phrases.json` — machine-readable banned phrases
+4. `docs/playbooks/templates/reactivation-tracker.md` — non-tech operator tracker
+5. `docs/playbooks/templates/reactivation-decision-tree.md` — decision tree
+6. Update `agent/clapcheeks/followup/reactivation.py` — add doc-string pointing to playbook
+
+## Key Research Findings Shaping the Playbook
+
+1. **MIT Sloan dormant ties research**: dormant contacts provide MORE novel value than active ones because they accumulated new experiences during the gap. This reframes reactivation from "fixing failure" to "activating latent value."
+2. **Gap-acknowledgment psychology**: naming the gap forces the recipient to relitigate why they stopped responding. Jumping over it (Manson, Kennedy, every email marketing playbook) converts better because it treats the silence as neutral.
+3. **Cross-domain attempt caps**: Manson's 3 chances, Klaviyo's 3-email winback, Bloomreach sunset rule — all converge on 2-3 attempts max. Clapcheeks uses 2, which is appropriate and validated.
+
+## Ethical Frame
+The playbook is about respect and honest outreach — not manipulation. Every technique documented enables genuine reconnection that respects recipient agency. Anything coercive, guilt-inducing, or high-pressure is explicitly documented as wrong and why.

--- a/.planning/bussit/worker-B-research.md
+++ b/.planning/bussit/worker-B-research.md
@@ -1,0 +1,184 @@
+# Worker-B Research — AI-8815 Reactivation Playbook
+
+**Agent:** agent8 / worker-B  
+**Date:** 2026-04-27  
+**Branch:** AI-8815-reactivation-playbook  
+
+---
+
+## 1. Sales Nurture / Re-engagement Frameworks
+
+### Aaron Ross — Predictable Revenue
+- Source: https://www.saastr.com/re-igniting-growth-with-predictable-revenue/
+- Core insight: specialization separates prospecting from closing. Applied to reactivation: the person who made the original contact should own the re-engagement (consistency, familiar face).
+- The "re-ignition playbook" requires slowing down to build *systems*, not heroic one-off attempts. Directly maps to the cadence ladder we implement in `drip.py` (14d → 45d, max 2 attempts).
+- Key tactic: nail a niche. For reactivation messages, this means referencing the specific thing that made the original contact memorable — not generic reconnect language.
+
+### HubSpot / Bloomreach Lapsed-Lead Sequences
+- Source: https://www.poweredbysearch.com/blog/dead-lead-reviver/ + documentation.bloomreach.com
+- Standard B2B sequence: 3-5 touches, spaced 7-21 days apart.
+- First email: lightest touch. Subject-line-level insight: the shorter and more specific, the better.
+- The walk-away rule: if no response after 3-5 attempts, move to a "sunset" segment. Continuing to reach dormant leads damages sender reputation (email) and wastes equity (personal relationships).
+- B2B-specific: send from the account owner, not a generic alias. The recipient must recognize the name.
+
+### Dan Kennedy / Russell Brunson — Direct Response Reactivation
+- Source: https://marketingsecrets.com/ + https://www.poweredbysearch.com/blog/dead-lead-reviver/
+- Kennedy's core principle: *a list is an asset*. Reactivating 10% of dormant contacts with no acquisition cost beats chasing cold prospects.
+- Brunson's Soap Opera Sequence (SOS): five suspense-filled messages that pull people forward. Applied to reactivation: each message teases something new, not just "are you there?"
+- MIFGE (Most Incredible Free Gift Ever) principle for reactivation: give before you ask. The first reactivation message should reference value — something that happened since you last talked.
+
+### Klaviyo Win-Back Benchmarks (e-commerce, maps to any domain)
+- Source: https://www.klaviyo.com/blog/winback-email-campaign-examples
+- Timing: trigger at 1.5x the average gap between interactions. For dating (avg convo = 2-3 days), this maps to ~14 days — which is exactly what `DEFAULT_CADENCE["reactivation_first_attempt_days"]` encodes.
+- Three-email rule: "keep winback flows to three emails per recipient." Clapcheeks uses max_attempts=2 for messages, which is more conservative — good for personal contexts.
+- 45% of subscribers who receive a win-back message will engage with future outreach from that brand. Applies directly: the reactivation attempt has compounding value even if she doesn't reply immediately.
+- Omnichannel: start with main channel, follow up with secondary. For dating: app DM first, then Instagram DM if connected.
+
+---
+
+## 2. Dating / Interpersonal Psychology
+
+### Mark Manson — Models: Attract Women Through Honesty
+- Source: https://markmanson.net + thepowermoves.com/models/
+- Core framework: "fuck yes or fuck no." Most women who ghost sit in neutral — not a hard no, just unactivated. The reactivation window exists in this neutral zone.
+- **Fading commitment curve**: neutral women will drift toward unreceptive if nothing polarizes them. But re-engagement with a low-pressure, specific message can re-polarize. The window: ~2 weeks for early-stage (opener-ghosted), ~45 days for post-conversation (longer shared history = longer window).
+- The 3-chance rule: try once, try again if blown off, walk away after the third. This directly informs `reactivation_max_attempts=2` — we're giving one + one chance (the original conversation attempts count as earlier contacts).
+- Anti-manipulation principle: Manson's framework explicitly rejects guilt, neediness, and pressure tactics. The playbook must enforce this — every technique in here is about creating genuine interest, not engineering compliance.
+
+### Robert Greene — The Art of Seduction (Methodology Extraction Only)
+- Source: https://thepowermoves.com/the-art-of-seduction-summary/
+- Absence principle: "a seduction requires patience. The longer you take and the slower you go, the deeper you will penetrate into the mind of the other person." This validates the 14-day wait before first reactivation — immediate follow-up after being ghosted reads as desperation.
+- The second seduction framework: "never let the other person take you for granted — use absence, create pain and conflict." Applied ethically: re-engaging after absence is a legitimate, healthy pattern, not a manipulation. The absence is genuine (you moved on with your life). The re-engagement is genuine (something reminded you of them).
+- **Key extraction**: what's useful is the *timing* principle and the *asymmetric investment* principle. The message should feel like it cost you nothing to send, because it genuinely didn't — you thought of something, you sent it. Not "I've been waiting 14 days to reach out."
+
+### Academic Research — Why "Hey Stranger" Fails
+- Source: PMC / Nature Communications 2024 — "People are surprisingly hesitant to reach out to old friends"
+- **Critical finding**: people overestimate the awkwardness of reconnecting and underestimate how positively the outreach is received. This directly answers why most people don't reactivate: they assume rejection, so they don't try.
+- The behavioral warm-up study: participants who spent 3 minutes messaging current contacts first had a 53% higher reconnect rate than the control group. Applied: if you're cold on a reactivation, mentally rehearse the positive outcome before writing.
+- **Why gap-acknowledgment fails**: explicitly naming the gap ("it's been a while") activates the other person's memory of why they stopped responding. It forces them to relitigate the disconnection. Jumping over the gap ("just saw this and thought of you") treats the silence as neutral, not loaded.
+
+### Cialdini — Reciprocity and Liking in Re-engagement
+- Source: https://cxl.com/blog/cialdinis-principles-persuasion/
+- Reciprocity: give first. A reactivation message that references something of value (a shared memory, a specific compliment anchored to their profile) triggers the reciprocity reflex.
+- Liking: "we are more likely to respond to someone we like, who likes us, who we can identify with because we see enough points of similarity." The specific reference in the reactivation message (vs. generic opener) increases perceived similarity and liking.
+- Unity (Cialdini's 7th principle, added later): shared identity. "We were talking about X" invokes group membership. This is why referencing the last real conversation topic is so effective — it re-activates the "we" framing.
+
+---
+
+## 3. Networking Re-engagement
+
+### Keith Ferrazzi — Never Eat Alone
+- Source: https://readingraphics.com/book-summary-never-eat-alone/
+- Core ping strategy: "ping your contacts at least a few times a year — not just when you need something." The key word is *not when you need something*. The reactivation message must feel like it came from abundance, not scarcity.
+- Contact categorization system: Ferrazzi uses tiers (1 = deep, 2 = quarterly touch-base, 3 = annual). "Ghosted" matches are tier-2 or tier-3 — the relationship exists, it just needs a low-cost activation.
+- Birthday principle: best time to reconnect is a natural, expected moment (birthday, job change, shared event). For dating, this maps to: season change ("it finally got warm"), something on their profile that's seasonal, a relevant news item they'd care about.
+- **Never keep score**: Ferrazzi's framework is explicitly reciprocal and non-transactional. Applied to reactivation: you're not "owed" a response. If you burn the attempt on guilt or expectation, you've wasted it.
+
+### MIT Sloan — Dormant Ties Research (Levin, Walter, Murnighan)
+- Source: https://sloanreview.mit.edu/article/the-power-of-reconnection-how-dormant-ties-can-surprise-you/
+- **Core finding**: dormant ties are as valuable — often MORE valuable — than active ties. Advice from dormant ties tends to be more novel and more efficient to get than from current ties.
+- Why: the dormant contact wasn't hibernating while you were apart. They accumulated new experiences, perspectives, context. The reconnection unlocks this fresh capital.
+- For dating translation: she's had new experiences since you last talked. A reactivation message that references something genuinely new (about you or about the world) reactivates fresh curiosity, not stale history.
+- Trust doesn't fade: "old feelings of trust and a common perspective do not fade away and are rekindled almost immediately." This is why the 14-day reactivation window is so powerful — enough time for the slate to feel fresh, not so long that the trust has degraded.
+
+---
+
+## 4. Customer Success / Lapsed Client
+
+### SaaS NRR Recovery — Gainsight / ChurnZero Patterns
+- Source: https://altiorco.com/resources/blog/churn-reduction + saascity.io
+- At-risk detection: early churn signals appear well before the actual cancel. For relationships: the "ghosted" mark in clapcheeks is the equivalent of a usage dip — early enough to intervene.
+- Win-back rate benchmarks: "use cancellation flows to recover 10-15% of exits." In dating context: 10-15% reactivation rate on true ghosts is a realistic and worthwhile target.
+- The reason for lapse matters more than the lapse itself. SaaS playbook: segment churned users by *reason for leaving* before crafting the message. Dating equivalent: segment ghosted matches by stage (opener-ghost vs. post-conversation ghost vs. post-date-ask ghost) and tailor the message accordingly. This is exactly what `_DEFAULT_TEMPLATES` does.
+
+### Braze / ActiveCampaign Win-back Patterns
+- Source: https://www.braze.com/resources/articles/what-is-a-win-back-campaign-anyway
+- Omnichannel sequencing: email first → SMS second → push third. For dating: app message → Instagram DM → email (if exchanged).
+- The "last chance" message: explicitly framing the final outreach as the last reduces friction (no more wondering "should I try again?") while creating mild scarcity. Clapcheeks's `reactivation_max_attempts=2` hard cap makes every second attempt implicitly the last.
+- Sunset non-responders: maintaining a clean "burned" list is as important as the reactivation itself. Continuing to pursue non-responders (after max attempts) damages self-respect and wastes effort.
+
+---
+
+## 5. Cross-Domain Analysis — Universal Patterns
+
+### What Every Framework Agrees On
+
+1. **Specific beats generic, always.** Whether it's sales, dating, or friendship — the message that references something real about the person converts. Generic openers fail because they signal mass outreach.
+
+2. **Low investment signals high value.** Paradoxically, the shorter and more casual the reactivation message, the more interested the recipient is. A long, effortful message signals desperation. A brief, light message signals you have options.
+
+3. **The gap itself is irrelevant.** No successful re-engagement framework asks you to address the gap. Ferrazzi doesn't say "I know I haven't called in 6 months, but..." Kennedy doesn't start with an apology. Manson doesn't recommend explaining the silence. Jump over the gap. The gap is neutral.
+
+4. **Attempt caps exist for a reason.** Two to three attempts, then walk away. This is consistent across every framework: Manson's 3-chance rule, Klaviyo's 3-email winback flow, Bloomreach's sunset cadence, Ferrazzi's tiered contact system. The walk-away is not failure — it's resource allocation.
+
+5. **Timing is the leverage point.** The optimal window for re-engagement (14 days for dating openers, 45 days for post-conversation) isn't arbitrary — it's where enough time has passed for the emotional friction to fade, but not so long that the person has forgotten you entirely.
+
+6. **The recipient's agency is paramount.** Every ethical framework (Manson, Cialdini's proper application, Ferrazzi) respects that the other person can say no. The reactivation message is an invitation, not a demand. Anything coercive, guilt-inducing, or pressure-based is both unethical and counterproductive.
+
+### Universal Banned Phrases (cross-domain)
+These fail in **every** domain — sales, dating, networking, client reactivation:
+
+| Phrase | Why It Fails |
+|--------|-------------|
+| "Just checking in" | Signals no real reason to reach out; pure obligation |
+| "I know it's been a while" | Draws attention to the gap; forces them to relitigate it |
+| "Hey stranger" | Ironic distance; feels like a form letter |
+| "Long time no talk/see" | Same as above; passive-aggressive undertone |
+| "Circling back" | Sales-speak; instantly reads as mass outreach |
+| "Touching base" | Same; the phrase itself signals you have nothing new to say |
+| "Did I do something wrong?" | Guilt-induction; puts pressure on the recipient |
+| "Miss me?" | Clingy, presumptuous |
+| "Remember me?" | Self-deprecating in a way that isn't charming |
+| "Hope you're doing well" | Filler that precedes every cold template ever sent |
+| "Bumping this" | Visible automation; death to any warm relationship |
+
+### Universal Effective Patterns
+| Pattern | Why It Works | Example |
+|---------|-------------|---------|
+| Specific reference to shared context | Cialdini reciprocity + liking; triggers "we" frame | "that hiking trail you mentioned" |
+| Something new about your life | Reactivates curiosity; fulfills the dormant-tie novelty principle | "just got back from..." |
+| Low-pressure invite | Manson's polarize-without-pressure principle | "you should come if you're around" |
+| Relevance anchor | Connects their reality to your outreach | "saw this and thought of you" |
+| Honest casualness | Signals abundance; low investment | "random thought but..." |
+
+---
+
+## 6. Operator Decision Framework
+
+### When to Walk Away vs. Try Again
+
+Consistent across Manson, Kennedy, Ferrazzi, Klaviyo, Bloomreach, Gainsight:
+
+**Walk away when:**
+- You've sent 2 reactivation attempts at the defined intervals
+- The person has actively indicated disinterest (blocked, rude reply, explicit no)
+- The reactivation has a terminal outcome flag (burned, opted_out)
+- You're starting to feel resentment or pressure — that leaks into the message
+
+**Try again when:**
+- Only 1 attempt has been made
+- Significant time has passed since the last attempt (45d+ quiet window)
+- There's a genuinely new reason to reach out (new context, shared event, something on their profile changed)
+- You feel genuinely light and unattached to the outcome
+
+**The confidence/effort calibration rule:** the amount of effort in the reactivation message should be *inversely proportional* to how much you care about the outcome. If you've worked hard on the message, you're too attached. Rewrite it in under 30 seconds.
+
+---
+
+## Sources
+
+1. Aaron Ross / Predictable Revenue: https://www.saastr.com/re-igniting-growth-with-predictable-revenue/
+2. Klaviyo Win-Back: https://www.klaviyo.com/blog/winback-email-campaign-examples
+3. Bloomreach Reactivation Docs: https://documentation.bloomreach.com/engagement/docs/reactivation-campaign-for-lapsing-and-lapsed
+4. Mark Manson — Models summary: https://thepowermoves.com/models/
+5. Robert Greene — Art of Seduction summary: https://thepowermoves.com/the-art-of-seduction-summary/
+6. MIT Sloan — Dormant Ties research: https://sloanreview.mit.edu/article/the-power-of-reconnection-how-dormant-ties-can-surprise-you/
+7. Nature Communications — Reconnecting old friends: https://www.nature.com/articles/s44271-024-00075-8
+8. Keith Ferrazzi — Never Eat Alone summary: https://readingraphics.com/book-summary-never-eat-alone/
+9. Cialdini Principles: https://cxl.com/blog/cialdinis-principles-persuasion/
+10. Braze Win-back: https://www.braze.com/resources/articles/what-is-a-win-back-campaign-anyway
+11. ActiveCampaign Win-back: https://www.activecampaign.com/blog/win-back-email-campaigns
+12. Gainsight Churn Guide: https://www.gainsight.com/essential-guide/churn/
+13. B2B Dead Lead Reviver: https://www.poweredbysearch.com/blog/dead-lead-reviver/
+14. SaaS Churn Reduction: https://altiorco.com/resources/blog/churn-reduction
+15. National Geographic — Reconnect old friends: https://www.nationalgeographic.com/science/article/reconnect-old-friends-loneliness-social-media

--- a/agent/clapcheeks/commands/playbook.py
+++ b/agent/clapcheeks/commands/playbook.py
@@ -1,0 +1,365 @@
+"""Playbook CLI — AI-8815.
+
+Print re-engagement guidance for a ghosted contact without needing
+the Clapcheeks platform.
+
+Usage:
+    clapcheeks playbook --domain dating --ghost-date 2026-04-01
+    clapcheeks playbook --domain sales --ghost-date 2026-03-01 --context "post-demo, mentioned ROI concerns"
+    clapcheeks playbook --domain networking --attempts 1 --last-attempt-date 2026-03-15
+    clapcheeks playbook --list-domains
+    clapcheeks playbook --show-banned --domain sales
+
+Reads guidance from docs/playbooks/reactivation-campaign.md and
+docs/playbooks/banned-phrases.json.
+
+Full methodology: docs/playbooks/reactivation-campaign.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import date, datetime, timedelta
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Paths (relative to the repo root)
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+_BANNED_PHRASES_PATH = os.path.join(
+    _REPO_ROOT, "docs", "playbooks", "banned-phrases.json"
+)
+_PLAYBOOK_PATH = os.path.join(
+    _REPO_ROOT, "docs", "playbooks", "reactivation-campaign.md"
+)
+
+
+# ---------------------------------------------------------------------------
+# Timing constants (mirrors DEFAULT_CADENCE in drip.py)
+# ---------------------------------------------------------------------------
+
+FIRST_ATTEMPT_DAYS = 14
+FOLLOWUP_DAYS = 45
+MAX_ATTEMPTS = 2
+
+
+# ---------------------------------------------------------------------------
+# Domain config
+# ---------------------------------------------------------------------------
+
+DOMAINS = {
+    "dating": {
+        "label": "Dating",
+        "stages": ["opener", "conversing", "date_proposed"],
+        "context_prompt": "What stage did the conversation reach before going quiet?",
+    },
+    "sales": {
+        "label": "Sales",
+        "stages": ["discovery", "demo", "proposal"],
+        "context_prompt": "What was the last touchpoint? (e.g. discovery call, demo, proposal sent)",
+    },
+    "networking": {
+        "label": "Networking",
+        "stages": ["met", "connected", "first_meeting"],
+        "context_prompt": "How did you meet and what did you discuss?",
+    },
+    "friendship": {
+        "label": "Friendship",
+        "stages": ["casual", "close", "lost_touch"],
+        "context_prompt": "What do you remember about your last real conversation?",
+    },
+    "lapsed_client": {
+        "label": "Lapsed Client",
+        "stages": ["churned", "proposal_ignored", "paused"],
+        "context_prompt": "Why did they churn or go quiet? (e.g. pricing, timing, competitor)",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+def _parse_date(date_str: str) -> date:
+    """Parse YYYY-MM-DD string. Raises ValueError on bad input."""
+    try:
+        return datetime.strptime(date_str, "%Y-%m-%d").date()
+    except ValueError:
+        raise ValueError(f"Date must be in YYYY-MM-DD format, got: {date_str!r}")
+
+
+def _days_since(d: date) -> int:
+    return (date.today() - d).days
+
+
+def _load_banned_phrases(domain: Optional[str] = None) -> list[dict]:
+    """Load banned phrases from JSON, optionally filtered by domain."""
+    if not os.path.exists(_BANNED_PHRASES_PATH):
+        return []
+    with open(_BANNED_PHRASES_PATH) as f:
+        data = json.load(f)
+    phrases = data.get("banned_phrases", [])
+    if domain:
+        phrases = [p for p in phrases if domain in p.get("domains", [])]
+    return phrases
+
+
+def _recommend_next_action(
+    ghost_date: date,
+    attempts: int,
+    last_attempt_date: Optional[date],
+) -> dict:
+    """Return the recommended action and target date."""
+    today = date.today()
+    days_ghosted = _days_since(ghost_date)
+
+    if attempts >= MAX_ATTEMPTS:
+        return {
+            "action": "STOP",
+            "reason": f"You've made {attempts} attempts (max: {MAX_ATTEMPTS}). Mark this contact burned.",
+            "target_date": None,
+        }
+
+    if attempts == 0:
+        target = ghost_date + timedelta(days=FIRST_ATTEMPT_DAYS)
+        if today >= target:
+            return {
+                "action": "SEND_NOW",
+                "reason": f"Day {days_ghosted} since ghost. Attempt 1 is due.",
+                "target_date": today,
+            }
+        days_left = (target - today).days
+        return {
+            "action": "WAIT",
+            "reason": f"Wait {days_left} more day(s) before attempt 1 (target: {target}).",
+            "target_date": target,
+        }
+
+    # attempts == 1
+    if last_attempt_date is None:
+        return {
+            "action": "WAIT",
+            "reason": "You made 1 attempt but didn't record the date. Set --last-attempt-date.",
+            "target_date": None,
+        }
+
+    target = last_attempt_date + timedelta(days=FOLLOWUP_DAYS)
+    if today >= target:
+        return {
+            "action": "SEND_NOW",
+            "reason": f"Day {_days_since(last_attempt_date)} since attempt 1. Attempt 2 is due.",
+            "target_date": today,
+        }
+    days_left = (target - today).days
+    return {
+        "action": "WAIT",
+        "reason": f"Wait {days_left} more day(s) before attempt 2 (target: {target}).",
+        "target_date": target,
+    }
+
+
+def _build_output(
+    domain: str,
+    ghost_date: date,
+    attempts: int,
+    last_attempt_date: Optional[date],
+    context: Optional[str],
+) -> str:
+    """Build the full CLI output string."""
+    domain_cfg = DOMAINS.get(domain, {})
+    domain_label = domain_cfg.get("label", domain.title())
+    rec = _recommend_next_action(ghost_date, attempts, last_attempt_date)
+
+    lines = [
+        "",
+        f"  REACTIVATION PLAYBOOK — {domain_label.upper()}",
+        f"  Methodology: docs/playbooks/reactivation-campaign.md",
+        "",
+        "  SITUATION",
+        f"  Domain:         {domain_label}",
+        f"  Ghost date:     {ghost_date} ({_days_since(ghost_date)} days ago)",
+        f"  Attempts made:  {attempts} / {MAX_ATTEMPTS}",
+    ]
+
+    if last_attempt_date:
+        lines.append(f"  Last attempt:   {last_attempt_date} ({_days_since(last_attempt_date)} days ago)")
+    if context:
+        lines.append(f"  Context:        {context}")
+
+    lines += [
+        "",
+        "  RECOMMENDATION",
+        f"  Action:   {rec['action']}",
+        f"  Why:      {rec['reason']}",
+    ]
+
+    if rec["target_date"]:
+        lines.append(f"  Date:     {rec['target_date']}")
+
+    if rec["action"] in ("SEND_NOW",):
+        lines += [
+            "",
+            "  WHAT TO SAY",
+            "  ---------------",
+            "  - Under 15 words",
+            "  - Reference something specific about them or your last conversation",
+            "  - Do NOT acknowledge the gap",
+            "  - Do NOT apologize for the silence",
+            "  - Treat it like you randomly thought of them",
+            "",
+            "  FORMULA:",
+            "  [Specific reference] + [Something new or light signal] + [Optional: soft invite]",
+            "",
+            "  See Part 1 of the playbook for 12 example messages across all domains.",
+        ]
+
+        if context:
+            lines += [
+                "",
+                "  CONTEXT-SPECIFIC TIPS (based on what you provided):",
+                f"  You mentioned: \"{context}\"",
+                "  Use that as your anchor. Reference it specifically, not generically.",
+            ]
+
+    if rec["action"] == "STOP":
+        lines += [
+            "",
+            "  You've made the maximum number of attempts. Walk away cleanly.",
+            "  Optional farewell message (sends no expectation of reply):",
+            "  \"going to leave this one here — if the timing ever changes, you know where to find me.\"",
+        ]
+
+    lines += [
+        "",
+        "  BANNED PHRASES (never use these in this domain):",
+        "  Run: clapcheeks playbook --show-banned --domain " + domain,
+        "",
+    ]
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="clapcheeks playbook",
+        description=(
+            "Print re-engagement guidance for a ghosted contact. "
+            "Full methodology: docs/playbooks/reactivation-campaign.md"
+        ),
+    )
+    parser.add_argument(
+        "--domain",
+        choices=list(DOMAINS.keys()),
+        default="dating",
+        help="Context domain (default: dating)",
+    )
+    parser.add_argument(
+        "--ghost-date",
+        metavar="YYYY-MM-DD",
+        help="Date the contact went quiet",
+    )
+    parser.add_argument(
+        "--attempts",
+        type=int,
+        default=0,
+        help="Number of reactivation attempts already made (default: 0)",
+    )
+    parser.add_argument(
+        "--last-attempt-date",
+        metavar="YYYY-MM-DD",
+        help="Date of the most recent reactivation attempt (required if --attempts > 0)",
+    )
+    parser.add_argument(
+        "--context",
+        metavar="TEXT",
+        help="Free-text context about the relationship / last interaction",
+    )
+    parser.add_argument(
+        "--list-domains",
+        action="store_true",
+        help="List all available domains and exit",
+    )
+    parser.add_argument(
+        "--show-banned",
+        action="store_true",
+        help="Show banned phrases for the domain and exit",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.list_domains:
+        print("\nAvailable domains:\n")
+        for key, cfg in DOMAINS.items():
+            print(f"  {key:<20} {cfg['label']}")
+            print(f"  {'':<20} Context tip: {cfg['context_prompt']}")
+            print()
+        return 0
+
+    if args.show_banned:
+        phrases = _load_banned_phrases(args.domain)
+        if not phrases:
+            print(f"\nNo banned phrases found for domain '{args.domain}'.")
+            print(f"Check: {_BANNED_PHRASES_PATH}")
+            return 1
+        print(f"\nBanned phrases for domain: {args.domain}\n")
+        criticals = [p for p in phrases if p["severity"] == "critical"]
+        highs = [p for p in phrases if p["severity"] == "high"]
+        print("  CRITICAL (never use):")
+        for p in criticals:
+            print(f"    - \"{p['phrase']}\"")
+            print(f"      Why: {p['rationale']}")
+            print(f"      Instead: {p['replacement_pattern']}")
+            print()
+        if highs:
+            print("  HIGH SEVERITY (strongly avoid):")
+            for p in highs:
+                print(f"    - \"{p['phrase']}\"")
+                print(f"      Why: {p['rationale']}")
+                print()
+        return 0
+
+    if not args.ghost_date:
+        print("Error: --ghost-date is required. Use YYYY-MM-DD format.")
+        parser.print_help()
+        return 1
+
+    try:
+        ghost_date = _parse_date(args.ghost_date)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+
+    last_attempt_date = None
+    if args.last_attempt_date:
+        try:
+            last_attempt_date = _parse_date(args.last_attempt_date)
+        except ValueError as e:
+            print(f"Error: {e}")
+            return 1
+
+    if args.attempts > 0 and last_attempt_date is None:
+        print("Warning: --attempts > 0 but --last-attempt-date not set. Timing for attempt 2 will be approximate.")
+
+    output = _build_output(
+        domain=args.domain,
+        ghost_date=ghost_date,
+        attempts=args.attempts,
+        last_attempt_date=last_attempt_date,
+        context=args.context,
+    )
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agent/clapcheeks/followup/reactivation.py
+++ b/agent/clapcheeks/followup/reactivation.py
@@ -1,5 +1,15 @@
 """Ghost-recovery reactivation prompt builder — Phase G2, AI-8804.
 
+**Playbook reference:** docs/playbooks/reactivation-campaign.md
+  The full teachable methodology behind this module — timing ladder,
+  banned phrases, cross-domain adaptations, operator guide, and research
+  bibliography — lives there. If you're extending this module or tuning
+  templates, read Part 2 (Clapcheeks Implementation) and Part 1
+  (Universal Strategy) first.
+
+  Machine-readable banned phrases: docs/playbooks/banned-phrases.json
+  Decision tree and tracker templates: docs/playbooks/templates/
+
 This is a **pure function** module — no Supabase calls, no LLM calls.
 It takes the context of a ghosted match and returns a fully-formed
 system prompt to feed into the existing Phase E pipeline

--- a/agent/tests/test_playbook_cli.py
+++ b/agent/tests/test_playbook_cli.py
@@ -1,0 +1,131 @@
+"""Unit tests for the playbook CLI — AI-8815.
+
+Tests cover:
+- Timing logic (wait / send now / stop)
+- Date parsing
+- Domain selection
+- --list-domains and --show-banned flags
+- Context-aware output
+
+Run: pytest agent/tests/test_playbook_cli.py -v
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import date, timedelta
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from clapcheeks.commands.playbook import (  # noqa: E402
+    FIRST_ATTEMPT_DAYS,
+    FOLLOWUP_DAYS,
+    MAX_ATTEMPTS,
+    _parse_date,
+    _recommend_next_action,
+    main,
+)
+
+
+class TestParseDate:
+    def test_valid_date(self):
+        d = _parse_date("2026-04-01")
+        assert d == date(2026, 4, 1)
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError):
+            _parse_date("04/01/2026")
+
+    def test_nonsense_raises(self):
+        with pytest.raises(ValueError):
+            _parse_date("not-a-date")
+
+
+class TestRecommendNextAction:
+    def _today(self) -> date:
+        return date.today()
+
+    def test_no_attempts_too_soon(self):
+        ghost_date = self._today() - timedelta(days=5)
+        rec = _recommend_next_action(ghost_date, attempts=0, last_attempt_date=None)
+        assert rec["action"] == "WAIT"
+
+    def test_no_attempts_ready(self):
+        ghost_date = self._today() - timedelta(days=FIRST_ATTEMPT_DAYS)
+        rec = _recommend_next_action(ghost_date, attempts=0, last_attempt_date=None)
+        assert rec["action"] == "SEND_NOW"
+        assert "attempt 1" in rec["reason"].lower()
+
+    def test_one_attempt_too_soon(self):
+        ghost_date = self._today() - timedelta(days=FIRST_ATTEMPT_DAYS + 10)
+        last_attempt = self._today() - timedelta(days=10)
+        rec = _recommend_next_action(ghost_date, attempts=1, last_attempt_date=last_attempt)
+        assert rec["action"] == "WAIT"
+
+    def test_one_attempt_ready(self):
+        ghost_date = self._today() - timedelta(days=FIRST_ATTEMPT_DAYS + FOLLOWUP_DAYS)
+        last_attempt = self._today() - timedelta(days=FOLLOWUP_DAYS)
+        rec = _recommend_next_action(ghost_date, attempts=1, last_attempt_date=last_attempt)
+        assert rec["action"] == "SEND_NOW"
+        assert "attempt 2" in rec["reason"].lower()
+
+    def test_max_attempts_stop(self):
+        ghost_date = self._today() - timedelta(days=90)
+        rec = _recommend_next_action(ghost_date, attempts=MAX_ATTEMPTS, last_attempt_date=None)
+        assert rec["action"] == "STOP"
+
+    def test_over_max_attempts_also_stop(self):
+        ghost_date = self._today() - timedelta(days=90)
+        rec = _recommend_next_action(ghost_date, attempts=5, last_attempt_date=None)
+        assert rec["action"] == "STOP"
+
+
+class TestMainCLI:
+    def test_list_domains(self, capsys):
+        result = main(["--list-domains"])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "dating" in captured.out
+        assert "sales" in captured.out
+
+    def test_missing_ghost_date_returns_nonzero(self, capsys):
+        result = main(["--domain", "dating"])
+        assert result != 0
+
+    def test_invalid_ghost_date_returns_nonzero(self, capsys):
+        result = main(["--domain", "dating", "--ghost-date", "not-a-date"])
+        assert result != 0
+
+    def test_send_now_output(self, capsys):
+        ghost_date = (date.today() - timedelta(days=FIRST_ATTEMPT_DAYS)).strftime("%Y-%m-%d")
+        result = main(["--domain", "dating", "--ghost-date", ghost_date])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "SEND_NOW" in captured.out
+
+    def test_wait_output(self, capsys):
+        ghost_date = (date.today() - timedelta(days=2)).strftime("%Y-%m-%d")
+        result = main(["--domain", "dating", "--ghost-date", ghost_date])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "WAIT" in captured.out
+
+    def test_stop_output(self, capsys):
+        ghost_date = (date.today() - timedelta(days=90)).strftime("%Y-%m-%d")
+        result = main(["--domain", "dating", "--ghost-date", ghost_date, "--attempts", "2"])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "STOP" in captured.out
+
+    def test_context_appears_in_output(self, capsys):
+        ghost_date = (date.today() - timedelta(days=FIRST_ATTEMPT_DAYS)).strftime("%Y-%m-%d")
+        result = main([
+            "--domain", "sales",
+            "--ghost-date", ghost_date,
+            "--context", "post-demo mentioned ROI concerns",
+        ])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "ROI concerns" in captured.out

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -1,0 +1,47 @@
+# Playbooks — Clapcheeks Methodology Library
+
+This directory contains teachable, domain-agnostic methodology playbooks extracted from the Clapcheeks AI Dating Co-Pilot system.
+
+## What a Playbook Is
+
+A playbook documents a battle-tested methodology in a format that any operator — technical or not — can pick up and apply the same day. Playbooks:
+
+- Are grounded in research and data, not opinion
+- Include concrete examples (good and bad)
+- Work with or without the Clapcheeks tooling
+- Map explicitly to cross-domain use cases (dating, sales, networking, client recovery)
+- Respect recipient agency — nothing coercive or manipulative
+
+## Available Playbooks
+
+| Playbook | Description | Cross-domain |
+|----------|-------------|--------------|
+| [reactivation-campaign.md](./reactivation-campaign.md) | Ghost-recovery and re-engagement methodology | Dating, sales, networking, lapsed clients |
+
+## Playbook Structure Standard
+
+Every playbook follows this structure:
+
+```
+Part 1: Universal Strategy      — works for any domain, no tooling required
+Part 2: Clapcheeks Implementation — how it maps to the codebase
+Part 3: Cross-Domain Adaptations  — 4 explicit non-dating use cases
+Part 4: Operator Manual           — non-technical step-by-step guide
+Bibliography                      — cited research sources
+```
+
+## Adding a New Playbook
+
+1. Create `docs/playbooks/<name>.md` using the structure above
+2. If it introduces new banned phrases or replacement patterns, add them to `banned-phrases.json`
+3. Add a row to the table in this README
+4. If the playbook maps to agent behavior, add a doc-string reference in the relevant agent module
+
+## Templates
+
+- `templates/reactivation-tracker.md` — copy-paste table for tracking ghosted contacts (no tooling needed)
+- `templates/reactivation-decision-tree.md` — decision tree for when to reach out, when to wait, when to walk away
+
+## Machine-Readable Data
+
+- `banned-phrases.json` — structured list of phrases the AI sanitizer enforces, loadable by any domain configuration

--- a/docs/playbooks/banned-phrases.json
+++ b/docs/playbooks/banned-phrases.json
@@ -1,0 +1,143 @@
+{
+  "_meta": {
+    "version": "1.0.0",
+    "description": "Machine-readable banned phrases for re-engagement / reactivation outreach. Loadable by any domain sanitizer. Grouped by domain applicability and severity.",
+    "severity_levels": {
+      "critical": "Guaranteed to kill the re-engagement. Never use.",
+      "high": "Strongly signals mass outreach or desperation. Avoid in almost all cases.",
+      "medium": "Weakens the message. Acceptable only in specific documented contexts.",
+      "low": "Cliché but not fatal. Replace when possible."
+    },
+    "domains": ["dating", "sales", "networking", "lapsed_client", "friendship"],
+    "source": "docs/playbooks/reactivation-campaign.md",
+    "last_updated": "2026-04-27"
+  },
+  "banned_phrases": [
+    {
+      "phrase": "hey stranger",
+      "severity": "critical",
+      "domains": ["dating", "friendship", "networking"],
+      "rationale": "Ironic framing that immediately signals mass outreach. Nobody says 'hey stranger' to someone they genuinely thought of.",
+      "replacement_pattern": "Start with a specific reference to them or a genuine thought. 'just saw [thing related to their profile]' or jump straight to content."
+    },
+    {
+      "phrase": "long time no talk",
+      "severity": "critical",
+      "domains": ["dating", "friendship", "networking", "sales", "lapsed_client"],
+      "rationale": "Forces the recipient to acknowledge the gap. The gap is neutral — naming it makes it loaded. Triggers the 'why did I stop responding?' reflex.",
+      "replacement_pattern": "Skip the gap entirely. Reference something new or something real from the last conversation."
+    },
+    {
+      "phrase": "long time no see",
+      "severity": "critical",
+      "domains": ["dating", "friendship", "networking", "sales", "lapsed_client"],
+      "rationale": "Same as 'long time no talk' — gap-naming. Makes the receiver re-evaluate the silence.",
+      "replacement_pattern": "Jump over the gap. Start where you are now, not where you left off."
+    },
+    {
+      "phrase": "just checking in",
+      "severity": "critical",
+      "domains": ["sales", "networking", "lapsed_client", "dating", "friendship"],
+      "rationale": "Signals zero real reason to reach out. The phrase exists purely to fulfill an obligation, and the recipient knows it. Universally recognized as a cliché in every outreach context.",
+      "replacement_pattern": "Ask a real question, reference a real thing, or share something genuinely interesting. If you have nothing real to say, wait until you do."
+    },
+    {
+      "phrase": "circling back",
+      "severity": "critical",
+      "domains": ["sales", "networking", "lapsed_client"],
+      "rationale": "Pure sales-speak. Immediately tags the sender as operating from a script, not genuine interest.",
+      "replacement_pattern": "Name the actual topic. 're: the proposal from March' or 'I've been thinking about what you said about X.'"
+    },
+    {
+      "phrase": "touching base",
+      "severity": "critical",
+      "domains": ["sales", "networking", "lapsed_client", "friendship"],
+      "rationale": "Same as 'circling back' — corporate filler that signals the sender has nothing real to say.",
+      "replacement_pattern": "Same as above. Be specific."
+    },
+    {
+      "phrase": "bumping this",
+      "severity": "critical",
+      "domains": ["sales", "networking", "lapsed_client"],
+      "rationale": "Visible automation signal. Confirms to the recipient that this is the 4th follow-up in a sequence and they are on a list.",
+      "replacement_pattern": "If you need a follow-up, reframe it entirely. New subject line, new angle, new reason."
+    },
+    {
+      "phrase": "did i do something wrong",
+      "severity": "critical",
+      "domains": ["dating", "friendship"],
+      "rationale": "Guilt-induction. Forces the recipient to either defend their silence or lie. Creates emotional pressure that makes non-response feel unkind, which triggers avoidance.",
+      "replacement_pattern": "Never address why they went quiet. Reference something real. If you need to address tension, do it directly and once: 'if i said something off, totally understand.'"
+    },
+    {
+      "phrase": "miss me?",
+      "severity": "critical",
+      "domains": ["dating", "friendship"],
+      "rationale": "Presumptuous and clingy. Sets up a power dynamic that puts the sender in a position of seeking validation.",
+      "replacement_pattern": "Don't ask. Share something genuine. If she's going to miss you, make her realize it through what you're doing, not by asking."
+    },
+    {
+      "phrase": "remember me?",
+      "severity": "critical",
+      "domains": ["dating", "networking", "sales"],
+      "rationale": "Self-deprecating in a way that doesn't land. If they might not remember you, give them context naturally. If they definitely remember you, the question is redundant.",
+      "replacement_pattern": "Provide natural context: 'we talked at [event] about [topic]' — or just reference the last real thing you discussed."
+    },
+    {
+      "phrase": "i know it's been a while",
+      "severity": "high",
+      "domains": ["dating", "friendship", "networking", "sales", "lapsed_client"],
+      "rationale": "Gap-naming. Forces the receiver to sit with the gap before they can even read your message. Starting on the back foot.",
+      "replacement_pattern": "Jump straight to the content. The recipient knows how long it's been. You don't need to narrate it."
+    },
+    {
+      "phrase": "hope you're doing well",
+      "severity": "high",
+      "domains": ["sales", "networking", "lapsed_client", "dating", "friendship"],
+      "rationale": "Filler that precedes 100% of cold and form-letter outreach. The recipient pattern-matches it to 'this is a template' before they read the next line.",
+      "replacement_pattern": "Start with the real reason. Or skip formalities entirely: 'random thought' / 'quick one'."
+    },
+    {
+      "phrase": "hope all is well",
+      "severity": "high",
+      "domains": ["sales", "networking", "lapsed_client", "dating", "friendship"],
+      "rationale": "Same pattern as 'hope you're doing well.'",
+      "replacement_pattern": "Same: cut the filler, start with the substance."
+    },
+    {
+      "phrase": "sorry for the late reply",
+      "severity": "medium",
+      "domains": ["dating", "friendship", "networking"],
+      "rationale": "Draws attention to the gap and opens with an apology, which signals you've been thinking about this for a while. Undermines the casual tone.",
+      "replacement_pattern": "Skip the apology. Continue the conversation naturally. If you were genuinely in the wrong, address it directly once, not pre-emptively."
+    },
+    {
+      "phrase": "i've been meaning to reach out",
+      "severity": "medium",
+      "domains": ["friendship", "networking", "dating"],
+      "rationale": "Signals that you've been overthinking this for a while. The best re-engagements feel spontaneous, even when they're planned.",
+      "replacement_pattern": "Just reach out. Don't narrate the reaching out."
+    },
+    {
+      "phrase": "wanted to reconnect",
+      "severity": "medium",
+      "domains": ["networking", "sales", "lapsed_client"],
+      "rationale": "Process narration. You don't need to tell them what you're doing — just do it.",
+      "replacement_pattern": "Skip the meta-commentary. Give them a reason to engage, not a label for what you're attempting."
+    },
+    {
+      "phrase": "per my last email",
+      "severity": "critical",
+      "domains": ["sales", "lapsed_client", "networking"],
+      "rationale": "Passive-aggressive. Even if unintentional, the phrase is so associated with frustration that it immediately puts the recipient on defense.",
+      "replacement_pattern": "Restate the relevant point directly: 'to summarize the proposal: [X].' Leave out the passive reference to prior communication."
+    },
+    {
+      "phrase": "following up on my last message",
+      "severity": "high",
+      "domains": ["sales", "lapsed_client", "networking"],
+      "rationale": "Process narration that reminds them they already ignored you. Start with a fresh angle instead.",
+      "replacement_pattern": "New subject, new angle. Reference the same topic if needed, but frame it as new information: 'one more thought on [topic]...'"
+    }
+  ]
+}

--- a/docs/playbooks/reactivation-campaign.md
+++ b/docs/playbooks/reactivation-campaign.md
@@ -1,0 +1,717 @@
+# Reactivation Campaign Playbook
+
+**Version:** 1.0 — AI-8815  
+**Status:** Production  
+**Domains:** Dating, Sales, Networking, Friendship, Lapsed Clients  
+**Implementation reference:** `agent/clapcheeks/followup/reactivation.py`
+
+---
+
+## What This Playbook Is
+
+This is a methodology document, not a script library. It explains *why* certain re-engagement approaches work and others destroy the relationship entirely. The examples are starting points — adapt them to your voice.
+
+It works whether you're using the Clapcheeks tooling or a calendar and a notes app.
+
+**Ethical note:** everything in here is about creating genuine, honest re-engagement that respects the other person's right to say no. Nothing here is manipulation. The moment you're trying to engineer a response through guilt or pressure, you've left the playbook.
+
+---
+
+## Part 1: Universal Strategy
+
+---
+
+### 1.1 The Core Problem with Most Re-engagement Attempts
+
+Most people fail at re-engagement before they even write a word. The failure is conceptual.
+
+They frame the re-engagement as: *"I need to address the fact that they went quiet."*
+
+This framing is wrong. It puts the silence at the center. The silence is not the story. The silence is background noise.
+
+The right frame is: *"I thought of something real about this person, and I'm sharing it."*
+
+That's it. That's the entire methodology in one sentence. Everything below is detail on how to execute it.
+
+---
+
+### 1.2 Why Gap-Acknowledgment Fails
+
+Research from Nature Communications (2024) on reconnecting with old friends found a counterintuitive pattern: people massively overestimate the awkwardness of reconnecting and underestimate how positively their outreach is received. But the people who fail to reconnect share a common mistake — they focus on the gap rather than the person.
+
+When you open with "it's been a while" or "hey stranger," you're doing two things:
+1. Forcing the recipient to consciously recall why they stopped responding
+2. Signaling that you've been tracking the silence — which reads as either anxious or accusatory
+
+The brain reads "it's been a while" as an implicit question: *"why haven't you reached out?"* Even if that's not your intent, the receiver has to answer that question internally before they can respond to you. Most people, when asked an uncomfortable question, choose non-answer.
+
+The MIT Sloan Management Review research on dormant ties (Levin, Walter, Murnighan) found something that reframes this entirely: dormant relationships don't degrade the way people expect. Trust and goodwill are largely preserved, even after years. The awkwardness people anticipate is mostly imagined. Reconnecting feels like picking up where you left off — *if you don't make the gap the centerpiece*.
+
+**Practical rule: jump over the gap. Treat the silence as neutral. Start where you are now.**
+
+---
+
+### 1.3 The Timing Ladder
+
+This is the most important structural element of any reactivation campaign. Derived from cross-domain analysis of Klaviyo win-back benchmarks, Mark Manson's three-chance framework, and Bloomreach's lapsed-customer cadence:
+
+| Window | What Happens | Why |
+|--------|-------------|-----|
+| Day 0 | Contact goes quiet | Don't reach out yet |
+| Day 1-13 | Quiet period | Too soon. They may still be processing. Reaching out now signals impatience. |
+| Day 14 | Attempt 1 eligible | Enough time for emotional friction to fade. Not so long they've forgotten you. |
+| Day 14-59 after attempt 1 | Quiet window | If attempt 1 got no reply, let it breathe. |
+| Day 60 after attempt 1 | Attempt 2 eligible | If you try again, this is your last shot. Make it count, but keep it light. |
+| After attempt 2 with no reply | Burned | Two fair chances given. Mark it closed. Move on. |
+
+These aren't arbitrary. The 14-day first-attempt window maps directly to Klaviyo's "1.5x the average interaction gap" formula applied to early-stage conversations. The 45-60 day quiet window between attempts matches Robert Greene's absence-creates-desire principle — enough time that your return feels like a genuine surprise rather than a relentless follow-up.
+
+---
+
+### 1.4 The Message Formula
+
+Every effective reactivation message has three components. None of them are optional. Some can be implied, but not skipped.
+
+```
+[Specific reference] + [New information or low-pressure signal] + [Optional: soft invite]
+```
+
+**Specific reference** — something that anchors the message to this person specifically. Not "hey" — that could go to anyone. Something that makes them think "they remembered that?"
+
+**New information or low-pressure signal** — what's new since you last talked? Something about you, something in the world, something you saw. Or simply: the lightness of the message itself signals "I'm doing fine and thought of you."
+
+**Optional soft invite** — a very loose, take-it-or-leave-it invitation. "would be fun to grab a drink if you're around sometime." Not a calendar invite. Not a specific time. Just an open door.
+
+---
+
+### 1.5 The Message Length Rule
+
+Under 15 words. For most contexts — under 10.
+
+This sounds aggressive, but it's backed by every framework we researched. Here's why it matters:
+
+A long message signals effort. Effort signals attachment. Attachment signals you've been thinking about this for days, which signals that the silence affected you more than it should have, which signals that they have power over you.
+
+A short, casual message signals the opposite: you thought of them spontaneously, wrote it in 30 seconds, and sent it. Exactly the way you'd text a friend you randomly thought of. 
+
+The message doesn't need to be impressive. It needs to feel like you didn't try.
+
+---
+
+### 1.6 Banned Phrases (Universal)
+
+These fail in every domain — dating, sales, networking, client recovery. Do not use them:
+
+| Phrase | Why It Fails |
+|--------|-------------|
+| "Hey stranger" | Mass outreach signal. Nobody says this to someone they genuinely thought of. |
+| "Long time no talk/see" | Gap-naming. Forces them to sit in the awkwardness. |
+| "Just checking in" | Signals zero real reason to contact. Pure obligation. |
+| "Circling back" | Pure sales-speak. Confirms you're working from a script. |
+| "Touching base" | Same as circling back. |
+| "Bumping this" | Visible automation. Confirms they're on a list. |
+| "Did I do something wrong?" | Guilt-induction. Creates emotional pressure that triggers avoidance. |
+| "Miss me?" | Clingy, presumptuous. |
+| "Remember me?" | Self-deprecating in a way that doesn't work. |
+| "I know it's been a while" | Gap-naming again. |
+| "Hope you're doing well" | Precedes 100% of cold outreach. Pattern-matched to "template." |
+| "I've been meaning to reach out" | You've been overthinking this. Don't narrate it. |
+| "Following up on my last message" | Reminds them they already ignored you. |
+
+Full machine-readable list with replacements: `docs/playbooks/banned-phrases.json`
+
+---
+
+### 1.7 When to Walk Away
+
+Two attempts. Then stop.
+
+This is consistent across every framework in the research:
+- Mark Manson: three chances total (including the original conversation)
+- Klaviyo: three-email winback, then sunset non-responders
+- Aaron Ross / Predictable Revenue: hard stop on lapsed leads after defined attempts
+- Bloomreach: automatic unsubscribe after winback sequence with no engagement
+
+Walking away is not failure. It's respect — for the other person's right to say no, and for your own time. Continuing to reach out after two ignored attempts is neither kind nor effective. It's just an easier way to feel like you did something.
+
+When you walk away, you also preserve the relationship for a genuinely different future context. A contact you politely stopped pursuing is recoverable. A contact you harassed is not.
+
+---
+
+## Part 2: Clapcheeks Implementation
+
+---
+
+### 2.1 State Machine Overview
+
+```mermaid
+stateDiagram-v2
+    [*] --> Active: match created
+
+    Active --> Ghosted: silence > configured threshold
+    Active --> Dated: date booked
+
+    Ghosted --> Reactivatable: 14+ days elapsed, attempts < max
+    Ghosted --> Burned: attempts >= max (default: 2)
+
+    Reactivatable --> Reactivating: reactivation queued
+    Reactivating --> Active: she replies (platform ingest flips status)
+    Reactivating --> Waiting: message sent, quiet window active
+
+    Waiting --> Reactivatable: 45+ days since last attempt
+    Waiting --> Burned: max attempts reached
+
+    Burned --> [*]: reactivation_outcome = "burned"
+```
+
+The full implementation lives in `agent/clapcheeks/followup/drip.py`. The reactivation-specific prompt builder is in `agent/clapcheeks/followup/reactivation.py`.
+
+---
+
+### 2.2 Key Configuration Values
+
+```python
+# From DEFAULT_CADENCE in drip.py
+"reactivation_first_attempt_days": 14.0   # days after ghosted -> first attempt
+"reactivation_followup_days": 45.0         # days between attempts
+"reactivation_max_attempts": 2             # hard cap; beyond this -> burned
+"reactivation_quiet_window_days": 60.0     # do not re-attempt within N days of last
+```
+
+These are overridable per user via `persona.followup_cadence` in `clapcheeks_user_settings`.
+
+---
+
+### 2.3 Template Selection Logic
+
+The `build_reactivation_prompt` function in `reactivation.py` selects a template based on the stage when the match went quiet:
+
+| Stage | Template Focus |
+|-------|---------------|
+| `opened` | Opener sent, no reply. Reference something from profile, 10 words max. |
+| `conversing` | Mid-conversation stall. Reference the conversation's last real topic. |
+| `date_proposed` | Date ask was ignored. Pop back in casually, no mention of the ask. |
+| `default` | Fallback for unknown stages. Light, genuine, 10 words max. |
+
+---
+
+### 2.4 Sanitizer Integration
+
+All reactivation drafts pass through `clapcheeks.ai.sanitizer.sanitize_and_validate` before queuing. The sanitizer checks for banned phrases (configured in `persona.banned_words`), banned punctuation (em-dashes, semicolons), Unicode glyphs, and length limits.
+
+To extend the banned-phrase list from this playbook's `banned-phrases.json`:
+
+```python
+# In your persona configuration or sanitizer loader:
+import json
+
+with open("docs/playbooks/banned-phrases.json") as f:
+    data = json.load(f)
+
+# Filter by domain and severity
+domain = "dating"
+banned = [
+    p["phrase"] for p in data["banned_phrases"]
+    if domain in p["domains"] and p["severity"] in ("critical", "high")
+]
+```
+
+The sanitizer will reject any draft containing these phrases and log the discard.
+
+---
+
+### 2.5 Opt-Out and Override
+
+Per-match opt-out: set `reactivation_disabled = true` on the match row. The state machine returns `noop` immediately.
+
+Terminal outcomes: `reactivation_outcome` values of `"burned"`, `"ignored"`, or `"opted_out"` are permanent. Once set, the reactivation arm exits.
+
+---
+
+## Part 3: Cross-Domain Adaptations
+
+---
+
+### 3.1 Sales Nurture — Dead Lead Reactivation
+
+**Context:** A prospect went through your pipeline, had calls, maybe a demo, then went quiet. They haven't responded in 2+ months.
+
+**What doesn't work:** "Just wanted to follow up on the proposal we sent." They know. That's why they went quiet.
+
+**What works:**
+
+**Stage: Early-stage ghost (one call, then silence)**
+
+Good example:
+> "[Name] — we just shipped the integration you asked about in our call. might be a different conversation now."
+
+Why it works: Specific reference to something they cared about. New information (the integration shipped). Zero pressure. If the integration matters to them, they'll reply. If it doesn't, you've learned something.
+
+Bad example:
+> "Hi [Name], just checking in to see if you've had a chance to review the proposal I sent over. I know you were busy — totally understand. Let me know if you have any questions!"
+
+Why it fails: "just checking in" is dead on arrival. "I know you were busy" is an implicit guilt-trip. "Let me know if you have any questions" is a non-ask. The whole thing signals that you have no other prospects.
+
+---
+
+**Stage: Post-demo ghost (they saw it, then silence)**
+
+Good example:
+> "quick thought — [specific pain point from their demo call]. we fixed that last week. different story now if you want to take another look."
+
+Why it works: Specific reference to something real they raised. New information. The phrase "different story now" is a light invitation to re-evaluate, not a pressure to decide.
+
+Bad example:
+> "Hi [Name], circling back on the demo from last month. You mentioned ROI was a concern — I wanted to address that. We have some case studies that might help. Would love to hop on a 15-minute call to discuss. How does next week look?"
+
+Why it fails: "circling back" is template-speak. The immediate ask for a call before they've re-engaged adds friction. The specificity in the bad example is actually there — but it's buried under process narration that signals CRM automation.
+
+---
+
+**The sales walk-away message (use only after 2 failed attempts):**
+> "[Name] — going to stop nudging. if the timing changes, you know where to find me."
+
+Why it works: clean, no guilt, leaves the door open. The brevity signals confidence. Many prospects reply to this one — it's a pattern sometimes called the "break-up email" in B2B sales, and its conversion rate is disproportionately high relative to the effort.
+
+---
+
+### 3.2 Networking Re-engagement — Dormant Professional Contacts
+
+**Context:** Someone you met at a conference, worked with at a previous job, or connected with online. You haven't talked in 6-18 months.
+
+**The MIT Sloan advantage:** Dormant ties provide *more* novel value than active ties because they've been accumulating new experiences while the connection was dormant. You're not just reactivating a relationship — you're accessing someone who has grown since you last talked. Lead with curiosity about what they've built, not with what you need.
+
+**Good example — conference contact, 8 months dormant:**
+> "saw that [their company] just closed the series B. congrats. that launch you mentioned is probably a different conversation now."
+
+Why it works: Specific reference (the conversation you had), new information (they closed funding), light question implied (what does the launch look like now?). You did one minute of LinkedIn research and it shows.
+
+**Bad example:**
+> "Hi [Name], hope you're doing well! I wanted to reconnect and see if there might be any opportunities for us to collaborate. I've been keeping an eye on what [company] is doing and I'm impressed. Would love to catch up over coffee sometime. Let me know if you're free!"
+
+Why it fails: "hope you're doing well" is a template opener. "wanted to reconnect" is process narration. "see if there might be any opportunities" signals you want something from them. "coffee sometime" with no specificity is a soft invite that easy to say yes to in theory and forget in practice.
+
+**Good example — former colleague, 1 year dormant:**
+> "hey — random question. you were deep in [specific technology] at [old company]. still thinking about it? working on something and you'd have an opinion."
+
+Why it works: Specific to their expertise, signals you value their perspective (not just their network), framed as a genuine question not a request. The phrase "you'd have an opinion" is a compliment that doesn't feel like one.
+
+---
+
+### 3.3 Friendship Re-engagement — Lost Touch with a Friend
+
+**Context:** A friend you've grown apart from — moved cities, life got busy, different seasons. You've thought about reaching out for months. This is the hardest category because the stakes feel personal.
+
+**The research insight:** People are surprisingly hesitant to reach out to old friends — and systematically underestimate how welcome the outreach will be. In a 2024 Nature Communications study, over 90% of people could name a friend they wanted to reconnect with, but only a third actually sent a message when given the opportunity. The reluctance is mostly imagined. Send the message.
+
+**Good example — friend from college, 2 years dormant:**
+> "just watched [show/movie you know they'd love]. remembered you'd been waiting for it. was i right?"
+
+Why it works: Something specific they cared about, a genuine question, zero pressure. The question gives them an easy, fun reply. It also signals you remember the real things about them, not just that you exist.
+
+**Bad example:**
+> "hey! omg it's been forever. i've been meaning to reach out for so long. life has just been so crazy. how are you? what are you up to? we should definitely hang out soon!"
+
+Why it fails: Every sentence signals mass or obligation outreach. "it's been forever" draws attention to the gap. "i've been meaning to reach out" narrates your failure to do so. "how are you?" is a social pleasantry that doesn't require a real answer. "we should definitely hang out soon" is a soft commit that goes nowhere.
+
+**Good example — friend who moved to another city:**
+> "coming to [their city] for [real reason] next month. if you're around, i'm buying."
+
+Why it works: Specific, concrete, low-pressure, you're offering value (your visit + the drink). They don't have to commit to anything — they can say "great, when?" or let it go. Either way is fine.
+
+---
+
+### 3.4 Lapsed Client Re-engagement
+
+**Context:** A former client whose contract ended, or who went quiet after a proposal. You want to see if there's a renewed fit.
+
+**Unique challenge:** Unlike dating or friendship, there's an explicit commercial context. You can't ignore it — but you also can't lead with it. The key is leading with genuine value and letting the commercial conversation follow naturally.
+
+**Good example — client who churned 6 months ago:**
+> "[Name] — we just released [specific feature they requested when they left]. thought you'd want to know."
+
+Why it works: Specific (the feature they asked for), new information (it shipped), no sales pitch embedded. If they care about the feature, they'll ask about pricing themselves.
+
+**Bad example:**
+> "Hi [Name], hope you're well! I wanted to touch base and see if your needs have evolved since we last worked together. We've made a lot of improvements to the platform that I think would be relevant to your team. Would love to schedule a call to reconnect!"
+
+Why it fails: "touch base" is dead. "hope you're well" is dead. "your needs have evolved" is generic. "a lot of improvements" is vague. "schedule a call" is a demand before re-engagement.
+
+**Good example — lapsed client, proposal ignored:**
+> "one thought I forgot to include in the proposal: [specific thing relevant to their business]. probably changes the math."
+
+Why it works: Specific, new information, implies you've been thinking about their problem specifically. "probably changes the math" is a light invite to revisit without demanding it.
+
+**The lapsed-client walk-away:**
+> "[Name] — going to leave this one here. if the timing changes or you want a different approach, happy to pick this up. best of luck with [specific project you know about]."
+
+Why it works: Clean close, no guilt, specific enough to feel human, leaves the door open with zero pressure.
+
+---
+
+## Part 4: Operator Playbook — No Tooling Required
+
+---
+
+### 4.1 What You Need
+
+- A way to track contacts (spreadsheet, Notion, Apple Notes — anything works)
+- A calendar for reminders
+- The reactivation tracker template: `docs/playbooks/templates/reactivation-tracker.md`
+- This playbook
+
+That's it. No software, no automation, no AI required.
+
+---
+
+### 4.2 Step-by-Step for a Single Contact
+
+**Day 0: They go quiet**
+
+Add them to your tracker with today's date. Set a calendar reminder for Day 14. Close the tracker. Don't think about it until then.
+
+This is important: the waiting is structural, not emotional. You're not "giving it time" in the hope they'll miss you. You're waiting because reaching out before Day 14 signals impatience, and impatience is unattractive in every context.
+
+---
+
+**Day 14: Write Attempt 1**
+
+Open the tracker. Look at what you know about this person:
+- What was the last real thing you discussed?
+- What do you know about their interests, job, life?
+- What's happened in the world or in your life that connects to who they are?
+
+Write a message in under 60 seconds. Under 15 words. Don't reference the gap. Don't apologize. Jump straight to the content.
+
+If you can't think of anything genuine to say: set the reminder for Day 21 and try again then. A bad message sent on schedule is worse than a good message sent a week late.
+
+---
+
+**After Attempt 1**
+
+- If they reply: great. Continue the conversation.
+- If no reply: set a calendar reminder for Day 60 after attempt 1. Close the tracker. Move on with your life. Do not think about this person until the reminder fires.
+
+---
+
+**Day 60 after Attempt 1: Write Attempt 2 (if you want to)**
+
+This is optional. Two attempts is the standard. One attempt is entirely valid. Never more than two.
+
+Attempt 2 should feel different from Attempt 1. Don't repeat the same angle. Find something new:
+- Something that happened in your life that they'd find interesting
+- A low-pressure, specific invite to something real
+- A genuinely different observation about something in their world
+
+---
+
+**After Attempt 2**
+
+- If they reply: great.
+- If no reply: mark them burned in the tracker. Do not reach out again. Ever. This isn't about giving up — it's about respecting that two messages with no response is a clear signal, and continuing beyond that harms your reputation and their peace.
+
+---
+
+### 4.3 Managing Multiple Contacts
+
+Use the tracker template to manage up to 20-30 active reactivations at once. Set weekly calendar blocks (15 min) to:
+
+1. Review who has a reminder firing this week
+2. Write messages for eligible contacts
+3. Update the tracker with results
+4. Mark burned any contacts whose second attempt got no reply
+
+If you're managing more than 30, you need a spreadsheet and likely some automation. The Clapcheeks tooling handles this automatically at scale.
+
+---
+
+### 4.4 Choosing What to Say — A Practical Method
+
+When you sit down to write the message, run through this checklist:
+
+**The 5-second scan:**
+1. Look at the last 3 things you know about this person
+2. What happened in the world this week that connects to any of them?
+3. What happened in your life this week that they'd find interesting?
+
+If one of those questions generates a genuine thought, that's your message. If none of them do, wait.
+
+**The 10-word test:**
+Write your core message. Remove every word that doesn't carry weight. If what's left makes sense, send it.
+
+**The "would I say this to a friend?" test:**
+Would you say this exact thing, out loud, to a friend you randomly ran into? If yes, send it. If it would sound weird out loud, it'll sound weird in text.
+
+---
+
+### 4.5 The Confidence Calibration Check
+
+Before you send: notice how attached you feel to the outcome.
+
+If you're refreshing your messages app 10 minutes after sending: that's attachment. It leaks into the message itself — often through length, over-explanation, or a subtle pressure in the word choices.
+
+The messages that convert are the ones written and sent without urgency. The sender genuinely moved on and happened to think of the person. That casualness is detectable. Manufacture it by actually moving on, not by pretending to.
+
+Practical: write the message, put your phone down, do something else for an hour. Then decide whether to send.
+
+---
+
+## Example Library
+
+### Section A: Good Examples (12 messages, 3 stages × 4 domains)
+
+---
+
+**Dating / Opener Ghost (Attempt 1)**
+
+Scenario: You matched on Hinge, sent an opener about her love of bouldering, she never replied. 17 days later.
+
+> "bet you've crushed v5 by now"
+
+Why it works: Specific reference (bouldering from her profile), light assumption that she's progressed, 7 words, no mention of the match or the silence. It's the kind of message you'd send a friend who climbs.
+
+---
+
+**Dating / Mid-Conversation Ghost (Attempt 1)**
+
+Scenario: You were talking for a week, she went quiet mid-thread about where to eat in your city. 15 days later.
+
+> "went to [restaurant you mentioned] — you were right about the wait"
+
+Why it works: Direct callback to the conversation topic, new information (you actually went), gives her something to respond to without requiring any emotional processing.
+
+---
+
+**Dating / Post-Date-Ask Ghost (Attempt 2)**
+
+Scenario: You asked her out, she didn't confirm, it fizzled. Attempt 1 was ignored. 50 days later.
+
+> "going to [event related to her interests] next weekend — thought you might be into it"
+
+Why it works: Specific invite that doesn't require her to admit she ignored the date ask. It's a fresh start. The invite is real and specific enough to be credible.
+
+---
+
+**Sales / Early-Stage Ghost (Attempt 1)**
+
+Scenario: Discovery call went well, sent the proposal, no response for 3 weeks.
+
+> "[Name] — we just added the [specific integration they asked about]. might change your math on the timing."
+
+Why it works: Specific to their ask, new information, invites re-evaluation without demanding it.
+
+---
+
+**Sales / Post-Demo Ghost (Attempt 2)**
+
+Scenario: Demo was positive, they said they'd discuss internally, then disappeared. Attempt 1 ignored. 6 weeks later.
+
+> "one thing I forgot to mention in the demo: [specific capability relevant to their use case]. worth a 20-minute conversation if the timing works."
+
+Why it works: Genuinely new information (not a repeat), specific to their context, the time ask is specific (20 min) and light.
+
+---
+
+**Sales / Walk-Away (Final)**
+
+Scenario: Two attempts with no reply.
+
+> "[Name] — going to leave this one here. if anything changes, you know where to find me."
+
+Why it works: Clean close, no guilt, signals confidence. Often triggers replies from people who were genuinely just busy and felt bad about not responding sooner.
+
+---
+
+**Networking / Conference Contact Ghost (Attempt 1)**
+
+Scenario: Met at a conference, had a great conversation about their pivot, connected on LinkedIn, then silence for 4 months.
+
+> "saw you're at [new role/company] now. how's the pivot going?"
+
+Why it works: Specific (their career move), genuine curiosity question, no agenda.
+
+---
+
+**Networking / Former Colleague Ghost (Attempt 1)**
+
+Scenario: Worked together 2 years ago, connected on LinkedIn but never really talked after you both left the company.
+
+> "randomly — do you still know [specific technical area]? working on something and your brain would help."
+
+Why it works: Specific to their expertise, frames them as valuable, the "randomly" signals it's a genuine thought not a planned outreach.
+
+---
+
+**Friendship / College Friend Ghost (Attempt 1)**
+
+Scenario: Best friend from college, you've both been busy, 18 months since last real conversation.
+
+> "finally watched [show they recommended]. you were right."
+
+Why it works: Calls back to something they told you about, validates their recommendation, easy to reply to ("wasn't it incredible?").
+
+---
+
+**Friendship / Long-Dormant Friend (Attempt 2)**
+
+Scenario: Attempt 1 ("saw this and thought of you" link to something relevant) was ignored. 6 weeks later.
+
+> "coming to [their city] in [month]. if you're around, i owe you a drink."
+
+Why it works: Concrete, specific, low-pressure, you're offering value (the drink, the visit). They can engage or not — either signal is useful.
+
+---
+
+**Lapsed Client / Churned on Pricing (Attempt 1)**
+
+Scenario: Client left because the pricing didn't fit their budget. 5 months later, you've launched a new tier.
+
+> "[Name] — we just launched a [tier name] plan at [price]. might be the conversation we should have had last time."
+
+Why it works: Specific to why they left, new information (new tier), doesn't require them to admit the previous churn was wrong.
+
+---
+
+**Lapsed Client / Proposal Ignored (Attempt 2)**
+
+Scenario: Proposal was ignored. Attempt 1 ("one thing I forgot") got no reply. 45 days later.
+
+> "going to leave this one here — if the timing shifts or you want a different approach, I'm easy to reach. good luck with [specific initiative they mentioned]."
+
+Why it works: Clean walk-away that doesn't burn the relationship. The specific reference at the end proves this is a human message, not a template.
+
+---
+
+### Section B: Bad Examples (12 messages, with explanations)
+
+---
+
+**Dating / Opener Ghost — Wrong**
+
+> "hey stranger! it's been a while haha. wanted to check in and see if you're still active on here? would love to grab coffee if you're interested :)"
+
+Why it fails: "hey stranger" + "it's been a while" + "wanted to check in" — three banned phrases in the first two sentences. The exclamation marks and emoji signal effort. "Still active on here" is passive-aggressive (implying she's ignoring you). The question format makes it easy to not reply.
+
+---
+
+**Dating / Mid-Conversation Ghost — Wrong**
+
+> "did i say something wrong? i thought we were having a good conversation but then you went quiet. just wanted to check in and make sure everything is okay"
+
+Why it fails: Opens with guilt-induction. "I thought we were having a good conversation" is fishing for validation. "Went quiet" labels the behavior you're trying to move past. This is the message that cements the ghost rather than ending it.
+
+---
+
+**Dating / Post-Date-Ask Ghost — Wrong**
+
+> "hey! so i guess you're not interested anymore? i asked you out and never heard back lol. no worries if that's the case, just would have appreciated a response. anyway hope you're doing well!"
+
+Why it fails: Passive-aggressive throughout. "I guess you're not interested anymore" is a question that forces an uncomfortable answer. "Would have appreciated a response" is a mild scolding. "No worries" + "anyway" signal emotional damage control. "Hope you're doing well!" is a template closer. This message ensures she never responds.
+
+---
+
+**Sales / Early-Stage Ghost — Wrong**
+
+> "Hi [Name], just circling back on the proposal I sent three weeks ago. I wanted to see if you had a chance to review it and if you had any questions. Happy to jump on a quick call this week to walk through it. How does your schedule look?"
+
+Why it fails: "Circling back" is dead. "I wanted to see if you had a chance" is mealy-mouthed. Three questions in one message adds decision friction. The ask for a meeting before they've re-engaged is too much.
+
+---
+
+**Sales / Post-Demo Ghost — Wrong**
+
+> "Hi [Name], hope all is well! Following up on our demo from last month. I know you mentioned you'd take it to your team — just wanted to see where things landed. We have some great case studies that might help move things forward internally. Would love to reconnect!"
+
+Why it fails: "Hope all is well" is a template opener. "Following up" is process narration. "I know you mentioned" is subtle pressure (proving you remember their commitment). "Would love to reconnect" is vague. The case studies offer is a burden, not a value add.
+
+---
+
+**Sales / Walk-Away — Wrong**
+
+> "Hi [Name], this is my last attempt to reach out. I've tried reaching you multiple times and haven't heard back. I just want to make sure everything is okay and that I haven't done anything to upset you. Please let me know either way. I value our potential partnership and hope we can work together."
+
+Why it fails: Guilt-induction in every sentence. "My last attempt" is manipulative framing. "I just want to make sure everything is okay" is passive. "I haven't done anything to upset you" is fishing. "Please let me know either way" is a demand for emotional labor. The word "partnership" before any deal exists is premature.
+
+---
+
+**Networking / Conference Contact Ghost — Wrong**
+
+> "Hi [Name], hope you've been well! I've been meaning to reach out since we met at [conference] — life just got so busy. I'd love to reconnect and see if there might be some synergies between what we're both doing. Would you be open to a 30-minute coffee chat?"
+
+Why it fails: "Hope you've been well" + "been meaning to reach out" + "life just got so busy" — trifecta of filler and self-excuse. "Synergies" is corporate nonsense. A 30-minute coffee chat ask as the first message after months of silence is too much friction.
+
+---
+
+**Networking / Former Colleague Ghost — Wrong**
+
+> "Hey [Name]! Long time no talk! I've been keeping an eye on what you've been up to and it looks like you've been doing great things. I'm working on something new and would love to pick your brain sometime. Let me know if you're free for a call!"
+
+Why it fails: "Long time no talk" is gap-naming. "Keeping an eye on what you've been up to" reads as surveillance, not genuine interest. "Pick your brain" is a request that gives them nothing. "Let me know if you're free" is a low-commitment ask that's easy to defer.
+
+---
+
+**Friendship / College Friend Ghost — Wrong**
+
+> "omg hey!! it literally feels like forever. i've been so bad at keeping in touch and i feel so guilty about it. we really need to hang out soon — i miss you! how has everything been??"
+
+Why it fails: Opens with self-flagellation (guilt-tripping yourself is still guilt-tripping). "We really need to hang out soon" is a soft commitment that goes nowhere. "How has everything been?" is a social question that doesn't require a real answer.
+
+---
+
+**Friendship / Long-Dormant Ghost — Wrong**
+
+> "hey. sorry for the late reply. i know it's been way too long. i've been going through a lot and just haven't had the bandwidth to keep up with people. i hope you understand. i miss our friendship and would love to reconnect when things calm down."
+
+Why it fails: Opens with apology and then immediately explains why it's not really the sender's fault. "When things calm down" is not a plan — it's a deferral. The whole message is about the sender's internal state, not the recipient.
+
+---
+
+**Lapsed Client / Churned — Wrong**
+
+> "Hi [Name], hope everything is going well with [company]. I wanted to touch base and see if your situation has changed since we last worked together. We've made a lot of improvements since then and I think you'd be impressed. Would love to get your thoughts over a quick call."
+
+Why it fails: "Touch base" is dead. "I think you'd be impressed" is telling them how to feel. "A lot of improvements" is generic. The call ask before re-engagement is too much too soon.
+
+---
+
+**Lapsed Client / Final Walk-Away — Wrong**
+
+> "Hi [Name], I've now reached out multiple times and haven't heard back. I want to be respectful of your time, but I also want to make sure we've fully explored whether there's an opportunity here. If you're not interested, I completely understand, but I'd appreciate just a quick yes or no. Thank you for your time."
+
+Why it fails: Leads with a subtle accusation ("I've now reached out multiple times"). "I want to be respectful of your time" is contradicted by what follows. "A quick yes or no" is a guilt-inducing demand for emotional labor. "Thank you for your time" is passive-aggressive in context.
+
+---
+
+## Bibliography
+
+1. Levin, D.Z., Walter, J., & Murnighan, J.K. — "The Power of Reconnection: How Dormant Ties Can Surprise You." MIT Sloan Management Review. https://sloanreview.mit.edu/article/the-power-of-reconnection-how-dormant-ties-can-surprise-you/
+
+2. Perkins, A.W., et al. — "People are surprisingly hesitant to reach out to old friends." Nature Communications Psychology, 2024. https://www.nature.com/articles/s44271-024-00075-8
+
+3. Cialdini, R.B. — *Influence: The Psychology of Persuasion*. Overview: https://cxl.com/blog/cialdinis-principles-persuasion/
+
+4. Manson, M. — *Models: Attract Women Through Honesty*. Summary: https://thepowermoves.com/models/
+
+5. Greene, R. — *The Art of Seduction*. Methodology extraction (absence, patience, timing): https://thepowermoves.com/the-art-of-seduction-summary/
+
+6. Ferrazzi, K. — *Never Eat Alone*. Summary: https://readingraphics.com/book-summary-never-eat-alone/
+
+7. Ross, A. & Tyler, M. — *Predictable Revenue*. Re-ignition playbook: https://www.saastr.com/re-igniting-growth-with-predictable-revenue/
+
+8. Klaviyo — Win-Back Email Campaign Best Practices. https://www.klaviyo.com/blog/winback-email-campaign-examples
+
+9. Braze — What Is a Win-Back Campaign? https://www.braze.com/resources/articles/what-is-a-win-back-campaign-anyway
+
+10. Bloomreach — Reactivation Campaign for Lapsing and Lapsed Customers. https://documentation.bloomreach.com/engagement/docs/reactivation-campaign-for-lapsing-and-lapsed
+
+11. Powered by Search — B2B SaaS Reactivation Emails for Dead Leads. https://www.poweredbysearch.com/blog/dead-lead-reviver/
+
+12. Gainsight — Essential Guide to Customer Churn. https://www.gainsight.com/essential-guide/churn/
+
+13. Altior & Co — B2B SaaS Churn Reduction Playbook. https://altiorco.com/resources/blog/churn-reduction
+
+14. National Geographic — "It's hard to reconnect with old friends." https://www.nationalgeographic.com/science/article/reconnect-old-friends-loneliness-social-media
+
+---
+
+*This playbook is part of the Clapcheeks methodology library. For the decision tree: `docs/playbooks/templates/reactivation-decision-tree.md`. For the contact tracker: `docs/playbooks/templates/reactivation-tracker.md`. For banned phrases JSON: `docs/playbooks/banned-phrases.json`.*

--- a/docs/playbooks/templates/reactivation-decision-tree.md
+++ b/docs/playbooks/templates/reactivation-decision-tree.md
@@ -1,0 +1,147 @@
+# Reactivation Decision Tree
+
+Use this before writing any re-engagement message. Answer each question in order.
+
+---
+
+## ASCII Decision Tree
+
+```
+START: Should I reach out to this ghosted contact?
+|
++-- Has it been fewer than 14 days since they went quiet?
+|   |
+|   YES --> WAIT. Too soon. They may still be processing.
+|           Set a calendar reminder for day 14.
+|   |
+|   NO --> Continue.
+|
++-- Have I already sent 2 reactivation attempts?
+|   |
+|   YES --> STOP. You've given them two fair chances.
+|           Mark as burned. Move on.
+|   |
+|   NO --> Continue.
+|
++-- Did I attempt to reach out less than 45 days ago?
+|   |
+|   YES --> WAIT. Quiet window active. Too soon for attempt 2.
+|           Set a reminder for day 45 after last attempt.
+|   |
+|   NO --> Continue.
+|
++-- Do I have a specific, genuine reason to reach out?
+|   (a memory from the conversation, something on their profile,
+|    a shared interest, something new in your life)
+|   |
+|   NO --> WAIT. Don't reach out with nothing to say.
+|          Wait until something real comes to mind.
+|   |
+|   YES --> Continue.
+|
++-- Is my intended message under 15 words?
+|   |
+|   NO --> Shorten it. If you can't say it in 15 words,
+|          you're working too hard. Working hard signals attachment.
+|   |
+|   YES --> Continue.
+|
++-- Does my message mention the gap?
+|   ("it's been a while", "long time no talk", "hey stranger")
+|   |
+|   YES --> Remove it. Jump straight to the content.
+|          The gap is neutral. Don't make it loaded.
+|   |
+|   NO --> Continue.
+|
++-- Does my message guilt-trip or pressure them?
+|   ("did I do something wrong?", "I've been waiting", "miss me?")
+|   |
+|   YES --> Start over. The message is coming from a
+|          place of attachment, not abundance.
+|   |
+|   NO --> SEND IT.
+```
+
+---
+
+## Plain English Version
+
+**Step 1 — Check timing**
+- If it's been fewer than 14 days: wait.
+- If you already sent one attempt and it's been fewer than 45 days: wait.
+- If you've sent 2 attempts: stop. Mark them burned.
+
+**Step 2 — Check your reason**
+You need a real reason. Not "I want to try again." That's not a reason — that's a feeling. A real reason is:
+- Something from your last conversation you can reference
+- Something you saw that made you think of them specifically
+- Something new in your life that connects to who they are
+- A genuine, low-pressure invite to something relevant
+
+If you don't have a real reason, wait until you do.
+
+**Step 3 — Write the message**
+Under 15 words. Lowercase (for apps/texts). No gap-acknowledgment. No guilt. No apology.
+
+**Step 4 — Read it out loud**
+Does it sound like something you'd say to a friend you thought of randomly? Good. Send it.
+Does it sound like you've been thinking about sending this for days? Rewrite it.
+
+**Step 5 — After sending**
+- If they reply: great. Continue the conversation.
+- If no reply in 45 days: optional second attempt following the same rules.
+- If no reply to 2 attempts: mark burned. Done.
+
+---
+
+## State Machine (Mermaid)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Active: matched / first contact
+
+    Active --> Ghosted: silence after N days
+    Active --> [*]: conversation + date booked
+
+    Ghosted --> Reactivatable: 14+ days elapsed, attempt count < 2
+    Ghosted --> Burned: 2 attempts exhausted
+
+    Reactivatable --> Reactivating: attempt queued
+    Reactivating --> Active: she replies
+    Reactivating --> Waiting: message sent, no reply yet
+
+    Waiting --> Reactivatable: 45+ days elapsed (attempt 2 eligible)
+    Waiting --> Burned: 2 attempts exhausted with no reply
+
+    Burned --> [*]: close, move on
+```
+
+---
+
+## One-Page Summary Card
+
+Print this. Put it somewhere visible.
+
+```
++------------------------------------------------------+
+| REACTIVATION — THE RULES                             |
+|                                                      |
+| WAIT  14 days before attempt 1                       |
+| WAIT  45 days before attempt 2 (from attempt 1)      |
+| STOP  after 2 attempts with no reply                 |
+|                                                      |
+| DO:                                                  |
+|  - Specific reference to them or your life           |
+|  - Under 15 words                                    |
+|  - Lowercase, casual                                 |
+|  - Jump over the gap                                 |
+|                                                      |
+| DON'T:                                               |
+|  - Name the gap ("it's been a while")                |
+|  - Apologize for the silence                         |
+|  - Guilt-trip ("did I do something wrong?")          |
+|  - Ask if they remember you                          |
+|  - Write more than you'd say in a hallway            |
++------------------------------------------------------+
+```

--- a/docs/playbooks/templates/reactivation-tracker.md
+++ b/docs/playbooks/templates/reactivation-tracker.md
@@ -1,0 +1,86 @@
+# Reactivation Tracker Template
+
+Copy this table into Notion, Apple Notes, Google Sheets, or anywhere you track contacts. One row per ghosted contact.
+
+---
+
+## How to Use This
+
+1. When someone goes quiet, add them here with today's date as `ghosted_on`.
+2. Set `attempt_1_date` to 14 days after `ghosted_on` (or the date you actually sent).
+3. After attempt 1, check response. If still quiet, set `attempt_2_date` to 45 days after attempt 1.
+4. After attempt 2 with no response, move them to the burned list. Done.
+
+**The rule: 2 attempts, then walk away.** You gave them two fair chances. Your time has value.
+
+---
+
+## Active Reactivations
+
+| Name | Platform/Context | Ghosted On | Stage When Ghosted | Attempt 1 Date | Attempt 1 Sent? | Response? | Attempt 2 Date | Attempt 2 Sent? | Final Outcome |
+|------|-----------------|------------|-------------------|----------------|-----------------|-----------|----------------|-----------------|---------------|
+| [Name] | [App / Email / Phone] | [Date] | [Opener / Convo / Date-ask] | [Date = Ghosted + 14d] | [ ] | [ ] | [Date = Attempt1 + 45d] | [ ] | [Replied / Burned] |
+
+---
+
+## Message Log
+
+For each contact, paste the actual message you sent here so you don't repeat yourself.
+
+### [Name] — Attempt 1 ([Date])
+
+> [Paste your message here]
+
+Response: [What they said, or "no reply"]
+
+### [Name] — Attempt 2 ([Date])
+
+> [Paste your message here]
+
+Response: [What they said, or "no reply"]
+
+---
+
+## Burned List
+
+These contacts received 2 attempts with no response. Stop. Move on.
+
+| Name | Ghosted On | Final Attempt | Why Burned |
+|------|-----------|---------------|-----------|
+| | | | |
+
+---
+
+## Quick Reference — Timing Rules
+
+| Stage When Ghosted | Wait Before Attempt 1 | Wait Before Attempt 2 |
+|-------------------|-----------------------|----------------------|
+| Opener / no reply | 14 days | 45 days after attempt 1 |
+| Mid-conversation | 14 days | 45 days after attempt 1 |
+| After date-ask | 14 days | 45 days after attempt 1 |
+
+---
+
+## Quick Reference — What to Say
+
+**Attempt 1 — opener ghost:**
+> [something specific from their profile] — [one line observation or question, no reference to the gap]
+
+**Attempt 1 — mid-convo ghost:**
+> [callback to last real topic] — pick up as if no time passed
+
+**Attempt 2 (either stage):**
+> [something entirely new — a life update, a relevant thing you saw, a low-pressure invite]
+
+**Walk away message (optional, only if you want to be explicit):**
+> "hey — not gonna keep poking. if you ever want to catch up, you know where to find me."
+
+---
+
+## Rules
+
+- Never mention the gap. Jump over it.
+- Never ask "did i do something wrong?" — don't guilt-trip.
+- Keep it short. Long messages signal you worked hard on this, which signals attachment.
+- If the message took you more than 60 seconds to write, it's too long. Rewrite it.
+- After 2 attempts with no reply: mark burned, move on. No exceptions.


### PR DESCRIPTION
## Summary

- Adds a domain-agnostic ghost-recovery / re-engagement playbook grounded in research across sales, dating, networking, and customer-success frameworks
- 5,895-word main playbook covering 4 parts: universal strategy, Clapcheeks implementation, 4 cross-domain adaptations, and a non-tech operator guide
- 24 example messages (12 good + 12 bad with explanations), Mermaid state diagram, ASCII decision tree
- Machine-readable `banned-phrases.json` (18 phrases, severity-graded, loadable by the AI-8804 sanitizer)
- Optional `clapcheeks playbook` CLI scaffolding with 16 unit tests (all passing)

## Files

| File | Description |
|------|-------------|
| `docs/playbooks/reactivation-campaign.md` | Main playbook — 5,895 words |
| `docs/playbooks/README.md` | Playbook system overview |
| `docs/playbooks/banned-phrases.json` | 18 banned phrases, machine-readable |
| `docs/playbooks/templates/reactivation-tracker.md` | Notion/Notes copy-paste tracker |
| `docs/playbooks/templates/reactivation-decision-tree.md` | Decision tree + Mermaid diagram |
| `agent/clapcheeks/commands/playbook.py` | CLI: `clapcheeks playbook --domain dating --ghost-date 2026-04-01` |
| `agent/tests/test_playbook_cli.py` | 16 unit tests |
| `agent/clapcheeks/followup/reactivation.py` | Added doc-string cross-link |

## Test plan

- [x] `pytest agent/tests/test_playbook_cli.py -v` — 16/16 passing
- [x] Playbook is self-contained (readable without tooling)
- [x] banned-phrases.json is valid JSON with all required fields
- [x] Mermaid state diagram renders on GitHub
- [ ] Julian reads Parts 1 + 4 before sharing externally (review the ethical framing section)

## Research sources (top 3 shaping decisions)

1. **MIT Sloan dormant ties research** (Levin, Walter, Murnighan) — dormant contacts provide MORE novel value than active ones. Reframes reactivation from "fixing failure" to "activating latent value." Directly justifies why the 14-day wait produces better results than immediate follow-up.
2. **Nature Communications 2024** — people overestimate awkwardness and underestimate how welcome reconnection is. The gap isn't the problem — making the gap the centerpiece is.
3. **Cross-domain attempt-cap convergence** — Manson's 3-chance rule, Klaviyo's 3-email winback, Bloomreach's sunset rule all converge on 2-3 attempts max. Validates the `reactivation_max_attempts=2` default in `drip.py`.

Resolves AI-8815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)