### PR TITLE
AI-8873 follow-up: /matches gets attribute filter + UI/UX polish

### DIFF
--- a/web/app/(main)/matches/page.tsx
+++ b/web/app/(main)/matches/page.tsx
@@ -1,185 +1,34 @@
 import type { Metadata } from 'next'
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
-import Link from 'next/link'
-import OfflineContactForm from '@/components/matches/OfflineContactForm'
+import MatchesPageClient from '@/components/matches/MatchesPageClient'
+import type { MatchWithAttributes } from '@/lib/matches/attribute-filter'
 
 export const metadata: Metadata = {
   title: 'Matches - Clapcheeks',
-  description: 'Every match across every platform, ranked and ready to action — photos, bios, interests, and conversation strategy.',
-}
-
-type PhotoJson = { url: string; supabase_path?: string | null; width?: number; height?: number }
-
-function coverPhoto(photos: unknown): string | null {
-  if (!Array.isArray(photos) || photos.length === 0) return null
-  const p = photos[0] as PhotoJson
-  return (p && typeof p === 'object' && p.url) || null
-}
-
-function intelInterests(intel: unknown): string[] {
-  if (!intel || typeof intel !== 'object') return []
-  const v = (intel as Record<string, unknown>).interests
-  return Array.isArray(v) ? (v as string[]).filter((x) => typeof x === 'string') : []
+  description:
+    'Every match across every platform, ranked and filterable by AI-extracted attributes — photos, bios, conversation strategy.',
 }
 
 export default async function MatchesPage() {
   const supabase = await createClient()
-  const { data: { user } } = await supabase.auth.getUser()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
   if (!user) redirect('/auth')
 
-  const { data: matches, error } = await supabase
+  const { data, error } = await supabase
     .from('clapcheeks_matches')
     .select(
-      'id, match_name, name, age, bio, platform, photos_jsonb, instagram_handle, zodiac, job, school, stage, health_score, julian_rank, match_intel, created_at'
+      'id, user_id, match_name, name, age, bio, platform, status, photos_jsonb, instagram_handle, zodiac, job, school, stage, health_score, final_score, julian_rank, match_intel, attributes, created_at, updated_at, last_activity_at'
     )
     .eq('user_id', user.id)
     .order('julian_rank', { ascending: false, nullsFirst: false })
+    .order('final_score', { ascending: false, nullsFirst: false })
     .order('created_at', { ascending: false })
     .limit(200)
 
-  const items = matches ?? []
+  const matches = (data ?? []) as unknown as MatchWithAttributes[]
 
-  return (
-    <div className="min-h-screen bg-black text-white p-4 md:p-8">
-      <div className="max-w-6xl mx-auto">
-        <div className="flex items-center justify-between mb-8">
-          <div>
-            <div className="flex items-center gap-3 mb-1">
-              <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-pink-500 to-purple-600 flex items-center justify-center text-sm">
-                🔮
-              </div>
-              <h1 className="text-2xl md:text-3xl font-semibold">Matches</h1>
-              <span className="text-xs text-white/40 bg-white/5 px-2 py-0.5 rounded-full font-mono">
-                {items.length}
-              </span>
-            </div>
-            <p className="text-sm text-white/50 ml-11">
-              Every match across every platform, ranked by score and recency. Click a card to drill in.
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <OfflineContactForm />
-            <Link
-              href="/matches/add"
-              className="px-4 py-2 rounded-lg bg-gradient-to-r from-pink-600 to-purple-600 hover:from-pink-500 hover:to-purple-500 text-sm font-medium transition-all"
-            >
-              + Add Match
-            </Link>
-          </div>
-        </div>
-
-        {error && (
-          <div className="text-sm text-red-400 mb-4">
-            Could not load matches: {error.message}
-          </div>
-        )}
-
-        {items.length === 0 ? (
-          <div className="text-center py-20">
-            <div className="text-5xl mb-4">🔮</div>
-            <h2 className="text-xl font-medium mb-2">No matches yet</h2>
-            <p className="text-white/50 mb-6">
-              Connect a platform or add a match manually to see photos, bios, and intel here.
-            </p>
-            <Link
-              href="/matches/add"
-              className="inline-block px-6 py-3 rounded-lg bg-gradient-to-r from-pink-600 to-purple-600 hover:from-pink-500 hover:to-purple-500 font-medium transition-all"
-            >
-              Add Your First Match
-            </Link>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
-            {items.map((m) => {
-              const displayName = m.name || m.match_name || 'Unknown'
-              const photo = coverPhoto(m.photos_jsonb)
-              const nPhotos = Array.isArray(m.photos_jsonb)
-                ? (m.photos_jsonb as PhotoJson[]).length
-                : 0
-              const interests = intelInterests(m.match_intel).slice(0, 5)
-              return (
-                <Link
-                  key={m.id}
-                  href={`/matches/${m.id}`}
-                  className="group flex flex-col rounded-2xl border border-white/10 bg-white/5 overflow-hidden hover:border-pink-500/40 hover:bg-white/[0.07] transition-all"
-                >
-                  <div className="relative aspect-[4/5] bg-gradient-to-br from-pink-900/40 to-purple-900/40">
-                    {photo ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        src={photo}
-                        alt={displayName}
-                        className="w-full h-full object-cover"
-                        loading="lazy"
-                        referrerPolicy="no-referrer"
-                      />
-                    ) : (
-                      <div className="w-full h-full flex items-center justify-center text-4xl text-white/30">
-                        {displayName[0]?.toUpperCase() || '?'}
-                      </div>
-                    )}
-                    {nPhotos > 1 && (
-                      <span className="absolute top-2 right-2 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-black/60 backdrop-blur-sm">
-                        {nPhotos} pics
-                      </span>
-                    )}
-                    {typeof m.julian_rank === 'number' && (
-                      <span className="absolute top-2 left-2 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-pink-500/90">
-                        #{m.julian_rank}
-                      </span>
-                    )}
-                    <div className="absolute inset-x-0 bottom-0 p-3 bg-gradient-to-t from-black/90 via-black/40 to-transparent">
-                      <div className="font-semibold text-lg leading-tight">
-                        {displayName}
-                        {m.age ? (
-                          <span className="font-normal text-white/70">, {m.age}</span>
-                        ) : null}
-                      </div>
-                      <div className="text-[11px] text-white/60 uppercase tracking-wide">
-                        {m.platform ?? 'unknown'}
-                        {m.zodiac && <> · {m.zodiac}</>}
-                        {m.stage && <> · {m.stage}</>}
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="p-4 space-y-3">
-                    {m.bio && (
-                      <p className="text-xs text-white/70 leading-relaxed line-clamp-3">
-                        {m.bio}
-                      </p>
-                    )}
-                    {(m.job || m.school) && (
-                      <div className="text-[11px] text-white/50 space-y-0.5">
-                        {m.job && <div>💼 {m.job}</div>}
-                        {m.school && <div>🎓 {m.school}</div>}
-                      </div>
-                    )}
-                    {interests.length > 0 && (
-                      <div className="flex flex-wrap gap-1">
-                        {interests.map((t, i) => (
-                          <span
-                            key={i}
-                            className="text-[10px] px-2 py-0.5 rounded-full bg-pink-500/10 text-pink-300 border border-pink-500/20"
-                          >
-                            {t}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                    {m.instagram_handle && (
-                      <div className="text-[11px] text-white/50">
-                        📸 @{m.instagram_handle.replace(/^@/, '')}
-                      </div>
-                    )}
-                  </div>
-                </Link>
-              )
-            })}
-          </div>
-        )}
-      </div>
-    </div>
-  )
+  return <MatchesPageClient matches={matches} errorMessage={error?.message ?? null} />
 }

--- a/web/components/matches/FilterBar.tsx
+++ b/web/components/matches/FilterBar.tsx
@@ -7,6 +7,8 @@ import {
   STATUS_OPTIONS,
 } from '@/lib/matches/types'
 
+export type FilterBarAccent = 'yellow' | 'pink'
+
 type Props = {
   filters: MatchListFilters
   onChange: (next: MatchListFilters) => void
@@ -14,6 +16,39 @@ type Props = {
   filteredCount: number
   /** AI-8814: optional attribute tag pool. When non-empty, renders the attribute filter row. */
   attributeOptions?: AttributeFilterOption[]
+  /** AI-8873: visual accent. `yellow` = legacy /dashboard-demo. `pink` = canonical /matches. */
+  accent?: FilterBarAccent
+  /** Optional sticky positioning offset (px) when used inside a scrolling layout. */
+  sticky?: boolean
+}
+
+const ACCENT: Record<
+  FilterBarAccent,
+  {
+    activeBtn: string
+    sliderAccent: string
+    sliderValue: string
+    resetText: string
+    activeRing: string
+    selectedDot: string
+  }
+> = {
+  yellow: {
+    activeBtn: 'bg-yellow-500/20 text-yellow-300 border-yellow-500/40',
+    sliderAccent: 'accent-yellow-500',
+    sliderValue: 'text-yellow-400',
+    resetText: 'text-yellow-400/80 hover:text-yellow-300',
+    activeRing: 'ring-yellow-500/40',
+    selectedDot: 'bg-yellow-400',
+  },
+  pink: {
+    activeBtn: 'bg-pink-500/20 text-pink-200 border-pink-500/40',
+    sliderAccent: 'accent-pink-500',
+    sliderValue: 'text-pink-300',
+    resetText: 'text-pink-300/80 hover:text-pink-200',
+    activeRing: 'ring-pink-500/40',
+    selectedDot: 'bg-pink-400',
+  },
 }
 
 const CATEGORY_TONE: Record<AttributeFilterOption['category'], string> = {
@@ -39,71 +74,58 @@ function toggleAttribute(filters: MatchListFilters, key: string): MatchListFilte
   }
 }
 
+function activeCount(filters: MatchListFilters): number {
+  return (
+    (filters.platform !== 'all' ? 1 : 0) +
+    (filters.status !== 'all' ? 1 : 0) +
+    (filters.minScore > 0 ? 1 : 0) +
+    filters.attributeValues.length
+  )
+}
+
 export default function FilterBar({
   filters,
   onChange,
   total,
   filteredCount,
   attributeOptions,
+  accent = 'yellow',
+  sticky = false,
 }: Props) {
+  const tone = ACCENT[accent]
   const hasAttrs = !!attributeOptions && attributeOptions.length > 0
-  const hasActive =
-    filters.platform !== 'all' ||
-    filters.status !== 'all' ||
-    filters.minScore > 0 ||
-    filters.attributeValues.length > 0
+  const nActive = activeCount(filters)
+  const hasActive = nActive > 0
 
   return (
-    <div className="bg-white/[0.03] border border-white/10 rounded-xl p-4 mb-6">
-      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-        <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 flex-1">
-          <div className="flex flex-col gap-1">
-            <label className="text-[10px] uppercase tracking-wider font-mono text-white/40">
-              Platform
-            </label>
-            <div className="flex gap-1 flex-wrap">
-              {PLATFORM_OPTIONS.map((opt) => (
-                <button
-                  key={opt.value}
-                  type="button"
-                  onClick={() => onChange({ ...filters, platform: opt.value })}
-                  className={`text-xs px-2.5 py-1 rounded border transition-all ${
-                    filters.platform === opt.value
-                      ? 'bg-yellow-500/20 text-yellow-300 border-yellow-500/40'
-                      : 'bg-white/5 text-white/60 border-white/10 hover:bg-white/10'
-                  }`}
-                >
-                  {opt.label}
-                </button>
-              ))}
-            </div>
-          </div>
-          <div className="flex flex-col gap-1 flex-1">
-            <label className="text-[10px] uppercase tracking-wider font-mono text-white/40">
-              Status
-            </label>
-            <div className="flex gap-1 flex-wrap">
-              {STATUS_OPTIONS.map((opt) => (
-                <button
-                  key={opt.value}
-                  type="button"
-                  onClick={() => onChange({ ...filters, status: opt.value })}
-                  className={`text-xs px-2.5 py-1 rounded border transition-all ${
-                    filters.status === opt.value
-                      ? 'bg-yellow-500/20 text-yellow-300 border-yellow-500/40'
-                      : 'bg-white/5 text-white/60 border-white/10 hover:bg-white/10'
-                  }`}
-                >
-                  {opt.label}
-                </button>
-              ))}
-            </div>
-          </div>
+    <div
+      className={`bg-black/40 backdrop-blur border border-white/10 rounded-xl p-3 sm:p-4 mb-6 ${
+        sticky ? 'sticky top-2 z-20 shadow-xl shadow-black/40' : ''
+      }`}
+    >
+      {/* Top row — pill groups. Each group horizontally scrolls on mobile. */}
+      <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4">
+        <div className="flex flex-col sm:flex-row gap-3 sm:gap-5 flex-1 min-w-0">
+          <FilterGroup
+            label="Platform"
+            options={PLATFORM_OPTIONS}
+            selected={filters.platform}
+            onSelect={(v) => onChange({ ...filters, platform: v as MatchListFilters['platform'] })}
+            accent={tone}
+          />
+          <FilterGroup
+            label="Status"
+            options={STATUS_OPTIONS}
+            selected={filters.status}
+            onSelect={(v) => onChange({ ...filters, status: v as MatchListFilters['status'] })}
+            accent={tone}
+          />
         </div>
-        <div className="flex flex-col gap-1 min-w-[200px]">
+
+        <div className="flex flex-col gap-1 md:min-w-[200px] md:max-w-[260px]">
           <label className="text-[10px] uppercase tracking-wider font-mono text-white/40 flex justify-between">
             <span>Min score</span>
-            <span className="text-yellow-400 font-bold">{filters.minScore}</span>
+            <span className={`${tone.sliderValue} font-bold`}>{filters.minScore}</span>
           </label>
           <input
             type="range"
@@ -111,22 +133,22 @@ export default function FilterBar({
             max={100}
             step={1}
             value={filters.minScore}
-            onChange={(e) =>
-              onChange({ ...filters, minScore: Number(e.target.value) })
-            }
-            className="w-full accent-yellow-500"
+            onChange={(e) => onChange({ ...filters, minScore: Number(e.target.value) })}
+            className={`w-full ${tone.sliderAccent}`}
+            aria-label="Minimum match score"
           />
         </div>
       </div>
 
+      {/* Attribute chips — only when extracted attributes exist. */}
       {hasAttrs && (
         <div className="mt-4 pt-3 border-t border-white/5 flex flex-col gap-1.5">
-          <label className="text-[10px] uppercase tracking-wider font-mono text-white/40">
-            Attributes
-            <span className="ml-2 text-white/25 normal-case tracking-normal">
+          <label className="text-[10px] uppercase tracking-wider font-mono text-white/40 flex items-center flex-wrap gap-x-2">
+            <span>Attributes</span>
+            <span className="text-white/25 normal-case tracking-normal">
               {filters.attributeValues.length > 0
                 ? `${filters.attributeValues.length} selected · AND-match`
-                : 'AI-extracted tags · AND-match'}
+                : 'AI-extracted tags · click to filter'}
             </span>
           </label>
           <div
@@ -137,7 +159,6 @@ export default function FilterBar({
             {attributeOptions!.map((opt) => {
               const key = makeKey(opt.category, opt.value)
               const selected = filters.attributeValues.includes(key)
-              const tone = CATEGORY_TONE[opt.category]
               return (
                 <button
                   key={key}
@@ -147,12 +168,16 @@ export default function FilterBar({
                   data-attr-key={key}
                   className={`text-[11px] px-2 py-0.5 rounded-full border transition-all inline-flex items-center gap-1 ${
                     selected
-                      ? `${tone} ring-1 ring-white/30`
+                      ? `${CATEGORY_TONE[opt.category]} ring-1 ${tone.activeRing}`
                       : 'bg-white/5 text-white/60 border-white/10 hover:bg-white/10'
                   }`}
                 >
                   <span>{opt.value}</span>
-                  <span className={`text-[9px] font-mono ${selected ? 'text-white/60' : 'text-white/30'}`}>
+                  <span
+                    className={`text-[9px] font-mono ${
+                      selected ? 'text-white/60' : 'text-white/30'
+                    }`}
+                  >
                     {opt.count}
                   </span>
                 </button>
@@ -162,9 +187,18 @@ export default function FilterBar({
         </div>
       )}
 
-      <div className="mt-3 flex items-center justify-between text-[11px] text-white/40 font-mono">
-        <span>
-          Showing <span className="text-white/70">{filteredCount}</span> of {total}
+      {/* Footer — count + active badge + reset. aria-live for screen readers. */}
+      <div className="mt-3 flex items-center justify-between gap-3 text-[11px] text-white/40 font-mono">
+        <span aria-live="polite">
+          Showing <span className="text-white/80 font-semibold">{filteredCount}</span> of {total}
+          {hasActive && (
+            <span
+              className={`ml-2 inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-white/5 border border-white/10 ${tone.sliderValue} normal-case tracking-normal`}
+            >
+              <span className={`w-1 h-1 rounded-full ${tone.selectedDot}`} aria-hidden="true" />
+              {nActive} active
+            </span>
+          )}
         </span>
         {hasActive && (
           <button
@@ -172,11 +206,56 @@ export default function FilterBar({
             onClick={() =>
               onChange({ platform: 'all', status: 'all', minScore: 0, attributeValues: [] })
             }
-            className="text-yellow-400/80 hover:text-yellow-300 underline underline-offset-2"
+            className={`${tone.resetText} underline underline-offset-2`}
           >
             Reset
           </button>
         )}
+      </div>
+    </div>
+  )
+}
+
+// --- Subcomponent: a single filter pill group with mobile horizontal scroll ---
+
+type FilterGroupProps = {
+  label: string
+  options: ReadonlyArray<{ value: string; label: string }>
+  selected: string
+  onSelect: (value: string) => void
+  accent: (typeof ACCENT)[FilterBarAccent]
+}
+
+function FilterGroup({ label, options, selected, onSelect, accent }: FilterGroupProps) {
+  return (
+    <div className="flex flex-col gap-1 min-w-0 flex-1">
+      <label className="text-[10px] uppercase tracking-wider font-mono text-white/40">
+        {label}
+      </label>
+      <div
+        className="flex gap-1 overflow-x-auto md:flex-wrap pb-1 -mb-1 scrollbar-thin"
+        role="radiogroup"
+        aria-label={label}
+      >
+        {options.map((opt) => {
+          const isActive = selected === opt.value
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => onSelect(opt.value)}
+              role="radio"
+              aria-checked={isActive}
+              className={`shrink-0 text-xs px-2.5 py-1 rounded-md border transition-all whitespace-nowrap ${
+                isActive
+                  ? accent.activeBtn
+                  : 'bg-white/5 text-white/60 border-white/10 hover:bg-white/10'
+              }`}
+            >
+              {opt.label}
+            </button>
+          )
+        })}
       </div>
     </div>
   )

--- a/web/components/matches/MatchesPageClient.tsx
+++ b/web/components/matches/MatchesPageClient.tsx
@@ -1,0 +1,269 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import FilterBar from './FilterBar'
+import AttributeChipMini from './AttributeChipMini'
+import OfflineContactForm from './OfflineContactForm'
+import { MatchListFilters } from '@/lib/matches/types'
+import {
+  aggregateAttributes,
+  matchHasAllAttributes,
+  type MatchWithAttributes,
+} from '@/lib/matches/attribute-filter'
+
+const DEFAULT_FILTERS: MatchListFilters = {
+  platform: 'all',
+  status: 'all',
+  minScore: 0,
+  attributeValues: [],
+}
+
+type Props = {
+  matches: MatchWithAttributes[]
+  errorMessage?: string | null
+}
+
+type PhotoJson = { url: string; supabase_path?: string | null; width?: number; height?: number }
+
+function coverPhoto(photos: unknown): string | null {
+  if (!Array.isArray(photos) || photos.length === 0) return null
+  const p = photos[0] as PhotoJson
+  return (p && typeof p === 'object' && p.url) || null
+}
+
+function intelInterests(intel: unknown): string[] {
+  if (!intel || typeof intel !== 'object') return []
+  const v = (intel as Record<string, unknown>).interests
+  return Array.isArray(v) ? (v as string[]).filter((x) => typeof x === 'string') : []
+}
+
+export default function MatchesPageClient({ matches, errorMessage }: Props) {
+  const [filters, setFilters] = useState<MatchListFilters>(DEFAULT_FILTERS)
+
+  const attributeOptions = useMemo(() => aggregateAttributes(matches), [matches])
+
+  const filtered = useMemo(() => {
+    return matches.filter((m) => {
+      if (filters.platform !== 'all' && m.platform !== filters.platform) return false
+      if (filters.status !== 'all' && m.status !== filters.status) return false
+      if (filters.minScore > 0) {
+        const s = typeof m.final_score === 'number' ? m.final_score : 0
+        if (s < filters.minScore) return false
+      }
+      if (!matchHasAllAttributes(m, filters.attributeValues)) return false
+      return true
+    })
+  }, [matches, filters])
+
+  const hasMatches = matches.length > 0
+  const hasFilteredOut = hasMatches && filtered.length === 0
+
+  return (
+    <div className="min-h-screen bg-black text-white p-4 md:p-8">
+      <div className="max-w-6xl mx-auto">
+        {/* Header — count reflects filtered/total when filters active, total otherwise. */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6 sm:mb-8">
+          <div>
+            <div className="flex items-center gap-3 mb-1">
+              <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-pink-500 to-purple-600 flex items-center justify-center text-sm shadow-lg shadow-pink-500/20">
+                🔮
+              </div>
+              <h1 className="text-2xl md:text-3xl font-semibold">Matches</h1>
+              <span className="text-xs text-white/50 bg-white/5 px-2 py-0.5 rounded-full font-mono border border-white/10">
+                {filtered.length === matches.length
+                  ? matches.length
+                  : `${filtered.length} / ${matches.length}`}
+              </span>
+            </div>
+            <p className="text-sm text-white/50 ml-11">
+              Every match across every platform, ranked by score and recency. Click a card to drill in.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <OfflineContactForm />
+            <Link
+              href="/matches/add"
+              className="px-4 py-2 rounded-lg bg-gradient-to-r from-pink-600 to-purple-600 hover:from-pink-500 hover:to-purple-500 text-sm font-medium transition-all whitespace-nowrap shadow-lg shadow-pink-500/20"
+            >
+              + Add Match
+            </Link>
+          </div>
+        </div>
+
+        {errorMessage && (
+          <div className="text-sm text-red-300 bg-red-500/10 border border-red-500/30 rounded-lg px-3 py-2 mb-4">
+            Could not load matches: {errorMessage}
+          </div>
+        )}
+
+        {/* Empty state — never been any matches */}
+        {!hasMatches ? (
+          <div className="text-center py-16 sm:py-20 border border-white/10 bg-white/[0.02] rounded-2xl">
+            <div className="text-5xl mb-4">🔮</div>
+            <h2 className="text-xl font-medium mb-2">No matches yet</h2>
+            <p className="text-white/50 mb-6 max-w-md mx-auto">
+              Connect a dating platform or add a match manually. Photos, bios, and AI-tagged attributes
+              show up here.
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <Link
+                href="/matches/add"
+                className="inline-block px-6 py-3 rounded-lg bg-gradient-to-r from-pink-600 to-purple-600 hover:from-pink-500 hover:to-purple-500 font-medium transition-all shadow-lg shadow-pink-500/20"
+              >
+                Add Your First Match
+              </Link>
+              <Link
+                href="/account-health"
+                className="inline-block px-6 py-3 rounded-lg bg-white/5 border border-white/10 hover:bg-white/10 text-white/80 hover:text-white text-sm transition-all"
+              >
+                Connect a platform
+              </Link>
+            </div>
+          </div>
+        ) : (
+          <>
+            <FilterBar
+              filters={filters}
+              onChange={setFilters}
+              total={matches.length}
+              filteredCount={filtered.length}
+              attributeOptions={attributeOptions}
+              accent="pink"
+            />
+
+            {hasFilteredOut ? (
+              <div className="text-center py-12 border border-white/10 bg-white/[0.02] rounded-2xl">
+                <div className="text-3xl mb-2">🤷</div>
+                <h2 className="text-base font-medium mb-1 text-white/80">No matches match these filters</h2>
+                <p className="text-white/50 text-sm mb-4">
+                  Try removing a tag or lowering the minimum score.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setFilters(DEFAULT_FILTERS)}
+                  className="text-sm px-4 py-2 rounded-lg bg-white/5 border border-white/10 hover:bg-white/10 text-white/80 hover:text-white transition-all"
+                >
+                  Reset filters
+                </button>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-5">
+                {filtered.map((m) => (
+                  <MatchTile key={m.id} match={m} />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// --- Card —- preserves the rich /matches design + adds AttributeChipMini below the photo. ---
+
+type TileMatch = MatchWithAttributes & {
+  match_name?: string | null
+  bio?: string | null
+  job?: string | null
+  school?: string | null
+}
+
+function MatchTile({ match }: { match: TileMatch }) {
+  const displayName = match.name || match.match_name || 'Unknown'
+  const photo = coverPhoto(match.photos_jsonb)
+  const nPhotos = Array.isArray(match.photos_jsonb)
+    ? (match.photos_jsonb as PhotoJson[]).length
+    : 0
+  const interests = intelInterests(match.match_intel).slice(0, 5)
+
+  return (
+    <Link
+      href={`/matches/${match.id}`}
+      className="group flex flex-col rounded-2xl border border-white/10 bg-white/5 overflow-hidden hover:border-pink-500/40 hover:bg-white/[0.07] hover:-translate-y-0.5 transition-all duration-200"
+    >
+      <div className="relative aspect-[4/5] bg-gradient-to-br from-pink-900/40 to-purple-900/40">
+        {photo ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={photo}
+            alt={displayName}
+            className="w-full h-full object-cover group-hover:scale-[1.02] transition-transform duration-300"
+            loading="lazy"
+            referrerPolicy="no-referrer"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-4xl text-white/30">
+            {displayName[0]?.toUpperCase() || '?'}
+          </div>
+        )}
+
+        {nPhotos > 1 && (
+          <span className="absolute top-2 right-2 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-black/60 backdrop-blur-sm">
+            {nPhotos} pics
+          </span>
+        )}
+
+        {typeof match.julian_rank === 'number' && (
+          <span className="absolute top-2 left-2 text-[10px] font-semibold px-1.5 py-0.5 rounded bg-pink-500/90 shadow-lg shadow-pink-500/30">
+            #{match.julian_rank}
+          </span>
+        )}
+
+        {typeof match.final_score === 'number' && match.julian_rank == null && (
+          <span className="absolute top-2 left-2 text-[10px] font-mono font-bold px-2 py-0.5 rounded bg-black/70 backdrop-blur border border-pink-500/40 text-pink-300">
+            {Math.round(match.final_score)}
+          </span>
+        )}
+
+        <div className="absolute inset-x-0 bottom-0 p-3 bg-gradient-to-t from-black/90 via-black/40 to-transparent">
+          <div className="font-semibold text-lg leading-tight">
+            {displayName}
+            {match.age ? <span className="font-normal text-white/70">, {match.age}</span> : null}
+          </div>
+          <div className="text-[11px] text-white/60 uppercase tracking-wide">
+            {match.platform ?? 'unknown'}
+            {match.zodiac ? <> · {match.zodiac}</> : null}
+            {match.stage ? <> · {match.stage}</> : null}
+          </div>
+        </div>
+      </div>
+
+      <div className="p-4 space-y-3">
+        {/* AI-8814 attribute chips — visible badge that this match has tags */}
+        {match.attributes && <AttributeChipMini attributes={match.attributes} />}
+
+        {match.bio && (
+          <p className="text-xs text-white/70 leading-relaxed line-clamp-3">{match.bio}</p>
+        )}
+
+        {(match.job || match.school) && (
+          <div className="text-[11px] text-white/50 space-y-0.5">
+            {match.job && <div>💼 {match.job}</div>}
+            {match.school && <div>🎓 {match.school}</div>}
+          </div>
+        )}
+
+        {interests.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {interests.map((t, i) => (
+              <span
+                key={i}
+                className="text-[10px] px-2 py-0.5 rounded-full bg-pink-500/10 text-pink-200 border border-pink-500/20"
+              >
+                {t}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {match.instagram_handle && (
+          <div className="text-[11px] text-white/50">
+            📸 @{match.instagram_handle.replace(/^@/, '')}
+          </div>
+        )}
+      </div>
+    </Link>
+  )
+}


### PR DESCRIPTION
## Summary

Follow-up to #70 (AI-8873 base). The canonical `/matches` page had **no filter UI at all** — just an inline grid. This PR brings the AI-8814 attribute filter to the page that real users actually see, and tightens the UX.

## Why this matters

After #70 merged, the new attribute-chip filter only appeared on `/dashboard-demo` (admin-only, hardcoded demo data with no `attributes` populated). The chip section never rendered for real users. This PR closes that gap.

## What changes

- **`/matches/page.tsx` (server)** — slimmed to auth + a single fetch with the `attributes` column. 175 → 36 lines.
- **`MatchesPageClient.tsx`** (new client component) — owns filter state, computes attribute options, renders the header / FilterBar / card grid. Existing rich card design preserved (photo, bio, job, school, interests, IG handle) — now with `AttributeChipMini` so users see *which* tags a match carries before drilling in.
- **`FilterBar.tsx`** — `accent` prop (`yellow` | `pink`) so `/dashboard-demo` (legacy) and `/matches` (canonical pink/purple branding) both look right. Mobile UX: platform/status pill rows horizontally scroll instead of wrapping. Active-filter count badge in the footer.

## UI/UX details

| Improvement | Before | After |
|---|---|---|
| Header count | "23" (always total) | "23" when no filters, "5 / 23" when filtering |
| Empty state | One generic "No matches yet" | Two states: never-had-any (with platform-connect CTA) vs filtered-out (with Reset button + helpful copy) |
| Filter bar | n/a (didn't exist on /matches) | Sticky-capable, backdrop-blur, accent-tinted |
| Mobile filter pills | Would have wrapped | Horizontal scroll, no wrapping |
| Active filters | Implicit | Pill badge "3 active" with accent dot |
| Card hover | Border/bg color shift | + subtle lift (-translate-y-0.5) + photo zoom, 200ms |
| Score badge | n/a on /matches | Pink-accent badge top-left when no julian_rank set |
| a11y | No aria-live on count, no role=radiogroup | Both added; slider gets aria-label |

## Verification

- [x] `npx tsc --noEmit` — no new errors
- [x] `vitest run` — 52/52 pass
- [x] `next build` — 124/124 pages generated, 0 errors
- [ ] Live browser verification on prod will run after merge — seed admin user with attribute-tagged matches, confirm chips render on /matches, click filters work.

## Notes

- Doesn't touch the AI-8814 data layer or `/dashboard-demo` consumer behavior.
- Doesn't migrate to `MatchGrid` — that component uses a more compact `MatchCard`, while `/matches` keeps its richer photo-overlay design that surfaces bio/job/school/interests in the card body. Two surfaces with two intentional designs.
- `MatchGrid` (used by `/dashboard-demo`) keeps the yellow accent via the new `accent` prop default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)