### PR TITLE
AI-9196: migrate clapcheeks-api/ai off Fly.io to VPS PM2 + scaffold Convex messaging engine

### DIFF
--- a/api/middleware/rateLimiter.js
+++ b/api/middleware/rateLimiter.js
@@ -1,4 +1,4 @@
-import rateLimit from 'express-rate-limit'
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit'
 
 // Auth endpoints: strict (5 req/min per IP)
 export const authLimiter = rateLimit({
@@ -13,7 +13,7 @@ export const authLimiter = rateLimit({
 export const aiLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 20,
-  keyGenerator: (req) => req.user?.id || req.userId || req.ip,
+  keyGenerator: (req) => req.user?.id || req.userId || ipKeyGenerator(req.ip),
   message: { error: 'Rate limit exceeded for AI features. Please wait.' },
   standardHeaders: true,
   legacyHeaders: false,

--- a/api/server.js
+++ b/api/server.js
@@ -1,4 +1,7 @@
-import 'dotenv/config'
+import dotenv from 'dotenv'
+// override:true so .env values win over any stale shell env vars on the host
+// (PM2 inherits parent shell env at daemon startup; we want .env to be authoritative).
+dotenv.config({ override: true })
 import express from 'express'
 import cors from 'cors'
 import helmet from 'helmet'

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,48 @@
+// Clapcheeks PM2 ecosystem — self-contained, NOT part of /home/dev/ai-acrobatics-fleet.
+// Run from this directory: `pm2 start ecosystem.config.cjs`
+// Reload after edits: `pm2 reload ecosystem.config.cjs`
+// Status: `pm2 list | grep clapcheeks`
+//
+// Linear: AI-9196 — moved off Fly.io trial onto VPS to drop hosting subscription.
+
+const path = require('path');
+const BASE = __dirname;
+
+const COMMON = {
+    max_memory_restart: '512M',
+    kill_timeout: 5000,
+    listen_timeout: 15000,
+    max_restarts: 15,
+    min_uptime: '30s',
+    exp_backoff_restart_delay: 500,
+    autorestart: true,
+};
+
+module.exports = {
+    apps: [
+        {
+            name: 'clapcheeks-api',
+            script: 'server.js',
+            cwd: path.join(BASE, 'api'),
+            interpreter: 'node',
+            env: {
+                NODE_ENV: 'production',
+                PORT: 3001,
+            },
+            // server.js loads dotenv from cwd, so api/.env is picked up automatically
+            ...COMMON,
+        },
+        {
+            name: 'clapcheeks-ai',
+            script: '.venv/bin/uvicorn',
+            args: 'main:app --host 127.0.0.1 --port 8000',
+            cwd: path.join(BASE, 'ai'),
+            interpreter: 'none',
+            env: {
+                PYTHONUNBUFFERED: '1',
+            },
+            // main.py calls load_dotenv() from cwd, so ai/.env is picked up automatically
+            ...COMMON,
+        },
+    ],
+};

--- a/web/convex/README.md
+++ b/web/convex/README.md
@@ -1,0 +1,84 @@
+# Convex — Clapcheeks Messaging Engine
+
+Foundation scaffolded under Linear AI-9196 (Phase 3 of off-Fly migration).
+
+## Scope
+
+Convex owns ONLY the live messaging engine. Postgres (Supabase) still owns
+users, profiles, subscriptions, billing, photos, and analytics. See
+`/opt/agency-workspace/.claude/rules/` rationale notes (file
+`AI-9196-architecture.md` if added) and the conversation thread Linear
+AI-9196.
+
+| Convex tables | Replaces (Postgres) |
+|---|---|
+| `conversations` | `clapcheeks_matches` (live state subset) |
+| `messages` | `clapcheeks_messages` (live state subset) |
+| `scheduled_messages` | `clapcheeks_scheduled_messages` |
+| `agent_jobs` | `agent_jobs_queue` |
+| `drip_states` | drip columns on `clapcheeks_matches` |
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `schema.ts` | Table definitions + indexes |
+| `crons.ts` | Scheduled functions — replaces `pg_cron` + worker pollers |
+| `conversations.ts` | Upsert + reactive list/get + reconciliation cron |
+| `messages.ts` | Append, mark-read, recent-feed query |
+| `scheduled_messages.ts` | Schedule, list, cancel, send-due cron |
+| `agent_jobs.ts` | Enqueue, claim (atomic), complete/fail, reap-stuck cron |
+| `drip.ts` | Drip state machine + advance cron |
+
+## To deploy (NOT done tonight — needs Convex CLI auth)
+
+1. From `web/`:
+   ```
+   npx convex dev
+   ```
+   First run prompts to authenticate via browser. Pick "create new project"
+   named `clapcheeks` (or similar) — DO NOT reuse the existing
+   `optimistic-cricket-162` deployment, which is JuliBoop's.
+
+2. Convex CLI writes `.env.local` with `CONVEX_DEPLOYMENT` and
+   `NEXT_PUBLIC_CONVEX_URL`. Add both to Vercel project env.
+
+3. Wrap the Next.js app in `<ConvexProvider client={convex}>` — see
+   `web/lib/convex.tsx` (TODO).
+
+4. Use `useQuery` / `useMutation` hooks in components for live
+   reactive UI. Example:
+   ```tsx
+   const conversations = useQuery(api.conversations.listForUser, {
+     user_id: session.user.id,
+   });
+   ```
+
+5. Migration of historical data from Postgres → Convex is the Hitesh task
+   under AI-9196. Don't drop the Postgres tables until Convex has been
+   live for 1+ week.
+
+## Why this lives on Convex and not Postgres
+
+- `crons.ts` replaces `pg_cron` + a separate worker poller. No more
+  "is the worker running?" outages.
+- Reactive queries in the dashboard replace Supabase Realtime channel
+  subscription + reconnection plumbing.
+- Atomic `agent_jobs.claim` mutation prevents two agents from double-
+  picking the same job — Postgres needs `SELECT … FOR UPDATE SKIP LOCKED`
+  patterns that have been a source of bugs.
+- Document model fits messaging conversation state cleanly.
+
+## What stays on Supabase
+
+User identity, auth, RLS, Stripe-driven subscription state, profile
+photos, immutable analytics. Industry-standard relational SaaS data —
+Postgres is the right tool, Convex would be a downgrade.
+
+## Bridge: Supabase ↔ Convex
+
+The Mac agent and web app authenticate via Supabase Auth. To call Convex
+functions on behalf of a Supabase user, set `user_id` arg to
+`session.user.id` from the Supabase session. (No Convex Auth integration
+tonight; that's a Hitesh task — likely Clerk-style JWT bridge or
+Supabase JWT verification in a Convex HTTP action.)

--- a/web/convex/_generated/api.d.ts
+++ b/web/convex/_generated/api.d.ts
@@ -1,0 +1,59 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as agent_jobs from "../agent_jobs.js";
+import type * as conversations from "../conversations.js";
+import type * as crons from "../crons.js";
+import type * as drip from "../drip.js";
+import type * as messages from "../messages.js";
+import type * as scheduled_messages from "../scheduled_messages.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  agent_jobs: typeof agent_jobs;
+  conversations: typeof conversations;
+  crons: typeof crons;
+  drip: typeof drip;
+  messages: typeof messages;
+  scheduled_messages: typeof scheduled_messages;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {};

--- a/web/convex/_generated/api.js
+++ b/web/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/web/convex/_generated/dataModel.d.ts
+++ b/web/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/web/convex/_generated/server.d.ts
+++ b/web/convex/_generated/server.d.ts
@@ -1,0 +1,143 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/web/convex/_generated/server.js
+++ b/web/convex/_generated/server.js
@@ -1,0 +1,93 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;

--- a/web/convex/agent_jobs.ts
+++ b/web/convex/agent_jobs.ts
@@ -1,0 +1,160 @@
+import { internalMutation, mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// Enqueue a job for the local Mac agent to pick up.
+export const enqueue = mutation({
+  args: {
+    user_id: v.string(),
+    job_type: v.string(),
+    payload: v.any(),
+    priority: v.optional(v.number()),
+    max_attempts: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    return await ctx.db.insert("agent_jobs", {
+      user_id: args.user_id,
+      job_type: args.job_type,
+      payload: args.payload,
+      status: "queued",
+      priority: args.priority ?? 0,
+      attempts: 0,
+      max_attempts: args.max_attempts ?? 3,
+      created_at: now,
+      updated_at: now,
+    });
+  },
+});
+
+// Local agent claims the next-highest-priority queued job for a user.
+// Atomic via Convex's optimistic concurrency — two agents can't grab
+// the same job.
+export const claim = mutation({
+  args: {
+    user_id: v.string(),
+    agent_instance_id: v.string(),
+    lock_seconds: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const queued = await ctx.db
+      .query("agent_jobs")
+      .withIndex("by_user_status", (q) =>
+        q.eq("user_id", args.user_id).eq("status", "queued"),
+      )
+      .order("desc")
+      .first();
+
+    if (!queued) return null;
+
+    const now = Date.now();
+    const lockMs = (args.lock_seconds ?? 120) * 1000;
+    await ctx.db.patch(queued._id, {
+      status: "running",
+      locked_by: args.agent_instance_id,
+      locked_until: now + lockMs,
+      attempts: queued.attempts + 1,
+      updated_at: now,
+    });
+    return await ctx.db.get(queued._id);
+  },
+});
+
+// Mark a claimed job as completed.
+export const complete = mutation({
+  args: {
+    id: v.id("agent_jobs"),
+    result: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    await ctx.db.patch(args.id, {
+      status: "completed",
+      result: args.result,
+      completed_at: now,
+      updated_at: now,
+    });
+  },
+});
+
+// Mark a claimed job as failed. If under max_attempts, requeue.
+export const fail = mutation({
+  args: {
+    id: v.id("agent_jobs"),
+    error: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const job = await ctx.db.get(args.id);
+    if (!job) throw new Error("Not found");
+    const now = Date.now();
+    if (job.attempts >= job.max_attempts) {
+      await ctx.db.patch(args.id, {
+        status: "failed",
+        last_error: args.error,
+        updated_at: now,
+      });
+    } else {
+      await ctx.db.patch(args.id, {
+        status: "queued",
+        last_error: args.error,
+        locked_by: undefined,
+        locked_until: undefined,
+        updated_at: now,
+      });
+    }
+  },
+});
+
+// Live view of pending + running jobs for a user (powers the dashboard).
+export const listForUser = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    const queued = await ctx.db
+      .query("agent_jobs")
+      .withIndex("by_user_status", (q) =>
+        q.eq("user_id", args.user_id).eq("status", "queued"),
+      )
+      .take(50);
+    const running = await ctx.db
+      .query("agent_jobs")
+      .withIndex("by_user_status", (q) =>
+        q.eq("user_id", args.user_id).eq("status", "running"),
+      )
+      .take(50);
+    return [...running, ...queued];
+  },
+});
+
+// Cron: any 'running' job whose lock expired without complete/fail is
+// considered stuck. Requeue it (or fail if attempts maxed).
+export const reapStuck = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const running = await ctx.db
+      .query("agent_jobs")
+      .withIndex("by_status_priority", (q) => q.eq("status", "running"))
+      .take(200);
+
+    let reaped = 0;
+    for (const job of running) {
+      if (!job.locked_until || job.locked_until > now) continue;
+      if (job.attempts >= job.max_attempts) {
+        await ctx.db.patch(job._id, {
+          status: "failed",
+          last_error: "Lock expired without completion",
+          updated_at: now,
+        });
+      } else {
+        await ctx.db.patch(job._id, {
+          status: "queued",
+          locked_by: undefined,
+          locked_until: undefined,
+          last_error: "Lock expired — requeued",
+          updated_at: now,
+        });
+      }
+      reaped++;
+    }
+    return { scanned: running.length, reaped };
+  },
+});

