### PR TITLE
AI-8934: unbreak profile scraping — manifest host_permissions + Hinge API host

### DIFF
--- a/extensions/token-harvester/manifest.json
+++ b/extensions/token-harvester/manifest.json
@@ -13,11 +13,14 @@
   "host_permissions": [
     "https://tinder.com/*",
     "https://*.tinder.com/*",
+    "https://api.gotinder.com/*",
     "https://hinge.co/*",
     "https://*.hinge.co/*",
+    "https://*.hingeaws.net/*",
     "https://bumble.com/*",
     "https://www.instagram.com/*",
     "https://instagram.com/*",
+    "https://i.instagram.com/*",
     "https://*.clapcheeks.tech/*"
   ],
   "background": {

--- a/scripts/enqueue_harvester_jobs.py
+++ b/scripts/enqueue_harvester_jobs.py
@@ -59,7 +59,7 @@ JOBS = [
         "body": None,
     }),
     ("hinge", "list_matches", {
-        "url": "https://prod.hingeaws.net/match/v1?last_activity_id=",
+        "url": "https://prod-api.hingeaws.net/match/v1?last_activity_id=",
         "method": "GET",
         "headers": {"Accept": "application/json", "Referer": "https://hinge.co/"},
         "body": None,


### PR DESCRIPTION
## Summary
- Add `api.gotinder.com`, `*.hingeaws.net`, `i.instagram.com` to extension host_permissions so MV3 service-worker fetches can ride session cookies. This is the same fix Julian shipped on `feat/elite-roster-intake` (commit `9b9dcfe`) that never landed on main.
- Fix `prod.hingeaws.net` → `prod-api.hingeaws.net` in `scripts/enqueue_harvester_jobs.py` (matches `agent/clapcheeks/match_sync.py:71`).

## Why
Every Hinge/Tinder `list_matches` job since 2026-04-24 has come back from the Chrome extension as `error: "Failed to fetch"`, `status_code: 0`. 48 jobs piled up into `stale_no_extension`. IG inbox jobs succeeded because `www.instagram.com` was already in host_permissions.

This kills profile scraping → kills swipe decisions → `clapcheeks_user_settings.preference_model_v` stays NULL → AI learning loop is dead.

## Test plan
- [ ] Reload unpacked extension on Mac Mini after merge so Chrome picks up the new manifest
- [ ] Wait for next `enqueue_harvester_jobs.py` tick (top of hour)
- [ ] Confirm `clapcheeks_agent_jobs` rows transition `pending` → `claimed` → `completed` (not `stale_no_extension`)
- [ ] Confirm new `clapcheeks_matches` rows appear with real `external_id`, `age`, `bio`, `photos_jsonb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)