### PR TITLE
fix(clapcheeks): AI-8926 surface real activity for super_admins

### DIFF
--- a/web/app/(main)/billing/billing-client.tsx
+++ b/web/app/(main)/billing/billing-client.tsx
@@ -117,8 +117,12 @@ export default function BillingClient({ plan, subscriptionStatus, hasStripeCusto
     return `$${(cents / 100).toFixed(2)}`
   }
 
-  // Not subscribed state
-  if (!hasStripeCustomer || subscriptionStatus === 'inactive') {
+  // Not subscribed state.
+  // AI-8926: super_admin / comp'd users are marked elite/active in `profiles`
+  // without ever creating a Stripe customer.  Honor that — only show the
+  // upsell for genuinely inactive accounts.
+  const isProfileActive = subscriptionStatus === 'active' && (plan === 'elite' || plan === 'base')
+  if (!isProfileActive && (!hasStripeCustomer || subscriptionStatus === 'inactive')) {
     return (
       <div className="space-y-6">
         <div className="bg-white/5 border border-white/10 rounded-xl p-6 text-center">

--- a/web/app/(main)/dashboard/page.tsx
+++ b/web/app/(main)/dashboard/page.tsx
@@ -66,7 +66,7 @@ export default async function Dashboard() {
   const fourteenDaysAgo = new Date()
   fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 14)
 
-  const [analyticsRes, convoRes, spendRes, deviceRes, subRes, profileRes] = await Promise.all([
+  const [analyticsRes, convoRes, spendRes, deviceRes, subRes, profileRes, heartbeatRes, matchCountRes] = await Promise.all([
     supabase
       .from('clapcheeks_analytics_daily')
       .select('app, swipes_right, swipes_left, matches, conversations_started, dates_booked, money_spent, date')
@@ -101,6 +101,20 @@ export default async function Dashboard() {
       .select('subscription_tier, subscription_status')
       .eq('id', user.id)
       .single(),
+    // AI-8926: modern device-presence source (daemon upserts every heartbeat).
+    supabase
+      .from('clapcheeks_device_heartbeats')
+      .select('last_heartbeat_at')
+      .eq('user_id', user.id)
+      .order('last_heartbeat_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    // AI-8926: actual matches count (clapcheeks_analytics_daily can be empty
+    // for users whose agent does not aggregate per-day yet).
+    supabase
+      .from('clapcheeks_matches')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', user.id),
   ])
 
   // Fetch coaching session
@@ -114,8 +128,22 @@ export default async function Dashboard() {
   const rows: DailyRow[] = analyticsRes.data || []
   const convos: ConvoRow[] = convoRes.data || []
   const spending = spendRes.data || []
-  const device: DeviceRow | null = deviceRes.data?.[0] || null
+
+  // AI-8926: pick the freshest of (devices.last_seen_at, clapcheeks_device_heartbeats.last_heartbeat_at).
+  const oldDevice = deviceRes.data?.[0] || null
+  const heartbeatTs = (heartbeatRes.data as { last_heartbeat_at: string | null } | null)?.last_heartbeat_at ?? null
+  const candidates: { last_seen_at: string; is_active: boolean }[] = []
+  if (oldDevice?.last_seen_at) candidates.push({ last_seen_at: oldDevice.last_seen_at, is_active: oldDevice.is_active })
+  if (heartbeatTs) candidates.push({ last_seen_at: heartbeatTs, is_active: true })
+  const device: DeviceRow | null = candidates.length
+    ? candidates.reduce((best, c) =>
+        new Date(c.last_seen_at).getTime() > new Date(best.last_seen_at).getTime() ? c : best,
+      ) as DeviceRow
+    : null
   const hasAgent = !!device
+
+  // AI-8926: real-match-count fallback when analytics_daily is empty.
+  const realMatchCount = (matchCountRes as { count?: number | null } | null)?.count ?? 0
 
   // Aggregate totals
   const totals = rows.reduce(
@@ -308,7 +336,8 @@ export default async function Dashboard() {
 
   const stats = [
     { label: 'Swipes Today', value: hasAgent ? String(todaySwipes) : '--', trend: undefined, invertColors: false },
-    { label: 'Total Matches', value: hasAgent ? String(totals.matches) : '--', trend: hasAgent ? chartData.trends.matches : undefined, invertColors: false },
+    // AI-8926: Always show match count from clapcheeks_matches when analytics_daily is empty.
+    { label: 'Total Matches', value: String(totals.matches || realMatchCount), trend: hasAgent ? chartData.trends.matches : undefined, invertColors: false },
     { label: 'Dates Booked', value: hasAgent ? String(totals.dates) : '--', trend: hasAgent ? chartData.trends.dates : undefined, invertColors: false },
     { label: 'Match Rate', value: hasAgent ? `${matchRate.toFixed(1)}%` : '--', trend: undefined, invertColors: false },
     { label: 'Rizz Score', value: hasAgent ? String(rizzScore) : '--', trend: hasAgent ? rizzTrend : undefined, invertColors: false },

--- a/web/components/layout/connection-bar.tsx
+++ b/web/components/layout/connection-bar.tsx
@@ -200,8 +200,11 @@ export default async function ConnectionBar() {
 
   const since = new Date(Date.now() - ONE_DAY_MS).toISOString()
 
-  // 3 reads in parallel — keep the bar render cheap.
-  const [settingsRes, eventsRes, deviceRes] = await Promise.all([
+  // 4 reads in parallel — keep the bar render cheap.
+  // AI-8926: clapcheeks_device_heartbeats is the modern source-of-truth for
+  // agent freshness (the daemon upserts every heartbeat).  Older `devices`
+  // rows can be stale; pick the freshest of the two.
+  const [settingsRes, eventsRes, deviceRes, heartbeatRes] = await Promise.all([
     (supabase as any)
       .from('clapcheeks_user_settings')
       .select(
@@ -225,11 +228,31 @@ export default async function ConnectionBar() {
       .order('last_seen_at', { ascending: false })
       .limit(1)
       .maybeSingle(),
+    (supabase as any)
+      .from('clapcheeks_device_heartbeats')
+      .select('last_heartbeat_at')
+      .eq('user_id', user.id)
+      .order('last_heartbeat_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
   ])
 
   const settings = (settingsRes.data as UserSettingsRow | null) ?? null
   const events = ((eventsRes.data as BanEventRow[] | null) ?? []) as BanEventRow[]
-  const device = (deviceRes.data as DeviceRow | null) ?? null
+  const deviceRow = (deviceRes.data as DeviceRow | null) ?? null
+  const heartbeatRow = (heartbeatRes.data as { last_heartbeat_at: string | null } | null) ?? null
+
+  // Compose a unified device view: take the freshest last_seen across both
+  // sources.  Treat a fresh heartbeat as is_active=true (the daemon only
+  // emits heartbeats while running).
+  const candidates: { last_seen_at: string | null; is_active: boolean }[] = []
+  if (deviceRow?.last_seen_at) candidates.push({ last_seen_at: deviceRow.last_seen_at, is_active: deviceRow.is_active ?? true })
+  if (heartbeatRow?.last_heartbeat_at) candidates.push({ last_seen_at: heartbeatRow.last_heartbeat_at, is_active: true })
+  const device: DeviceRow | null = candidates.length
+    ? candidates.reduce((best, c) =>
+        new Date(c.last_seen_at!).getTime() > new Date(best.last_seen_at!).getTime() ? c : best,
+      ) as DeviceRow
+    : null
 
   const pills: Pill[] = [
     pillForPlatform('tinder', settings, events),

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -28,6 +28,13 @@ const nextConfig = {
         permanent: false,
       },
       {
+        // AI-8926: sidebar label is "Pipeline" but the route is /leads.
+        // Anyone typing /pipeline directly used to get a 404.
+        source: '/pipeline',
+        destination: '/leads',
+        permanent: false,
+      },
+      {
         source: '/settings/ai',
         destination: '/settings',
         permanent: false,


### PR DESCRIPTION
## Summary
Four small fixes so the dashboard reflects ground-truth instead of empty upsell states for solo / super_admin accounts.

1. **Mac agent freshness** — read fresher of `devices.last_seen_at` + `clapcheeks_device_heartbeats.last_heartbeat_at`. Julian's badge was red despite a 30-second-old heartbeat because the dashboard read a stale `devices` row.
2. **Total Matches** — fallback to `clapcheeks_matches` count when `clapcheeks_analytics_daily` is empty for the user.
3. **Billing "No active subscription"** — honor `profiles.subscription_tier = elite / status = active` for comp'd accounts without Stripe customers.
4. **/pipeline → /leads** redirect.

## Test plan
- [ ] Login as julianb233@gmail.com / Password1$
- [ ] Top connection bar: "Mac agent" pill green
- [ ] Dashboard "Total Matches" reads 20 (not 0)
- [ ] /billing shows "Elite plan, $197/mo, Active"
- [ ] /pipeline 308-redirects to /leads

🤖 Generated with [Claude Code](https://claude.com/claude-code)