--- a/web/convex/conversations.ts
+++ b/web/convex/conversations.ts
@@ -1,0 +1,148 @@
+import { internalMutation, mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// Live list of a user's conversations, sorted by most recent activity.
+// Reactive — the dashboard subscribes and updates automatically when
+// any of the conversations change.
+export const listForUser = query({
+  args: {
+    user_id: v.string(),
+    status: v.optional(
+      v.union(
+        v.literal("active"),
+        v.literal("paused"),
+        v.literal("ghosted"),
+        v.literal("dating"),
+        v.literal("ended"),
+      ),
+    ),
+  },
+  handler: async (ctx, args) => {
+    if (args.status) {
+      return await ctx.db
+        .query("conversations")
+        .withIndex("by_user_status", (q) =>
+          q.eq("user_id", args.user_id).eq("status", args.status!),
+        )
+        .order("desc")
+        .take(200);
+    }
+    return await ctx.db
+      .query("conversations")
+      .withIndex("by_last_message", (q) => q.eq("user_id", args.user_id))
+      .order("desc")
+      .take(200);
+  },
+});
+
+// Single conversation with most recent N messages.
+export const getWithMessages = query({
+  args: {
+    conversation_id: v.id("conversations"),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const conv = await ctx.db.get(args.conversation_id);
+    if (!conv) return null;
+    const messages = await ctx.db
+      .query("messages")
+      .withIndex("by_conversation", (q) =>
+        q.eq("conversation_id", args.conversation_id),
+      )
+      .order("desc")
+      .take(args.limit ?? 50);
+    return { conversation: conv, messages: messages.reverse() };
+  },
+});
+
+// Upsert a conversation by external_match_id. Called by the local Mac
+// agent when it imports a new match or sees activity on an existing one.
+export const upsert = mutation({
+  args: {
+    user_id: v.string(),
+    platform: v.union(
+      v.literal("hinge"),
+      v.literal("tinder"),
+      v.literal("bumble"),
+      v.literal("imessage"),
+      v.literal("other"),
+    ),
+    external_match_id: v.string(),
+    match_name: v.optional(v.string()),
+    match_photo_url: v.optional(v.string()),
+    metadata: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("conversations")
+      .withIndex("by_user_external", (q) =>
+        q
+          .eq("user_id", args.user_id)
+          .eq("platform", args.platform)
+          .eq("external_match_id", args.external_match_id),
+      )
+      .first();
+
+    const now = Date.now();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        match_name: args.match_name ?? existing.match_name,
+        match_photo_url: args.match_photo_url ?? existing.match_photo_url,
+        metadata: args.metadata ?? existing.metadata,
+        updated_at: now,
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("conversations", {
+      ...args,
+      status: "active",
+      unread_count: 0,
+      created_at: now,
+      updated_at: now,
+    });
+  },
+});
+
+// Cron: re-derive last_message_at + unread_count from the messages table
+// for any conversation that may have drifted (agent crash, partial write).
+export const reconcile = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const stale = await ctx.db
+      .query("conversations")
+      .withIndex("by_last_message")
+      .order("asc")
+      .take(100);
+
+    let updated = 0;
+    for (const conv of stale) {
+      const lastMsg = await ctx.db
+        .query("messages")
+        .withIndex("by_conversation", (q) =>
+          q.eq("conversation_id", conv._id),
+        )
+        .order("desc")
+        .first();
+
+      if (!lastMsg) continue;
+      if (conv.last_message_at !== lastMsg.sent_at) {
+        await ctx.db.patch(conv._id, {
+          last_message_at: lastMsg.sent_at,
+          last_inbound_at:
+            lastMsg.direction === "inbound"
+              ? lastMsg.sent_at
+              : conv.last_inbound_at,
+          last_outbound_at:
+            lastMsg.direction === "outbound"
+              ? lastMsg.sent_at
+              : conv.last_outbound_at,
+          updated_at: now,
+        });
+        updated++;
+      }
+    }
+    return { scanned: stale.length, updated };
+  },
+});

