### PR TITLE
feat(clapcheeks/convex): AI-9409 add line column + upsertFromWebhook mutation

### DIFF
--- a/web/convex/messages.ts
+++ b/web/convex/messages.ts
@@ -1,9 +1,14 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
+import { Id } from "./_generated/dataModel";
 
 // Append a message to a conversation. Called by the local Mac agent when
 // it imports a new inbound iMessage / dating-app message, or by the user
 // approving an AI suggestion.
+//
+// AI-9409: extended with optional multi-line iMessage fields (line, transport,
+// external_guid, attachments_summary, send_error). Backwards-compatible —
+// existing call sites work unchanged. Dedup by external_guid at top of handler.
 export const append = mutation({
   args: {
     conversation_id: v.id("conversations"),
@@ -17,25 +22,158 @@ export const append = mutation({
       v.literal("ai_auto_send"),
       v.literal("scheduled"),
       v.literal("import"),
+      v.literal("bluebubbles_webhook"),
     ),
     ai_metadata: v.optional(v.any()),
+    // AI-9409 optional multi-line fields
+    line: v.optional(v.number()),
+    transport: v.optional(v.union(
+      v.literal("bluebubbles"),
+      v.literal("pypush"),
+      v.literal("applescript"),
+      v.literal("sms"),
+      v.literal("imessage_native"),
+    )),
+    external_guid: v.optional(v.string()),
+    attachments_summary: v.optional(v.any()),
+    send_error: v.optional(v.any()),
   },
   handler: async (ctx, args) => {
+    // Dedup check by external_guid if provided (AI-9409)
+    if (args.external_guid) {
+      const existing = await ctx.db
+        .query("messages")
+        .withIndex("by_external_guid", (q) =>
+          q.eq("external_guid", args.external_guid),
+        )
+        .first();
+      if (existing) return existing._id; // already ingested
+    }
+
     const messageId = await ctx.db.insert("messages", args);
 
     const conv = await ctx.db.get(args.conversation_id);
     if (conv) {
       const isInbound = args.direction === "inbound";
-      await ctx.db.patch(args.conversation_id, {
+      const patches: Record<string, unknown> = {
         last_message_at: args.sent_at,
         last_inbound_at: isInbound ? args.sent_at : conv.last_inbound_at,
         last_outbound_at: !isInbound ? args.sent_at : conv.last_outbound_at,
         unread_count: isInbound ? conv.unread_count + 1 : conv.unread_count,
         updated_at: Date.now(),
-      });
+      };
+      // Sticky-line: stamp the line on the conversation if not yet set (AI-9409)
+      if (args.line && !conv.line) patches.line = args.line;
+      await ctx.db.patch(args.conversation_id, patches);
     }
 
     return messageId;
+  },
+});
+
+// Single entry point for the VPS BlueBubbles receiver (AI-9409).
+// Resolves or creates the conversation by imessage_handle, then appends
+// the message. Safe to call concurrently — dedup in append() handles races.
+export const upsertFromWebhook = mutation({
+  args: {
+    user_id: v.string(),         // for now: hardcoded "fleet-julian"; multi-tenant later
+    line: v.number(),
+    direction: v.union(v.literal("inbound"), v.literal("outbound")),
+    handle: v.string(),          // E.164 phone or email (the OTHER party)
+    body: v.string(),
+    sent_at: v.number(),
+    external_guid: v.string(),
+    transport: v.union(
+      v.literal("bluebubbles"),
+      v.literal("pypush"),
+      v.literal("applescript"),
+      v.literal("sms"),
+      v.literal("imessage_native"),
+    ),
+    attachments_summary: v.optional(v.any()),
+    send_error: v.optional(v.any()),
+    ai_metadata: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    // 1. Find or create conversation for this handle
+    let convId: Id<"conversations">;
+    const existingConv = await ctx.db
+      .query("conversations")
+      .withIndex("by_imessage_handle", (q) =>
+        q.eq("imessage_handle", args.handle),
+      )
+      .filter((q) => q.eq(q.field("user_id"), args.user_id))
+      .first();
+
+    if (!existingConv) {
+      const now = Date.now();
+      convId = await ctx.db.insert("conversations", {
+        user_id: args.user_id,
+        platform: "imessage",
+        external_match_id: args.handle,
+        status: "active",
+        last_message_at: args.sent_at,
+        last_inbound_at:
+          args.direction === "inbound" ? args.sent_at : undefined,
+        last_outbound_at:
+          args.direction === "outbound" ? args.sent_at : undefined,
+        unread_count: args.direction === "inbound" ? 1 : 0,
+        line: args.line,
+        imessage_handle: args.handle,
+        created_at: now,
+        updated_at: now,
+      });
+    } else {
+      convId = existingConv._id;
+    }
+
+    // 2. Dedup check by external_guid
+    const existingMsg = await ctx.db
+      .query("messages")
+      .withIndex("by_external_guid", (q) =>
+        q.eq("external_guid", args.external_guid),
+      )
+      .first();
+    if (existingMsg) {
+      return { conversation_id: convId, message_id: existingMsg._id };
+    }
+
+    // 3. Insert message
+    const messageId = await ctx.db.insert("messages", {
+      conversation_id: convId,
+      user_id: args.user_id,
+      direction: args.direction,
+      body: args.body,
+      sent_at: args.sent_at,
+      source: "bluebubbles_webhook",
+      line: args.line,
+      transport: args.transport,
+      external_guid: args.external_guid,
+      attachments_summary: args.attachments_summary,
+      send_error: args.send_error,
+      ai_metadata: args.ai_metadata,
+    });
+
+    // 4. Update conversation stats + sticky-line
+    const conv = await ctx.db
+      .query("conversations")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .filter((q) => q.eq(q.field("_id"), convId))
+      .first();
+    if (conv) {
+      const isInbound = args.direction === "inbound";
+      const patches: Record<string, unknown> = {
+        last_message_at: args.sent_at,
+        last_inbound_at: isInbound ? args.sent_at : conv.last_inbound_at,
+        last_outbound_at: !isInbound ? args.sent_at : conv.last_outbound_at,
+        unread_count: isInbound ? conv.unread_count + 1 : conv.unread_count,
+        updated_at: Date.now(),
+      };
+      if (args.line && !conv.line) patches.line = args.line;
+      await ctx.db.patch(convId, patches);
+    }
+
+    return { conversation_id: convId, message_id: messageId };
   },
 });
 

--- a/web/convex/schema.ts
+++ b/web/convex/schema.ts
@@ -35,11 +35,17 @@ export default defineSchema({
     metadata: v.optional(v.any()),        // platform-specific blob (compatibility, age, etc.)
     created_at: v.number(),
     updated_at: v.number(),
+    // Multi-line iMessage fields (AI-9409)
+    line: v.optional(v.number()),                  // 1-5 for fleet multi-line; sticky once set
+    imessage_handle: v.optional(v.string()),       // E.164 phone or email tied to the contact
+    ghl_contact_id: v.optional(v.string()),        // GoHighLevel contact UUID once linked
   })
     .index("by_user", ["user_id"])
     .index("by_user_status", ["user_id", "status"])
     .index("by_user_external", ["user_id", "platform", "external_match_id"])
-    .index("by_last_message", ["user_id", "last_message_at"]),
+    .index("by_last_message", ["user_id", "last_message_at"])
+    .index("by_line_recent", ["line", "last_message_at"])      // AI-9409: per-line queries
+    .index("by_imessage_handle", ["imessage_handle"]),         // AI-9409: sticky-line lookup
 
   // Every message in or out, both for live UI updates and AI training context.
   messages: defineTable({
@@ -56,11 +62,35 @@ export default defineSchema({
       v.literal("ai_auto_send"),
       v.literal("scheduled"),
       v.literal("import"),
+      v.literal("bluebubbles_webhook"),   // AI-9409: inbound from BlueBubbles VPS receiver
     ),
     ai_metadata: v.optional(v.any()),     // model, tokens, prompt id, score, etc.
+    // Multi-line iMessage fields (AI-9409)
+    line: v.optional(v.number()),                  // 1-5 for fleet multi-line; optional — existing rows stay valid
+    transport: v.optional(v.union(                 // which iMessage transport delivered/sent it
+      v.literal("bluebubbles"),
+      v.literal("pypush"),
+      v.literal("applescript"),
+      v.literal("sms"),
+      v.literal("imessage_native"),               // existing clapcheeks rows
+    )),
+    external_guid: v.optional(v.string()),         // BlueBubbles message GUID for dedup + reaction targeting
+    attachments_summary: v.optional(v.array(v.object({
+      guid: v.string(),
+      name: v.optional(v.string()),
+      mime: v.optional(v.string()),
+      size: v.optional(v.number()),
+      is_audio_message: v.optional(v.boolean()),
+    }))),
+    send_error: v.optional(v.object({
+      code: v.optional(v.number()),
+      description: v.optional(v.string()),
+    })),
   })
     .index("by_conversation", ["conversation_id", "sent_at"])
-    .index("by_user_recent", ["user_id", "sent_at"]),
+    .index("by_user_recent", ["user_id", "sent_at"])
+    .index("by_line_recent", ["line", "sent_at"])              // AI-9409: per-line feed
+    .index("by_external_guid", ["external_guid"]),             // AI-9409: dedup lookup
 
   // Replaces public.clapcheeks_scheduled_messages on Postgres.
   scheduled_messages: defineTable({


### PR DESCRIPTION
## Summary

- **schema.ts**: Add `line`, `transport`, `external_guid`, `attachments_summary`, `send_error` to `messages` table; add `line`, `imessage_handle`, `ghl_contact_id` to `conversations` table; extend `source` union with `bluebubbles_webhook`; add indexes `by_line_recent` and `by_external_guid` on messages, `by_line_recent` and `by_imessage_handle` on conversations.
- **messages.ts**: Extend `append()` with new optional fields + dedup-by-external_guid + sticky-line patch on conversation. Add `upsertFromWebhook` mutation that finds-or-creates conversation by `imessage_handle` and inserts message with full dedup. All existing call sites unchanged.

## Test plan

- [ ] `npx tsc --noEmit --skipLibCheck` on web/ — zero convex/ errors ✅ (verified pre-merge)
- [ ] After Convex deployment: `npx convex dev --once` to apply schema migrations
- [ ] Smoke test: POST synthetic webhook event → verify `messages:recentForUser` returns row with `line:1`, `transport:"bluebubbles"`, `external_guid`
- [ ] Verify existing clapcheeks dashboard still loads and messages still appear (no regressions)
- [ ] Verify duplicate webhook (same `external_guid`) returns same messageId without creating duplicate row

Linear: AI-9409

🤖 Generated with [Claude Code](https://claude.com/claude-code)