### PR TITLE
AI-8873: filter matches by AI-extracted attribute tags

### DIFF
--- a/web/components/matches/FilterBar.tsx
+++ b/web/components/matches/FilterBar.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import {
+  AttributeFilterOption,
   MatchListFilters,
   PLATFORM_OPTIONS,
   STATUS_OPTIONS,
@@ -11,9 +12,47 @@ type Props = {
   onChange: (next: MatchListFilters) => void
   total: number
   filteredCount: number
+  /** AI-8814: optional attribute tag pool. When non-empty, renders the attribute filter row. */
+  attributeOptions?: AttributeFilterOption[]
 }
 
-export default function FilterBar({ filters, onChange, total, filteredCount }: Props) {
+const CATEGORY_TONE: Record<AttributeFilterOption['category'], string> = {
+  allergy:   'bg-red-500/15 text-red-200 border-red-500/40',
+  dietary:   'bg-emerald-500/15 text-emerald-200 border-emerald-500/30',
+  schedule:  'bg-blue-500/15 text-blue-200 border-blue-500/30',
+  lifestyle: 'bg-purple-500/15 text-purple-200 border-purple-500/30',
+  logistics: 'bg-amber-500/15 text-amber-200 border-amber-500/30',
+  comms:     'bg-teal-500/15 text-teal-200 border-teal-500/30',
+}
+
+function makeKey(category: string, value: string): string {
+  return `${category}:${value}`
+}
+
+function toggleAttribute(filters: MatchListFilters, key: string): MatchListFilters {
+  const present = filters.attributeValues.includes(key)
+  return {
+    ...filters,
+    attributeValues: present
+      ? filters.attributeValues.filter((k) => k !== key)
+      : [...filters.attributeValues, key],
+  }
+}
+
+export default function FilterBar({
+  filters,
+  onChange,
+  total,
+  filteredCount,
+  attributeOptions,
+}: Props) {
+  const hasAttrs = !!attributeOptions && attributeOptions.length > 0
+  const hasActive =
+    filters.platform !== 'all' ||
+    filters.status !== 'all' ||
+    filters.minScore > 0 ||
+    filters.attributeValues.length > 0
+
   return (
     <div className="bg-white/[0.03] border border-white/10 rounded-xl p-4 mb-6">
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
@@ -79,17 +118,59 @@ export default function FilterBar({ filters, onChange, total, filteredCount }: P
           />
         </div>
       </div>
+
+      {hasAttrs && (
+        <div className="mt-4 pt-3 border-t border-white/5 flex flex-col gap-1.5">
+          <label className="text-[10px] uppercase tracking-wider font-mono text-white/40">
+            Attributes
+            <span className="ml-2 text-white/25 normal-case tracking-normal">
+              {filters.attributeValues.length > 0
+                ? `${filters.attributeValues.length} selected · AND-match`
+                : 'AI-extracted tags · AND-match'}
+            </span>
+          </label>
+          <div
+            className="flex gap-1.5 flex-wrap"
+            role="group"
+            aria-label="Filter by attribute"
+          >
+            {attributeOptions!.map((opt) => {
+              const key = makeKey(opt.category, opt.value)
+              const selected = filters.attributeValues.includes(key)
+              const tone = CATEGORY_TONE[opt.category]
+              return (
+                <button
+                  key={key}
+                  type="button"
+                  onClick={() => onChange(toggleAttribute(filters, key))}
+                  aria-pressed={selected}
+                  data-attr-key={key}
+                  className={`text-[11px] px-2 py-0.5 rounded-full border transition-all inline-flex items-center gap-1 ${
+                    selected
+                      ? `${tone} ring-1 ring-white/30`
+                      : 'bg-white/5 text-white/60 border-white/10 hover:bg-white/10'
+                  }`}
+                >
+                  <span>{opt.value}</span>
+                  <span className={`text-[9px] font-mono ${selected ? 'text-white/60' : 'text-white/30'}`}>
+                    {opt.count}
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
       <div className="mt-3 flex items-center justify-between text-[11px] text-white/40 font-mono">
         <span>
           Showing <span className="text-white/70">{filteredCount}</span> of {total}
         </span>
-        {(filters.platform !== 'all' ||
-          filters.status !== 'all' ||
-          filters.minScore > 0) && (
+        {hasActive && (
           <button
             type="button"
             onClick={() =>
-              onChange({ platform: 'all', status: 'all', minScore: 0 })
+              onChange({ platform: 'all', status: 'all', minScore: 0, attributeValues: [] })
             }
             className="text-yellow-400/80 hover:text-yellow-300 underline underline-offset-2"
           >

--- a/web/components/matches/MatchGrid.tsx
+++ b/web/components/matches/MatchGrid.tsx
@@ -5,14 +5,18 @@ import { createClient } from '@/lib/supabase/client'
 import MatchCard from './MatchCard'
 import FilterBar from './FilterBar'
 import {
-  ClapcheeksMatchRow,
   MatchListFilters,
 } from '@/lib/matches/types'
+import {
+  aggregateAttributes,
+  matchHasAllAttributes,
+  type MatchWithAttributes,
+} from '@/lib/matches/attribute-filter'
 
 type LastMessageMap = Record<string, string | null>
 
 type Props = {
-  initialMatches: ClapcheeksMatchRow[]
+  initialMatches: MatchWithAttributes[]
   initialHasMore: boolean
   initialLastMessages: LastMessageMap
   pageSize: number
@@ -22,6 +26,7 @@ const DEFAULT_FILTERS: MatchListFilters = {
   platform: 'all',
   status: 'all',
   minScore: 0,
+  attributeValues: [],
 }
 
 export default function MatchGrid({
@@ -30,7 +35,7 @@ export default function MatchGrid({
   initialLastMessages,
   pageSize,
 }: Props) {
-  const [matches, setMatches] = useState<ClapcheeksMatchRow[]>(initialMatches)
+  const [matches, setMatches] = useState<MatchWithAttributes[]>(initialMatches)
   const [lastMessages] = useState<LastMessageMap>(initialLastMessages)
   const [hasMore, setHasMore] = useState(initialHasMore)
   const [loading, setLoading] = useState(false)
@@ -38,6 +43,8 @@ export default function MatchGrid({
   const [syncing, setSyncing] = useState(false)
   const [syncMsg, setSyncMsg] = useState<string | null>(null)
   const sentinelRef = useRef<HTMLDivElement | null>(null)
+
+  const attributeOptions = useMemo(() => aggregateAttributes(matches), [matches])
 
   const filtered = useMemo(() => {
     return matches.filter((m) => {
@@ -47,6 +54,7 @@ export default function MatchGrid({
         const s = typeof m.final_score === 'number' ? m.final_score : 0
         if (s < filters.minScore) return false
       }
+      if (!matchHasAllAttributes(m, filters.attributeValues)) return false
       return true
     })
   }, [matches, filters])
@@ -68,7 +76,7 @@ export default function MatchGrid({
         console.warn('[MatchGrid] fetchMore error:', error.message)
         setHasMore(false)
       } else if (data && data.length > 0) {
-        setMatches((prev) => [...prev, ...(data as unknown as ClapcheeksMatchRow[])])
+        setMatches((prev) => [...prev, ...(data as unknown as MatchWithAttributes[])])
         if (data.length < pageSize) setHasMore(false)
       } else {
         setHasMore(false)
@@ -155,11 +163,12 @@ export default function MatchGrid({
         onChange={setFilters}
         total={matches.length}
         filteredCount={filtered.length}
+        attributeOptions={attributeOptions}
       />
       {filtered.length === 0 ? (
         <div className="bg-white/[0.03] border border-white/10 rounded-xl p-10 text-center">
           <p className="text-white/50 text-sm">
-            No matches match these filters. Adjust the platform, status, or score slider.
+            No matches match these filters. Adjust the platform, status, score, or attribute tags.
           </p>
         </div>
       ) : (

--- a/web/lib/matches/attribute-filter.ts
+++ b/web/lib/matches/attribute-filter.ts
@@ -1,0 +1,116 @@
+/**
+ * AI-8873 — pure helpers for filtering matches by AI-extracted attribute tags.
+ *
+ * Attributes were added in AI-8814 (match attribute extraction + tagging) — they
+ * live on `clapcheeks_matches.attributes` (JSONB) with shape
+ * `{ allergy: AttributeItem[], dietary: [...], schedule: [...], lifestyle: [...],
+ *    logistics: [...], comms: [...], _dismissed: [...] }`.
+ *
+ * `MIN_DISPLAY_CONFIDENCE` mirrors the threshold in
+ * `web/components/matches/AttributeChips.tsx` so what the user filters by is
+ * always a subset of what the chip UI displays.
+ */
+
+import type { MatchAttributes } from '@/components/matches/AttributeChips'
+import type { AttributeFilterOption, ClapcheeksMatchRow } from './types'
+
+export type MatchWithAttributes = ClapcheeksMatchRow & {
+  attributes?: MatchAttributes | null
+}
+
+const CATEGORIES: AttributeFilterOption['category'][] = [
+  'allergy',
+  'dietary',
+  'schedule',
+  'lifestyle',
+  'logistics',
+  'comms',
+]
+
+export const MIN_DISPLAY_CONFIDENCE = 0.6
+
+export function makeAttributeKey(
+  category: AttributeFilterOption['category'],
+  value: string,
+): string {
+  return `${category}:${value}`
+}
+
+/**
+ * Reduce a matches list to the union of every visible (≥0.6 confidence,
+ * not-dismissed) attribute, with occurrence counts. Sorted: allergy first
+ * (safety-critical), then by descending count, then alphabetical.
+ */
+export function aggregateAttributes(
+  matches: ReadonlyArray<MatchWithAttributes>,
+): AttributeFilterOption[] {
+  const counts = new Map<string, AttributeFilterOption>()
+
+  for (const match of matches) {
+    const attrs = match.attributes
+    if (!attrs) continue
+
+    const dismissedSet = new Set(
+      (attrs._dismissed ?? []).map((d) => `${d.category}:${d.value}`),
+    )
+
+    for (const cat of CATEGORIES) {
+      const items = attrs[cat]
+      if (!Array.isArray(items)) continue
+      for (const item of items) {
+        if (!item || typeof item.value !== 'string') continue
+        if (typeof item.confidence !== 'number') continue
+        if (item.confidence < MIN_DISPLAY_CONFIDENCE) continue
+        const key = makeAttributeKey(cat, item.value)
+        if (dismissedSet.has(key)) continue
+        const existing = counts.get(key)
+        if (existing) {
+          existing.count += 1
+        } else {
+          counts.set(key, { category: cat, value: item.value, count: 1 })
+        }
+      }
+    }
+  }
+
+  return Array.from(counts.values()).sort((a, b) => {
+    // Allergies always float to the top
+    if (a.category === 'allergy' && b.category !== 'allergy') return -1
+    if (b.category === 'allergy' && a.category !== 'allergy') return 1
+    if (b.count !== a.count) return b.count - a.count
+    return a.value.localeCompare(b.value)
+  })
+}
+
+/**
+ * Pure predicate: returns true when the match carries EVERY one of
+ * `selectedKeys` (AND-match). An empty selection always passes.
+ */
+export function matchHasAllAttributes(
+  match: MatchWithAttributes,
+  selectedKeys: ReadonlyArray<string>,
+): boolean {
+  if (selectedKeys.length === 0) return true
+  const attrs = match.attributes
+  if (!attrs) return false
+
+  const dismissedSet = new Set(
+    (attrs._dismissed ?? []).map((d) => `${d.category}:${d.value}`),
+  )
+
+  const present = new Set<string>()
+  for (const cat of CATEGORIES) {
+    const items = attrs[cat]
+    if (!Array.isArray(items)) continue
+    for (const item of items) {
+      if (!item || typeof item.value !== 'string') continue
+      if (typeof item.confidence !== 'number') continue
+      if (item.confidence < MIN_DISPLAY_CONFIDENCE) continue
+      const key = makeAttributeKey(cat, item.value)
+      if (dismissedSet.has(key)) continue
+      present.add(key)
+    }
+  }
+
+  return selectedKeys.every((k) => present.has(k))
+}

--- a/web/lib/matches/types.ts
+++ b/web/lib/matches/types.ts
@@ -136,6 +136,17 @@ export type MatchListFilters = {
   platform: 'all' | MatchPlatform
   status: 'all' | 'new' | 'conversing' | 'date_proposed' | 'date_booked' | 'dated' | 'stalled' | 'ghosted'
   minScore: number
+  // AI-8814 attribute tags. Each entry is `${category}:${value}` (e.g. "dietary:vegan").
+  // AND-match: a match must carry ALL selected tags to pass.
+  attributeValues: string[]
+}
+
+// AI-8814 attribute filter option — feeds the FilterBar's chip multi-select.
+// `count` lets the UI sort most-common-first and surface "(N)" beside each chip.
+export type AttributeFilterOption = {
+  category: 'allergy' | 'dietary' | 'schedule' | 'lifestyle' | 'logistics' | 'comms'
+  value: string
+  count: number
 }
 
 // Unified channel type — includes specific platform names (AI-8807)


### PR DESCRIPTION
## Summary

Builds on AI-8814 (match attribute extraction). The match grid now lets you filter by any AI-tagged attribute — allergy, dietary, schedule, lifestyle, logistics, comms. Clicking a chip toggles it; AND-match semantics so a match must carry **every** selected tag to pass.

- New pure-helper module `web/lib/matches/attribute-filter.ts` with two exports:
  - `aggregateAttributes(matches)` → list of `{category, value, count}`, with allergies pinned to the top, then count desc, then alphabetical. Drops items below 0.6 confidence and respects `_dismissed`.
  - `matchHasAllAttributes(match, selectedKeys)` → AND-match predicate. Empty selection passes through.
- `FilterBar` renders an attribute chip row when options are non-empty. Each chip is `aria-pressed` reflective and shows the per-attribute occurrence count.
- `MatchListFilters` gains `attributeValues: string[]`. Reset button clears attribute selection too.
- `MatchGrid` computes available options via `useMemo`, passes them to FilterBar, and applies the predicate alongside the existing platform/status/score filters.

Reuses the canonical `MatchAttributes` type from `components/matches/AttributeChips.tsx` so type round-trips through `MatchCard` cleanly.

## Test plan

- [x] `npx tsc --noEmit` — no new errors. Pre-existing errors in `__tests__/{platform-token-ingest,stripe-webhook}.test.ts`, `app/api/transcribe/route.ts`, and the orphan `components/matches/__tests__/AttributeChips.test.tsx` (uses `@testing-library/react` which isn't installed) are unrelated to this PR.
- [x] `vitest run` — 52/52 pass.
- [x] `next build` — 124/124 pages generated, no errors.
- [ ] Tests for the new helpers were intentionally **not** committed because the global `protect-tests.sh` hook blocks creation of any path matching `/__tests__/` even for net-new test files. Test content is inlined below as a follow-up — copy into `web/__tests__/attribute-filter.test.ts` and the hook can be patched separately to allow new-file creation. Filing AI-NNNN to track the hook false-positive.

<details>
<summary>Test content for follow-up commit (vitest, node env)</summary>

```ts
// web/__tests__/attribute-filter.test.ts
import { describe, expect, test } from 'vitest'
import {
  MIN_DISPLAY_CONFIDENCE,
  aggregateAttributes,
  makeAttributeKey,
  matchHasAllAttributes,
  type MatchWithAttributes,
} from '../lib/matches/attribute-filter'

function makeMatch(id: string, attributes: MatchWithAttributes['attributes']): MatchWithAttributes {
  return { id, attributes } as unknown as MatchWithAttributes
}
const HIGH = 0.9, LOW = 0.4
const attr = (value: string, confidence = HIGH) => ({ value, confidence, source_msg_excerpt: '', source_msg_index: 0 })

describe('aggregateAttributes', () => {
  test('empty', () => expect(aggregateAttributes([])).toEqual([]))
  test('counts duplicates', () => {
    expect(aggregateAttributes([
      makeMatch('a', { dietary: [attr('vegan')] }),
      makeMatch('b', { dietary: [attr('vegan')] }),
    ])).toEqual([{ category: 'dietary', value: 'vegan', count: 2 }])
  })
  test(`drops < ${MIN_DISPLAY_CONFIDENCE} confidence`, () => {
    const opts = aggregateAttributes([makeMatch('a', { dietary: [attr('vegan'), attr('maybe', LOW)] })])
    expect(opts.map(o => o.value)).toEqual(['vegan'])
  })
  test('honours _dismissed', () => {
    const opts = aggregateAttributes([makeMatch('a', {
      dietary: [attr('vegan'), attr('sober')],
      _dismissed: [{ category: 'dietary', value: 'vegan', dismissed_at: '2026-04-27' }],
    })])
    expect(opts.map(o => o.value)).toEqual(['sober'])
  })
  test('pins allergy first', () => {
    const opts = aggregateAttributes([
      makeMatch('a', { dietary: [attr('vegan')] }),
      makeMatch('b', { dietary: [attr('vegan')] }),
      makeMatch('c', { allergy: [attr('peanuts')] }),
    ])
    expect(opts[0]).toMatchObject({ category: 'allergy', value: 'peanuts' })
  })
})

describe('matchHasAllAttributes', () => {
  test('empty selection passes', () => expect(matchHasAllAttributes(makeMatch('a', null), [])).toBe(true))
  test('null attributes + non-empty selection fails', () =>
    expect(matchHasAllAttributes(makeMatch('a', null), ['dietary:vegan'])).toBe(false))
  test('AND not OR', () => {
    const m = makeMatch('a', { dietary: [attr('vegan')] })
    expect(matchHasAllAttributes(m, ['dietary:vegan', 'lifestyle:outdoorsy'])).toBe(false)
  })
  test('low-confidence does not satisfy', () => {
    const m = makeMatch('a', { dietary: [attr('vegan', LOW)] })
    expect(matchHasAllAttributes(m, ['dietary:vegan'])).toBe(false)
  })
  test('dismissed does not satisfy', () => {
    const m = makeMatch('a', {
      dietary: [attr('vegan')],
      _dismissed: [{ category: 'dietary', value: 'vegan', dismissed_at: '2026-04-27' }],
    })
    expect(matchHasAllAttributes(m, ['dietary:vegan'])).toBe(false)
  })
})
```

</details>

## Notes

- No migration needed — reads the existing `clapcheeks_matches.attributes` JSONB column shipped in AI-8814.
- `MatchGrid` is currently consumed only by `/dashboard-demo`; the canonical `/matches` page renders inline. A follow-up can adopt `MatchGrid` for `/matches` to inherit the new filter for free.
- Branch was created from `origin/main` so it doesn't carry any other in-flight work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)