--- a/web/convex/crons.ts
+++ b/web/convex/crons.ts
@@ -1,0 +1,40 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+// Convex scheduled functions — replaces pg_cron + worker pollers on Postgres.
+// Linear: AI-9196 — Phase 3.
+
+const crons = cronJobs();
+
+// Drain due scheduled_messages every 30 seconds. Replaces the previous
+// PG worker that polled clapcheeks_scheduled_messages.
+crons.interval(
+  "send-due-scheduled-messages",
+  { seconds: 30 },
+  internal.scheduled_messages.sendDue,
+);
+
+// Advance the drip state machine every 5 minutes. Replaces the periodic
+// pg_cron that touched drip rows for cold conversations.
+crons.interval(
+  "advance-drip-states",
+  { minutes: 5 },
+  internal.drip.advance,
+);
+
+// Reap stuck agent jobs (locked_until expired) every 2 minutes.
+crons.interval(
+  "reap-stuck-agent-jobs",
+  { minutes: 2 },
+  internal.agent_jobs.reapStuck,
+);
+
+// Reconcile conversation last_message_at + unread_count every 10 minutes
+// in case a write was dropped or the agent disconnected mid-batch.
+crons.interval(
+  "reconcile-conversations",
+  { minutes: 10 },
+  internal.conversations.reconcile,
+);
+
+export default crons;

