### PR TITLE
fix(clapcheeks): AI-8926 load iMessage conversations on match detail page

### DIFF
--- a/web/app/(main)/matches/[id]/page.tsx
+++ b/web/app/(main)/matches/[id]/page.tsx
@@ -41,20 +41,28 @@ export default async function MatchDetailPage({
   if (herPhone) memoHandle = herPhone
   else if (externalId) memoHandle = platform ? `${platform}:${externalId}` : externalId
 
-  // AI-8876: canonical match_id for realtime subscription
-  const conversationMatchId =
-    externalId
-      ? platform && !externalId.includes(':')
+  // Canonical match_id for realtime subscription.
+  // AI-8876 produced this for tinder/hinge/bumble (uses external_id).
+  // AI-8926 extends it to imessage matches, which have no external_id but do
+  // have her_phone — those rows live under `imessage:<her_phone>`.
+  let conversationMatchId: string | null = null
+  if (externalId) {
+    conversationMatchId =
+      platform && !externalId.includes(':')
         ? `${platform}:${externalId}`
         : externalId
-      : null
+  } else if (herPhone) {
+    conversationMatchId = `imessage:${herPhone}`
+  }
 
-  // Unified cross-channel conversation fetch (AI-8807)
+  // Unified cross-channel conversation fetch (AI-8807, AI-8926).
+  // herPhone is the fallback when externalId is null (iMessage matches).
   const unifiedMessages = await getMatchConversationUnified(
     supabase as any,
     user.id,
     externalId,
     platform,
+    herPhone,
   )
 
   // Map UnifiedMessage -> ChatMessage (compatible type)

--- a/web/lib/matches/conversation.ts
+++ b/web/lib/matches/conversation.ts
@@ -108,6 +108,7 @@ function entryToMessage(
  * @param userId    Auth user UUID
  * @param externalId  The match's external_id (used by clapcheeks_conversations)
  * @param matchPlatform  The match's platform ('tinder'|'hinge'|'bumble'|...)
+ * @param herPhone  E.164 phone for imessage matches (AI-8926: used when externalId is null)
  * @returns Sorted, deduped list of up to 500 messages
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -116,24 +117,27 @@ export async function getMatchConversationUnified(
   userId: string,
   externalId: string | null | undefined,
   matchPlatform?: string | null,
+  herPhone?: string | null,
 ): Promise<UnifiedMessage[]> {
-  if (!externalId) return []
+  // AI-8926: build candidate match_id list. iMessage matches are stored with
+  // `match_id = imessage:<her_phone>` and have no external_id, so derive the
+  // canonical id from her_phone when externalId is missing.
+  const candidates: string[] = []
+  if (externalId) {
+    const canonicalId =
+      matchPlatform && !externalId.includes(':')
+        ? `${matchPlatform}:${externalId}`
+        : externalId
+    candidates.push(canonicalId)
+    if (canonicalId !== externalId) candidates.push(externalId)
+  }
+  if (herPhone) {
+    const phoneId = `imessage:${herPhone}`
+    if (!candidates.includes(phoneId)) candidates.push(phoneId)
+  }
+  if (candidates.length === 0) return []
 
-  // AI-8876: After PR #72 all writers emit canonical `<platform>:<external_id>`
-  // match_ids.  Support a brief migration-window overlap where some rows may
-  // still have the bare externalId.  Query for both forms via PostgREST OR filter.
-  const canonicalId =
-    matchPlatform && !externalId.includes(':')
-      ? `${matchPlatform}:${externalId}`
-      : externalId
-
-  // Build the filter: try canonical form first.  If it differs from the raw
-  // externalId, also include the legacy bare form so rows written before the
-  // migration are still visible.
-  const matchIdFilter =
-    canonicalId !== externalId
-      ? `match_id.eq.${canonicalId},match_id.eq.${externalId}`
-      : `match_id.eq.${canonicalId}`
+  const matchIdFilter = candidates.map((id) => `match_id.eq.${id}`).join(',')
 
   const { data, error } = await supabase
     .from('clapcheeks_conversations')


### PR DESCRIPTION
## Summary
- Conversation tab was empty for every iMessage match (Julian's primary use case) because `getMatchConversationUnified` bailed when `externalId` was null.
- Extends the unified loader to accept `herPhone` and use `imessage:<her_phone>` as the canonical match_id for iMessage matches.
- Updates `/matches/[id]/page.tsx` to pass `match.her_phone` and derive `conversationMatchId` correctly for the realtime subscription too.

## Root cause
`clapcheeks_matches` rows for iMessage matches have `external_id = null` and `her_phone = +1XXXXXXXXXX`. `clapcheeks_conversations` stores those messages under `match_id = imessage:<her_phone>`. The loader only built a candidate match_id from `external_id`, so it queried `match_id IS NULL` and returned `[]`.

## Verification
Pre-fix, against production Supabase (project oouuoepmkeqdyzsxrnjh):
- User `9c848c51-...` has 6 iMessage conversation rows with msg_count = 25 / 17 / 3 / 0 / 0 / 0.
- `/matches/<uuid>` Conversation tab rendered "No conversation yet" for all of them.

Post-fix Vercel preview will be live-tested as Julian (julianb233@gmail.com) on clapcheeks.tech production after merge.

## Test plan
- [ ] Vercel preview build green
- [ ] Login as julianb233@gmail.com
- [ ] Open Alketa Shkembi (match `7133d9a4-...`) → Conversation tab
- [ ] 25 messages render with iMessage channel badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)