### PR TITLE
AI-9196: scheduled follow-up scripts (token check + soak verify)

### DIFF
--- a/scripts/scheduled/README.md
+++ b/scripts/scheduled/README.md
@@ -1,0 +1,28 @@
+# scripts/scheduled/
+
+VPS-side cron scripts for follow-up tasks. These run on the AI Acrobatics VPS
+where 1Password CLI, the `god` Mac wrapper, and the Convex deploy key are all
+available — cloud remote agents (the `/schedule` skill) don't have access to
+those, so we use local `at`/systemd scheduling instead.
+
+## Active jobs
+
+Run `atq` on the VPS to see scheduled jobs. As of AI-9196 cutover (2026-05-02):
+
+| Script | Fires | Purpose |
+|---|---|---|
+| `check-convex-token.sh` | ~23h after AI-9196 cutover | Verifies Convex personal access token (`CONVEX-personal-access-token-julian` in 1Password) is still valid; iMessages Julian if expired so he can refresh from `dashboard.convex.dev/auth`. |
+| `soak-verify-convex.sh` | 7 days after AI-9196 cutover | Verifies Convex `clapcheeks` deployment health (function count + row counts), asks Julian for YES before dropping deprecated Postgres tables (`clapcheeks_scheduled_messages`, `clapcheeks_agent_jobs`). |
+
+## Re-schedule
+
+If `atd` is restarted or the box reboots before the job fires, re-queue:
+
+```bash
+echo /opt/agency-workspace/clapcheeks.tech/scripts/scheduled/check-convex-token.sh | at now + 23 hours
+echo /opt/agency-workspace/clapcheeks.tech/scripts/scheduled/soak-verify-convex.sh | at now + 7 days
+```
+
+Logs:
+- `/opt/agency-workspace/.claude/logs/ai-9196-token-check.log`
+- `/opt/agency-workspace/.claude/logs/ai-9196-soak-verify.log`