--- a/web/convex/drip.ts
+++ b/web/convex/drip.ts
@@ -1,0 +1,104 @@
+import { internalMutation, mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// Init or fetch the drip state for a conversation.
+export const upsertState = mutation({
+  args: {
+    conversation_id: v.id("conversations"),
+    user_id: v.string(),
+    state: v.string(),
+    next_action_at: v.optional(v.number()),
+    cool_down_until: v.optional(v.number()),
+    metadata: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("drip_states")
+      .withIndex("by_conversation", (q) =>
+        q.eq("conversation_id", args.conversation_id),
+      )
+      .first();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        state: args.state,
+        next_action_at: args.next_action_at,
+        cool_down_until: args.cool_down_until,
+        metadata: args.metadata,
+        updated_at: now,
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("drip_states", {
+      conversation_id: args.conversation_id,
+      user_id: args.user_id,
+      state: args.state,
+      next_action_at: args.next_action_at,
+      cool_down_until: args.cool_down_until,
+      consecutive_no_reply: 0,
+      metadata: args.metadata,
+      updated_at: now,
+    });
+  },
+});
+
+// Cron: advance any drip state whose next_action_at has elapsed.
+// For each, enqueue a job for the local Mac agent to act on.
+export const advance = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const due = await ctx.db
+      .query("drip_states")
+      .withIndex("by_next_action")
+      .filter((q) =>
+        q.and(
+          q.neq(q.field("state"), "closed"),
+          q.lte(q.field("next_action_at"), now),
+        ),
+      )
+      .take(100);
+
+    let enqueued = 0;
+    for (const drip of due) {
+      // Hand off to the agent_jobs queue — actual reply generation +
+      // delivery happens via the Mac agent picking this up.
+      await ctx.db.insert("agent_jobs", {
+        user_id: drip.user_id,
+        job_type: "drip_reengagement",
+        payload: {
+          conversation_id: drip.conversation_id,
+          state: drip.state,
+        },
+        status: "queued",
+        priority: 1,
+        attempts: 0,
+        max_attempts: 3,
+        created_at: now,
+        updated_at: now,
+      });
+
+      // Bump cool_down so we don't enqueue the same drip again immediately.
+      await ctx.db.patch(drip._id, {
+        cool_down_until: now + 6 * 60 * 60 * 1000, // 6 hours
+        next_action_at: undefined,
+        updated_at: now,
+      });
+      enqueued++;
+    }
+    return { scanned: due.length, enqueued };
+  },
+});
+
+// Live view for dashboard.
+export const listForUser = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("drip_states")
+      .filter((q) => q.eq(q.field("user_id"), args.user_id))
+      .take(200);
+  },
+});

--- a/web/convex/messages.ts
+++ b/web/convex/messages.ts
@@ -1,0 +1,86 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// Append a message to a conversation. Called by the local Mac agent when
+// it imports a new inbound iMessage / dating-app message, or by the user
+// approving an AI suggestion.
+export const append = mutation({
+  args: {
+    conversation_id: v.id("conversations"),
+    user_id: v.string(),
+    direction: v.union(v.literal("inbound"), v.literal("outbound")),
+    body: v.string(),
+    sent_at: v.number(),
+    source: v.union(
+      v.literal("user"),
+      v.literal("ai_suggestion_approved"),
+      v.literal("ai_auto_send"),
+      v.literal("scheduled"),
+      v.literal("import"),
+    ),
+    ai_metadata: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    const messageId = await ctx.db.insert("messages", args);
+
+    const conv = await ctx.db.get(args.conversation_id);
+    if (conv) {
+      const isInbound = args.direction === "inbound";
+      await ctx.db.patch(args.conversation_id, {
+        last_message_at: args.sent_at,
+        last_inbound_at: isInbound ? args.sent_at : conv.last_inbound_at,
+        last_outbound_at: !isInbound ? args.sent_at : conv.last_outbound_at,
+        unread_count: isInbound ? conv.unread_count + 1 : conv.unread_count,
+        updated_at: Date.now(),
+      });
+    }
+
+    return messageId;
+  },
+});
+
+// Mark all messages in a conversation as read.
+export const markRead = mutation({
+  args: { conversation_id: v.id("conversations") },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const unread = await ctx.db
+      .query("messages")
+      .withIndex("by_conversation", (q) =>
+        q.eq("conversation_id", args.conversation_id),
+      )
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("direction"), "inbound"),
+          q.eq(q.field("read_at"), undefined),
+        ),
+      )
+      .take(500);
+
+    for (const m of unread) {
+      await ctx.db.patch(m._id, { read_at: now });
+    }
+
+    await ctx.db.patch(args.conversation_id, {
+      unread_count: 0,
+      updated_at: now,
+    });
+    return { marked: unread.length };
+  },
+});
+
+// Recent messages for a user across all conversations — powers the
+// global activity feed in the dashboard.
+export const recentForUser = query({
+  args: {
+    user_id: v.string(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("messages")
+      .withIndex("by_user_recent", (q) => q.eq("user_id", args.user_id))
+      .order("desc")
+      .take(args.limit ?? 50);
+  },
+});

--- a/web/convex/scheduled_messages.ts
+++ b/web/convex/scheduled_messages.ts
@@ -1,0 +1,103 @@
+import { internalMutation, mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// Schedule a message to be sent at a future time. Called from web client
+// or from the local Mac agent via HTTP action.
+export const create = mutation({
+  args: {
+    conversation_id: v.id("conversations"),
+    user_id: v.string(),
+    body: v.string(),
+    scheduled_for: v.number(),
+    schedule_reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    return await ctx.db.insert("scheduled_messages", {
+      ...args,
+      status: "pending",
+      created_at: now,
+      updated_at: now,
+    });
+  },
+});
+
+// Pending scheduled messages for a conversation, oldest first.
+export const listPendingForConversation = query({
+  args: { conversation_id: v.id("conversations") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("scheduled_messages")
+      .withIndex("by_conversation", (q) =>
+        q.eq("conversation_id", args.conversation_id).eq("status", "pending"),
+      )
+      .order("asc")
+      .collect();
+  },
+});
+
+// Cancel a pending message before it sends.
+export const cancel = mutation({
+  args: { id: v.id("scheduled_messages") },
+  handler: async (ctx, args) => {
+    const msg = await ctx.db.get(args.id);
+    if (!msg) throw new Error("Not found");
+    if (msg.status !== "pending") {
+      throw new Error(`Cannot cancel message in status ${msg.status}`);
+    }
+    await ctx.db.patch(args.id, {
+      status: "cancelled",
+      updated_at: Date.now(),
+    });
+  },
+});
+
+// Cron-driven worker. Picks up every scheduled_message whose scheduled_for
+// is past now and kicks off the send. This replaces the pg_cron + worker
+// loop that polled clapcheeks_scheduled_messages on Postgres.
+export const sendDue = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const due = await ctx.db
+      .query("scheduled_messages")
+      .withIndex("by_status_due", (q) =>
+        q.eq("status", "pending").lte("scheduled_for", now),
+      )
+      .take(50);
+
+    let dispatched = 0;
+    for (const msg of due) {
+      // Insert as a real message row with source=scheduled. The local Mac
+      // agent picks this up via subscription and actually delivers via the
+      // user's iMessage / dating-app session.
+      const messageId = await ctx.db.insert("messages", {
+        conversation_id: msg.conversation_id,
+        user_id: msg.user_id,
+        direction: "outbound",
+        body: msg.body,
+        sent_at: now,
+        source: "scheduled",
+      });
+
+      await ctx.db.patch(msg._id, {
+        status: "sent",
+        sent_message_id: messageId,
+        updated_at: now,
+      });
+
+      // Touch the conversation so live UIs see the new message immediately.
+      const conv = await ctx.db.get(msg.conversation_id);
+      if (conv) {
+        await ctx.db.patch(msg.conversation_id, {
+          last_message_at: now,
+          last_outbound_at: now,
+          updated_at: now,
+        });
+      }
+      dispatched++;
+    }
+
+    return { dispatched, scanned: due.length };
+  },
+});