--- a/scripts/scheduled/check-convex-token.sh
+++ b/scripts/scheduled/check-convex-token.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Fires ~23h after AI-9196 cutover. If Convex personal access token has expired,
+# pings Julian with a one-tap action message. Linear: AI-9196.
+set -euo pipefail
+LOG=/opt/agency-workspace/.claude/logs/ai-9196-token-check.log
+mkdir -p "$(dirname "$LOG")"
+exec >>"$LOG" 2>&1
+echo "=== $(date -u +%Y-%m-%dT%H:%M:%SZ) check-convex-token.sh ==="
+
+TOKEN=$(op item get "CONVEX-personal-access-token-julian" --vault API-Keys --fields credential --reveal 2>/dev/null || echo "")
+if [ -z "$TOKEN" ]; then
+  echo "WARN: token not found in 1Password — sending alert"
+  god mac --target macbook-pro send "+16195090699" "AI-9196: Convex personal token missing from 1Password. Refresh at dashboard.convex.dev/auth and paste here so I can save it." || true
+  exit 0
+fi
+
+CODE=$(curl -sS -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $TOKEN" "https://api.convex.dev/api/dashboard/teams" || echo "000")
+echo "convex teams check: $CODE"
+
+if [ "$CODE" = "200" ]; then
+  echo "token still valid — no action"
+  exit 0
+fi
+
+# expired or revoked
+god mac --target macbook-pro send "+16195090699" "AI-9196: Convex personal token expired. 1 tap: dashboard.convex.dev/auth → paste token in our chat → I save it. Deploy key still works for production, this is only for CLI access." || true
+echo "expired alert sent"

--- a/scripts/scheduled/soak-verify-convex.sh
+++ b/scripts/scheduled/soak-verify-convex.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fires 7d after AI-9196 cutover. Verifies Convex deployment health, row counts.
+# If verified, asks Julian for OK before dropping deprecated PG tables. Linear: AI-9196.
+set -euo pipefail
+LOG=/opt/agency-workspace/.claude/logs/ai-9196-soak-verify.log
+mkdir -p "$(dirname "$LOG")"
+exec >>"$LOG" 2>&1
+echo "=== $(date -u +%Y-%m-%dT%H:%M:%SZ) soak-verify-convex.sh ==="
+
+DEPLOY_KEY=$(op item get "CONVEX-clapcheeks-dev-admin-key" --vault API-Keys --fields credential --reveal 2>/dev/null || echo "")
+if [ -z "$DEPLOY_KEY" ]; then
+  echo "FATAL: deploy key missing"
+  god mac --target macbook-pro send "+16195090699" "AI-9196 soak: Convex deploy key missing from 1Password. Investigation needed." || true
+  exit 1
+fi
+
+# 1. Function spec — should return ~20 functions
+FN_COUNT=$(CONVEX_DEPLOY_KEY="$DEPLOY_KEY" cd /opt/agency-workspace/clapcheeks.tech/web && npx convex function-spec 2>/dev/null | python3 -c "
+import json, sys
+text = sys.stdin.read()
+idx = text.find('{')
+d = json.loads(text[idx:]) if idx >= 0 else {}
+fns = set(f.get('identifier','') for f in d.get('functions',[]))
+print(len(fns))
+" || echo "0")
+echo "function count: $FN_COUNT"
+
+# 2. Table row counts — call public mutations
+USER_ID="9c848c51-8996-4f1f-9dbf-50128e3408ea"
+CONV_COUNT=$(curl -sS -X POST -H "Authorization: Convex $DEPLOY_KEY" -H "Content-Type: application/json" \
+  "https://valiant-oriole-651.convex.cloud/api/run/conversations/listForUser" \
+  -d "{\"args\":{\"user_id\":\"$USER_ID\"},\"format\":\"json\"}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+val = d.get('value', d)
+print(len(val) if isinstance(val, list) else 0)
+" || echo "0")
+echo "conversation count: $CONV_COUNT"
+
+JOB_COUNT=$(curl -sS -X POST -H "Authorization: Convex $DEPLOY_KEY" -H "Content-Type: application/json" \
+  "https://valiant-oriole-651.convex.cloud/api/run/agent_jobs/listForUser" \
+  -d "{\"args\":{\"user_id\":\"$USER_ID\"},\"format\":\"json\"}" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+val = d.get('value', d)
+print(len(val) if isinstance(val, list) else 0)
+" || echo "0")
+echo "agent_jobs count: $JOB_COUNT"
+
+# Decide
+HEALTHY=true
+[ "$FN_COUNT" -lt 18 ] && HEALTHY=false
+[ "$CONV_COUNT" -lt 3 ] && HEALTHY=false
+[ "$JOB_COUNT" -lt 50 ] && HEALTHY=false
+
+if [ "$HEALTHY" = "true" ]; then
+  god mac --target macbook-pro send "+16195090699" "AI-9196 soak verify: Convex healthy after 7d. Functions=$FN_COUNT, conversations=$CONV_COUNT, agent_jobs=$JOB_COUNT. Reply YES to drop deprecated PG tables (clapcheeks_scheduled_messages, clapcheeks_agent_jobs). Don't drop without your OK." || true
+  echo "verified — awaiting Julian's drop OK"
+else
+  god mac --target macbook-pro send "+16195090699" "AI-9196 soak verify FAILED. Functions=$FN_COUNT (expected ≥18), conversations=$CONV_COUNT (≥3), agent_jobs=$JOB_COUNT (≥50). Investigating + filing bug." || true
+  bash /opt/agency-workspace/scripts/escalate-bug-to-linear.sh \
+    --title "AI-9196 soak verify failed: Convex counts off after 7d" \
+    --priority 2 \
+    --system fleet-hooks \
+    --description-file <(echo "FN_COUNT=$FN_COUNT CONV_COUNT=$CONV_COUNT JOB_COUNT=$JOB_COUNT — see /opt/agency-workspace/.claude/logs/ai-9196-soak-verify.log") \
+    --fix-already-deployed no || true
+  echo "FAILED — escalated"
+fi


### PR DESCRIPTION
## Summary

Two VPS-side scheduled scripts for AI-9196 follow-ups, version-controlled.

| Script | Fires | What |
|---|---|---|
| `check-convex-token.sh` | 23h post-cutover (Sun May 3, 22:48 PT) | Curl Convex API with the personal access token from 1Password. If 401, iMessage Julian via MacBook Pro target with a 1-tap action message. |
| `soak-verify-convex.sh` | 7d post-cutover (Sat May 9, 23:48 PT) | Verify Convex deployment health (function count via `convex function-spec`, row counts via public `listForUser` mutations). If healthy, iMessage Julian for explicit YES before dropping deprecated PG tables. If unhealthy, escalate via `escalate-bug-to-linear.sh`. |

## Why VPS-local instead of `/schedule`

Cloud remote agents (Anthropic-hosted) can't:
- Read 1Password (no `op` CLI access)
- Use `god mac send` (VPS-only wrapper)
- Use the Convex deploy key (lives in 1Password)
- Run `escalate-bug-to-linear.sh` (lives on VPS)

VPS-side `at` jobs have all of those. Right tool for the job.

## Scheduled live

`atq` already shows both jobs queued:
```
17  Sun May  3 22:48:00 2026 a blake
18  Sat May  9 23:48:00 2026 a blake
```

Logs land at `/opt/agency-workspace/.claude/logs/ai-9196-{token-check,soak-verify}.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)