--- a/web/convex/schema.ts
+++ b/web/convex/schema.ts
@@ -1,0 +1,127 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+// Convex schema for the clapcheeks messaging engine.
+// Postgres still owns: users, profiles, subscriptions, billing, photos, analytics.
+// Convex owns: live messaging state, conversation tracking, scheduled flows, agent jobs.
+//
+// Linear: AI-9196 — Phase 3 messaging engine migration off pg_cron + agent_jobs_queue.
+
+export default defineSchema({
+  // One row per match the user is talking to. Keyed by Supabase user_id + external match id.
+  conversations: defineTable({
+    user_id: v.string(),                  // Supabase auth user id
+    platform: v.union(                    // dating app of origin
+      v.literal("hinge"),
+      v.literal("tinder"),
+      v.literal("bumble"),
+      v.literal("imessage"),
+      v.literal("other"),
+    ),
+    external_match_id: v.string(),        // platform-specific match id
+    match_name: v.optional(v.string()),
+    match_photo_url: v.optional(v.string()),
+    status: v.union(
+      v.literal("active"),
+      v.literal("paused"),
+      v.literal("ghosted"),
+      v.literal("dating"),
+      v.literal("ended"),
+    ),
+    last_message_at: v.optional(v.number()),
+    last_inbound_at: v.optional(v.number()),
+    last_outbound_at: v.optional(v.number()),
+    unread_count: v.number(),
+    metadata: v.optional(v.any()),        // platform-specific blob (compatibility, age, etc.)
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_user", ["user_id"])
+    .index("by_user_status", ["user_id", "status"])
+    .index("by_user_external", ["user_id", "platform", "external_match_id"])
+    .index("by_last_message", ["user_id", "last_message_at"]),
+
+  // Every message in or out, both for live UI updates and AI training context.
+  messages: defineTable({
+    conversation_id: v.id("conversations"),
+    user_id: v.string(),                  // denormalized for fast filtering
+    direction: v.union(v.literal("inbound"), v.literal("outbound")),
+    body: v.string(),
+    sent_at: v.number(),
+    delivered_at: v.optional(v.number()),
+    read_at: v.optional(v.number()),
+    source: v.union(                      // who/what generated the message
+      v.literal("user"),
+      v.literal("ai_suggestion_approved"),
+      v.literal("ai_auto_send"),
+      v.literal("scheduled"),
+      v.literal("import"),
+    ),
+    ai_metadata: v.optional(v.any()),     // model, tokens, prompt id, score, etc.
+  })
+    .index("by_conversation", ["conversation_id", "sent_at"])
+    .index("by_user_recent", ["user_id", "sent_at"]),
+
+  // Replaces public.clapcheeks_scheduled_messages on Postgres.
+  scheduled_messages: defineTable({
+    conversation_id: v.id("conversations"),
+    user_id: v.string(),
+    body: v.string(),
+    scheduled_for: v.number(),            // unix ms
+    schedule_reason: v.optional(v.string()),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("sent"),
+      v.literal("cancelled"),
+      v.literal("failed"),
+    ),
+    sent_message_id: v.optional(v.id("messages")),
+    failure_reason: v.optional(v.string()),
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_status_due", ["status", "scheduled_for"])
+    .index("by_user", ["user_id", "status"])
+    .index("by_conversation", ["conversation_id", "status"]),
+
+  // Replaces public.agent_jobs_queue on Postgres. Used by the local Mac agent for work units.
+  agent_jobs: defineTable({
+    user_id: v.string(),
+    job_type: v.string(),                 // 'fetch_messages', 'send_reply', 'score_photos', etc.
+    payload: v.any(),
+    status: v.union(
+      v.literal("queued"),
+      v.literal("running"),
+      v.literal("completed"),
+      v.literal("failed"),
+      v.literal("cancelled"),
+    ),
+    priority: v.number(),                 // higher = sooner
+    attempts: v.number(),
+    max_attempts: v.number(),
+    last_error: v.optional(v.string()),
+    locked_by: v.optional(v.string()),    // agent instance id
+    locked_until: v.optional(v.number()),
+    result: v.optional(v.any()),
+    created_at: v.number(),
+    updated_at: v.number(),
+    completed_at: v.optional(v.number()),
+  })
+    .index("by_status_priority", ["status", "priority"])
+    .index("by_user_status", ["user_id", "status"])
+    .index("by_user_type", ["user_id", "job_type"]),
+
+  // Per-conversation drip / re-engagement state machine.
+  drip_states: defineTable({
+    conversation_id: v.id("conversations"),
+    user_id: v.string(),
+    state: v.string(),                    // 'cold_open', 'awaiting_reply', 'rescheduled', 'closed'
+    next_action_at: v.optional(v.number()),
+    cool_down_until: v.optional(v.number()),
+    consecutive_no_reply: v.number(),
+    metadata: v.optional(v.any()),
+    updated_at: v.number(),
+  })
+    .index("by_next_action", ["state", "next_action_at"])
+    .index("by_conversation", ["conversation_id"]),
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -48,6 +48,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "1.0.4",
+        "convex": "^1.37.0",
         "date-fns": "4.1.0",
         "embla-carousel-react": "8.5.1",
         "gsap": "^3.14.2",
@@ -1681,6 +1682,422 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.0.tgz",
+      "integrity": "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.0.tgz",
+      "integrity": "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.0.tgz",
+      "integrity": "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.0.tgz",
+      "integrity": "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.0.tgz",
+      "integrity": "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.0.tgz",
+      "integrity": "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.0.tgz",
+      "integrity": "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.0.tgz",
+      "integrity": "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.0.tgz",
+      "integrity": "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.0.tgz",
+      "integrity": "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.0.tgz",
+      "integrity": "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.0.tgz",
+      "integrity": "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.0.tgz",
+      "integrity": "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.0.tgz",
+      "integrity": "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.0.tgz",
+      "integrity": "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.0.tgz",
+      "integrity": "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.0.tgz",
+      "integrity": "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.0.tgz",
+      "integrity": "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.0.tgz",
+      "integrity": "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.0.tgz",
+      "integrity": "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.0.tgz",
+      "integrity": "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.0.tgz",
+      "integrity": "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.0.tgz",
+      "integrity": "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -7681,6 +8098,65 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
+    "node_modules/convex": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.37.0.tgz",
+      "integrity": "sha512-xGSx5edIsXCEex3OU2U2N0oyB/cOa9qGwKiImF9yOWqjqZgOkx39idtpdlwNBTBSt4S30oAvs4yeXY5xxPIX3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esbuild": "0.27.0",
+        "prettier": "^3.0.0",
+        "ws": "8.18.0"
+      },
+      "bin": {
+        "convex": "bin/main.js"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "@auth0/auth0-react": "^2.0.1",
+        "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
+        "@clerk/react": "^6.4.3",
+        "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@auth0/auth0-react": {
+          "optional": true
+        },
+        "@clerk/clerk-react": {
+          "optional": true
+        },
+        "@clerk/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/convex/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
@@ -8331,6 +8807,47 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
+      "integrity": "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.0",
+        "@esbuild/android-arm": "0.27.0",
+        "@esbuild/android-arm64": "0.27.0",
+        "@esbuild/android-x64": "0.27.0",
+        "@esbuild/darwin-arm64": "0.27.0",
+        "@esbuild/darwin-x64": "0.27.0",
+        "@esbuild/freebsd-arm64": "0.27.0",
+        "@esbuild/freebsd-x64": "0.27.0",
+        "@esbuild/linux-arm": "0.27.0",
+        "@esbuild/linux-arm64": "0.27.0",
+        "@esbuild/linux-ia32": "0.27.0",
+        "@esbuild/linux-loong64": "0.27.0",
+        "@esbuild/linux-mips64el": "0.27.0",
+        "@esbuild/linux-ppc64": "0.27.0",
+        "@esbuild/linux-riscv64": "0.27.0",
+        "@esbuild/linux-s390x": "0.27.0",
+        "@esbuild/linux-x64": "0.27.0",
+        "@esbuild/netbsd-arm64": "0.27.0",
+        "@esbuild/netbsd-x64": "0.27.0",
+        "@esbuild/openbsd-arm64": "0.27.0",
+        "@esbuild/openbsd-x64": "0.27.0",
+        "@esbuild/openharmony-arm64": "0.27.0",
+        "@esbuild/sunos-x64": "0.27.0",
+        "@esbuild/win32-arm64": "0.27.0",
+        "@esbuild/win32-ia32": "0.27.0",
+        "@esbuild/win32-x64": "0.27.0"
       }
     },
     "node_modules/escalade": {

--- a/web/package.json
+++ b/web/package.json
@@ -52,6 +52,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",
+    "convex": "^1.37.0",
     "date-fns": "4.1.0",
     "embla-carousel-react": "8.5.1",
     "gsap": "^3.14.2",


### PR DESCRIPTION
## Summary

- **Phase 2 (executed):** `clapcheeks-api` and `clapcheeks-ai` now run via PM2 on the VPS at `127.0.0.1:3001` / `127.0.0.1:8000`. Self-contained `ecosystem.config.cjs` in repo root — NOT registered in `/home/dev/ai-acrobatics-fleet`. Drops the Fly.io subscription dependency. Both `/health` endpoints verified green.
- **Phase 3 (foundation only):** `web/convex/` scaffolds the messaging engine — `schema.ts` (conversations, messages, scheduled_messages, agent_jobs, drip_states), `crons.ts` replacing `pg_cron` + worker pollers, atomic agent_jobs claim mutation, reactive queries. NOT deployed — needs `npx convex dev` first run to create a new clapcheeks Convex project (do NOT reuse `optimistic-cricket-162`, that's JuliBoop's).
- **Bug fixes uncovered en route:**
  - `api/server.js`: switched to `dotenv.config({override:true})` because host shell had stale `SUPABASE_URL` pointing at Dashboard Daddy that was beating the local `.env` file.
  - `api/middleware/rateLimiter.js`: wrapped `req.ip` in `ipKeyGenerator()` — express-rate-limit v8 throws a `ValidationError` on boot otherwise (IPv6 bypass risk).

## What still depends on Fly (handed to Hitesh)

DNS still points `api.clapcheeks.tech` and `ai.clapcheeks.tech` at Fly. Production traffic continues there. Cutover plan:

1. Pull Fly secret list (`flyctl secrets list -a clapcheeks-api` / `clapcheeks-ai`) and fill the gaps in the new VPS `api/.env` and `ai/.env`. Specifically: `STRIPE_SECRET_KEY`, `STRIPE_PRICE_STARTER/PRO/ELITE`, `KIMI_API_KEY` if the AI service should keep Kimi as fallback.
2. Stand up Caddy on the VPS to reverse-proxy `api.clapcheeks.tech` → `127.0.0.1:3001` and `ai.clapcheeks.tech` → `127.0.0.1:8000` with auto-TLS.
3. Verify Caddy can hit both `/health` endpoints.
4. Swap Cloudflare CNAMEs.
5. Soak 24 hours.
6. Destroy `clapcheeks-api` and `clapcheeks-ai` Fly apps.
7. Cancel Fly subscription.

## Convex deploy steps (Hitesh)

1. From `web/`: `npx convex dev` — first run prompts browser auth.
2. Create a NEW project named `clapcheeks` (do NOT pick the existing JuliBoop deployment).
3. Convex CLI writes `CONVEX_DEPLOYMENT` and `NEXT_PUBLIC_CONVEX_URL` to `.env.local`. Mirror to Vercel project env.
4. Wire `<ConvexProvider>` into `web/app/layout.tsx`.
5. Migrate historical Postgres data (`clapcheeks_scheduled_messages`, `agent_jobs_queue`, drip columns on `clapcheeks_matches`) → Convex via a one-shot script.
6. Soak 1 week. Then drop deprecated Postgres tables.

## Test plan

- [x] `curl http://127.0.0.1:3001/health` → 200 with `{"status":"ok","db":"connected"}`
- [x] `curl http://127.0.0.1:8000/health` → 200 with `{"status":"ok","provider":"anthropic"}`
- [x] `pm2 list` shows both services online
- [x] `pm2 save` so services survive reboot
- [ ] (Hitesh) Caddy reverse proxy serves both subdomains via HTTPS
- [ ] (Hitesh) DNS swap; Fly apps destroyed; subscription cancelled
- [ ] (Hitesh) Convex project created, schema deployed, dashboard reactive queries live

🤖 Generated with [Claude Code](https://claude.com/claude-code)