### PR TITLE
feat(clapcheeks/local): AI-9500-H demo data seeder

### DIFF
--- a/.planning/clapcheeks-wave-2.4-bussit.md
+++ b/.planning/clapcheeks-wave-2.4-bussit.md
@@ -1,0 +1,234 @@
+# Clapcheeks Wave 2.4 — Bussit Task Package
+
+**Linear epic**: AI-9449 (Clapcheeks AI dating co-pilot, full system)
+**This wave's parent**: AI-9500 (Wave 2.4 — profile import, multi-platform polling, dossier)
+**Created**: 2026-05-06 by agent11
+
+This file lets multiple Claude Code terminals work in parallel via the `/bussit` flow.
+Each task below is **independent** of the others (no shared file edits in flight) so two
+to four terminals can claim + execute concurrently with zero merge conflicts.
+
+## How to claim a task (per terminal)
+
+1. Open a fresh Claude Code session at `cd /opt/agency-workspace/clapcheeks.tech`.
+2. Read this file. Pick a task with no `OWNER:` line.
+3. **Edit this file** and add `OWNER: <your agent name> <YYYY-MM-DD HH:MM>` under the chosen task.
+4. Commit `chore(planning): claim AI-9500-<task-letter>` immediately so other terminals see the lock.
+5. Branch: `git checkout -b AI-9500-<task-letter>-<slug>`.
+6. Ship to PR. Auto-merge per fleet rule.
+
+## Critical context every terminal needs
+
+- **Convex**: `valiant-oriole-651` dev. Deploy with `CONVEX_DEPLOY_KEY` from 1Password (`op item get "CONVEX-clapcheeks-dev-admin-key" --vault API-Keys --fields credential --reveal`). Schema in `web/convex/schema.ts`.
+- **Mac Mini daemon**: `tech.clapcheeks.runner` + `tech.clapcheeks.mediawatcher` launchd plists already loaded. Source code in `/opt/agency-workspace/clapcheeks-local/clapcheeks/`. Sync to Mac via `scp ... thewizzard@100.108.83.124:~/clapcheeks-local/`.
+- **gws on Mac Mini**: installed at `~/.local/bin/gws`, profile at `~/.config/gws-profiles/workspace/`. Set `GOOGLE_WORKSPACE_CLI_KEYRING_BACKEND=file`. Calendars: `julian@aiacrobatics.com` + `c_3084e8452ab4cd8bad2d7a18411144ebb54765a5462d3a8c79375b3041e35bf2@group.calendar.google.com` (Dating).
+- **LLM cascade (Convex side)**: `GEMINI_API_KEY`, `DEEPSEEK_API_KEY` set. Use Gemini Vision for image work.
+- **Dashboard**: routes under `/admin/clapcheeks-ops/`. Layout at `web/app/admin/layout.tsx`.
+- **Whitelist brake**: `people.whitelist_for_autoreply` must be true before AI sends anything to a person.
+- **Read first**: `obsidian-vault/Projects/ClapCheeks/2026-05-06-fleet-architecture.md` (full layered architecture).
+
+## Tasks
+
+---
+
+### TASK A — Profile screenshot importer (Tinder/Bumble/Hinge/IG → person row + zodiac + DISC)
+
+OWNER: agent11 2026-05-06 17:30
+
+**Goal**: Julian screenshots a girl's dating-app profile, drops it in via iPhone Shortcut (with `x-cc-kind: profile` header) or via dashboard upload. AI analyzes the screenshot, extracts everything visible, generates a Convex `people` row pre-filled with name, age, location, interests, zodiac analysis, DISC inference, opener suggestions.
+
+**Files to touch**:
+- `web/convex/schema.ts` — extend `media_assets` with `analysis_kind` enum (`media | profile_screenshot`) and `profile_screenshot_data` jsonb-style field; new optional fields on `people` for `zodiac_sign`, `zodiac_analysis`, `disc_inference`, `opener_suggestions`, `imported_from_profile_screenshot`.
+- `web/convex/media.ts` — new internalAction `analyzeAsProfile` (Gemini Vision with deep-context prompt: bio, age, occupation, location, photos, prompts, zodiac inference + interpretation, DISC style inference, communication tendencies, openers, red/green flags).
+- `web/convex/people.ts` — new mutation `createFromProfileAnalysis(media_id)` that pulls extracted profile data and creates a `people` row with `status="lead"`, `whitelist_for_autoreply=false` (safety default), and full enrichment.
+- `web/convex/http.ts` — extend `/clapcheeks/media-upload` to read `x-cc-kind` header and route to `analyzeAsProfile` instead of regular `autoTagMedia` when `kind=profile`.
+- `web/app/admin/clapcheeks-ops/profile-imports/page.tsx` — new dashboard route showing pending profile-screenshot analyses with: extracted fields, zodiac wisdom block, suggested openers, "Create person row" + "Discard" buttons.
+
+**Required prompt depth (zodiac + DISC + tendencies)**:
+
+The Gemini Vision prompt MUST include built-in wisdom blocks for all 12 zodiac signs (Aries through Pisces) covering:
+- Core motivation
+- Communication style preference (direct/indirect, formal/casual, playful/grounded)
+- What earns trust with this sign (specific behaviors)
+- What kills it (specific behaviors)
+- Best opener pattern for this sign
+- 2-3 example openers calibrated to the sign
+- Compatibility/friction notes when paired with Julian (capture his sign in env CC_USER_ZODIAC if set)
+
+DISC inference: from her bio's word choice + sentence structure + photo selection, infer Dominance / Influence / Steadiness / Conscientiousness profile and surface 2-3 communication tactics for that profile.
+
+**Acceptance**:
+- Upload `samples/sample-tinder-profile.jpg` (you'll need to drop a real screenshot in the Drive folder OR provide via a curl test). Returns extracted: `name, age, occupation, location, bio, prompts, photos_described, zodiac_sign, zodiac_block, disc, opener_suggestions[3]`.
+- Dashboard `/admin/clapcheeks-ops/profile-imports` shows pending uploads with all extracted fields. "Create person row" button calls `people:createFromProfileAnalysis` and the row appears in `/admin/clapcheeks-ops/network` with status=lead.
+
+---
+
+### TASK B — Person dossier deep-dive route
+
+OWNER: _(unclaimed)_
+
+**Goal**: Click any person in `/admin/clapcheeks-ops/network` → land on a per-person page that shows everything we know about her: full message timeline, personal_details ledger, curiosity_ledger, recent_life_events, emotional_state_recent (mini-chart), trust_score over time, courtship_stage, scheduled_touches, media_uses (which photos we've sent her), zodiac block, DISC notes.
+
+**Files to touch**:
+- `web/convex/people.ts` — new query `getDossier(person_id)` joining people + last 100 messages + scheduled_touches + media_uses + pending_touches.
+- `web/app/admin/clapcheeks-ops/people/[id]/page.tsx` — new dynamic route. Layout: header card (name, stage, trust, vibe, ask-readiness), tabs (Timeline / Memory / Schedule / Media / Profile / Notes).
+- `web/app/admin/clapcheeks-ops/network/page.tsx` — wrap each PersonRow in a `<Link>` to the dossier.
+
+**Acceptance**:
+- Click any name in /network → land on /people/<id> showing full dossier.
+- "Send a touch now" button enqueues a manual scheduled_touch (type=reply, scheduled_for=now+5min).
+
+---
+
+### TASK C — Hinge SendBird poller (claims `sync_hinge` agent_jobs)
+
+OWNER: agent3-bussit-C 2026-05-06 17:45 (Linear: AI-9507)
+
+**Goal**: Wire the existing `clapcheeks/platforms/hinge_api.py` + `hinge_auth.py` to poll the SendBird API for new conversations + messages, post each to `messages:upsertFromWebhook` with `transport=hinge_sendbird`.
+
+**Prerequisite**: Julian needs to capture Hinge tokens via mitmproxy (one-time iPhone step). Tokens land at `~/hinge-auth.json` + `~/sendbird-session.json` on Mac Mini. **DO NOT block on this** — write the poller to gracefully degrade with `{skipped:true, reason:"no_tokens"}` if files absent.
+
+**Files to touch**:
+- `clapcheeks-local/clapcheeks/intel/hinge_poller.py` — new module. Reads tokens, lists active SendBird channels, fetches new messages since last poll cursor, posts to Convex.
+- `clapcheeks-local/clapcheeks/convex_runner.py` — register `sync_hinge` handler.
+- `clapcheeks-local/scripts/run-hinge-poller.sh` + `tech.clapcheeks.hingepoller.plist` — separate launchd job polling every 5 min.
+- `web/convex/crons.ts` — 5min cron `enqueueHingeSync` that drops a `sync_hinge` agent_job.
+
+**Acceptance**:
+- Run on Mac Mini with token files present → reads N new SendBird messages, lands them in Convex `messages` table with `platform=hinge`, `person_id` linked via handle match (already covered by upsertFromWebhook).
+
+---
+
+### TASK D — Anti-loop + boundary-respect enforcer
+
+OWNER: agent3-bussit-D 2026-05-06 17:45 (Linear: AI-9508)
+
+**Goal**: Two safety layers around outbound:
+1. **Anti-loop**: AI never sends the same template + same draft pattern to two different girls within 7 days (so Sarah and Kate don't both get the identical "btw you mentioned…" line within a week).
+2. **Boundary respect**: If `person.boundaries_stated` contains things like "no texting late", "I don't drink", "slow it down", AI's reply generator MUST respect them — refuse to send templates that violate.
+
+**Files to touch**:
+- `web/convex/touches.ts` — in `fireOne`, before enqueueing the send_imessage job: check the last 7d of fired touches for the user's other people, hash the draft body shape (first-50-chars + template), refuse to send if collision.
+- `clapcheeks-local/clapcheeks/convex_runner.py` — in `_draft_with_template`, inject boundaries_stated into the system prompt as HARD RULES. Also add a post-draft validation pass: if draft contains banned-phrase tokens (configurable), regenerate once.
+
+**Acceptance**:
+- Fire two `pattern_interrupt` touches to two different test girls back-to-back. Second one regenerates to a different shape OR skips with `skip_reason: anti_loop_collision`.
+
+---
+
+### TASK E — Reply-velocity mirror + active-hours auto-tune
+
+OWNER: _(unclaimed)_
+
+**Goal**: AI replies should mirror her response time. If she takes 4h, AI replies in 3-5h, not 30s. AI also learns her active-hours preference automatically over 14d of observations.
+
+**Files to touch**:
+- `web/convex/enrichment.ts` — new internal action `recalibrateCadenceForOne(person_id)`: reads last 30d of message timestamps both directions, fits her median reply time, picks a target reply-gap distribution, updates `person.cadence_overrides.{min_reply_gap_ms, max_reply_gap_ms}` and `person.active_hours_local`.
+- `web/convex/crons.ts` — weekly cron `recalibrateCadenceSweep`.
+- `web/convex/touches.ts` — `fireOne` already respects active_hours; add reply-gap respect: if scheduled_for is too close to her last message gap, push it out.
+
+**Acceptance**:
+- Run `recalibrateCadenceForOne` on a person with 30+ messages — produces cadence_overrides matching her actual rhythm. Visible in /admin/clapcheeks-ops/people/<id>.
+
+---
+
+### TASK F — Conversation-fatigue + pattern-interrupt scheduler
+
+OWNER: agent3-bussit-F 2026-05-06 17:45 (Linear: AI-9509)
+
+**Goal**: Detect when a conversation is dying (declining engagement_score over last 5 messages, or 5+ days silent). Auto-schedule a `pattern_interrupt` touch with one of 5 calibrated templates (callback, meme-reference, low-pressure check-in, bold direct, seasonal hook).
+
+**Files to touch**:
+- `web/convex/enrichment.ts` — new sweep `sweepFatigueDetection`: scans CC TECH people, computes 5-message engagement slope, schedules pattern_interrupt for those trending negative + silent >3d.
+- `web/convex/crons.ts` — every 12h cron.
+- `clapcheeks-local/clapcheeks/convex_runner.py` — extend the `pattern_interrupt` template with 5 sub-styles, AI picks one based on her style_profile + courtship_stage.
+
+**Acceptance**:
+- A person with declining engagement gets a pattern_interrupt scheduled within 12h. Style choice varies based on her DISC.
+
+---
+
+### TASK G — Dashboard person dossier "Send a touch now" + draft preview
+
+OWNER: _(unclaimed)_
+
+**Goal**: From the dossier page (Task B), Julian can manually trigger a touch + preview the draft + edit before sending.
+
+**Files to touch**:
+- `web/convex/touches.ts` — extend `scheduleOne` with `preview_only: true` flag that returns the generated draft without enqueueing. Add `commit` mutation that takes a touch_id + edited_body and fires it.
+- `web/app/admin/clapcheeks-ops/people/[id]/page.tsx` — add "Compose" panel: pick template, click Preview → AI drafts → editable textarea → Send button.
+
+**Acceptance**:
+- From any person's dossier, click "Compose → Hot Reply" → preview appears in editable box → Send → message lands on her phone within 30s.
+
+---
+
+### TASK H — Sample data seeder (so dashboard isn't empty during demo)
+
+OWNER: agent3-bussit-H 2026-05-06 17:45 (Linear: AI-9510)
+
+**Goal**: Write a one-shot script that creates 3 fake people in Convex (lead status, not whitelisted) with realistic mock data so all 7 dashboard pages have content during dev / demo.
+
+**Files to touch**:
+- `clapcheeks-local/scripts/seed_demo_data.py` — new script. Creates 3 fake people with handles, interests, courtship_stage, personal_details, curiosity_ledger entries, recent_life_events, emotional_state samples, fake conversation/messages.
+- Document in this file's "Decommission" section how to wipe demo data when done.
+
+**Acceptance**:
+- Run script → /admin/clapcheeks-ops shows 3 candidates, /touches has 3-5 demo touches scheduled, /pending-links shows 1 demo ambiguous match.
+
+---
+
+## Dependency map (parallel-safe pairings)
+
+```
+Independent: A, C, D, E, F, H — claim any, no conflicts.
+Sequential:  B → G  (G needs B's dossier route).
+```
+
+You can run **two terminals on (A + C)**, **three on (A + C + H)**, or **four on (A + C + D + H)** without merge conflicts. **B + G must be the same terminal** OR coordinate by claiming `web/app/admin/clapcheeks-ops/people/[id]/page.tsx` only once.
+
+---
+
+## What's NOT in this wave (Wave 2.5+)
+
+- Tinder + Bumble pollers (similar pattern to Hinge — Task C, just swap the platform). Defer until Hinge is proven.
+- Instagram poller via browser-harness on Mac Mini's logged-in Chrome. Anti-bot risk; defer until rest of system is humming.
+- Photo A/B testing of Julian's profile photos. Need photo-scoring data + match-rate-per-photo tracking.
+- Place suggester (Foursquare API) for date_ask drafts. Currently AI proposes free hours from calendar; venue suggestion is layer 2.
+- Cross-platform person consolidation (Hinge match shares phone → auto-merge to iMessage thread). Half-built via handles[]; needs a `personLinker:autoMerge` action.
+
+---
+
+## Decommission / cleanup checklist (when wave is done)
+
+- Delete demo seed data (Task H) once real data flows.
+- Remove `OWNER:` lines from this file once tasks ship to main.
+- Tag PRs with `AI-9500-X` so Linear auto-progress fires.
+
+### Task H — Demo data wipe procedure
+
+Run from the repo root (VPS or Mac Mini with `NEXT_PUBLIC_CONVEX_URL` or
+`CONVEX_URL` in environment / web/.env.local):
+
+```bash
+cd /opt/agency-workspace/clapcheeks.tech
+python clapcheeks-local/scripts/seed_demo_data.py --wipe
+```
+
+Or with an explicit deployment URL:
+
+```bash
+python clapcheeks-local/scripts/seed_demo_data.py --wipe \
+  --convex-url https://valiant-oriole-651.convex.cloud
+```
+
+The wipe uses `display_name LIKE 'Demo: %'` as the filter — it calls the
+`people:deleteDemoRows` mutation which cascades to conversations, messages,
+scheduled_touches, and pending_links. It does NOT touch any row where
+`display_name` does not start with `"Demo: "`, so real data is safe.
+
+Verify clean: `/admin/clapcheeks-ops/network` should show 0 people after wipe.
+
+---
+
+— End Wave 2.4 bussit package

--- a/clapcheeks-local/scripts/seed_demo_data.py
+++ b/clapcheeks-local/scripts/seed_demo_data.py
@@ -1,0 +1,598 @@
+#!/usr/bin/env python3
+"""Seed demo data into Convex dev (valiant-oriole-651).
+
+Creates 3 fake people, ~30 messages, 4 scheduled_touches, and 1 pending_links
+row so every Clapcheeks dashboard page has content during dev/demo sessions.
+
+Usage:
+    python scripts/seed_demo_data.py            # seed
+    python scripts/seed_demo_data.py --wipe     # delete all Demo: rows
+
+SAFETY BRAKE:
+    All seeded people have whitelist_for_autoreply=False.
+    The AI will NEVER auto-send to demo handles.
+
+Linear: AI-9500-H (AI-9506)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Environment
+# ---------------------------------------------------------------------------
+
+ENV: dict[str, str] = {}
+for p in (
+    Path("/opt/agency-workspace/clapcheeks.tech/web/.env.local"),
+    Path("/opt/agency-workspace/clapcheeks.tech/.env.local"),
+    Path.home() / ".clapcheeks" / ".env",
+):
+    if p.exists():
+        for line in p.read_text().splitlines():
+            line = line.strip()
+            if line and "=" in line and not line.startswith("#"):
+                k, _, v = line.partition("=")
+                ENV.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+CONVEX_URL: str = ENV.get("CONVEX_URL") or ENV.get("NEXT_PUBLIC_CONVEX_URL", "")
+CONVEX_DEPLOY_KEY: str = ENV.get("CONVEX_DEPLOY_KEY", "")
+USER_ID: str = ENV.get("CONVEX_FLEET_USER_ID", "fleet-julian")
+
+if not CONVEX_URL:
+    sys.exit("FATAL: CONVEX_URL / NEXT_PUBLIC_CONVEX_URL not set in .env files.")
+
+CONVEX_URL = CONVEX_URL.rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Low-level Convex HTTP client
+# ---------------------------------------------------------------------------
+
+def _call(fn_path: str, args: dict[str, Any]) -> Any:
+    """Call a Convex mutation or query via the HTTP API.
+
+    ``fn_path`` examples:
+        ``people:insert``  (mutation)
+        ``conversations:findByHandle``  (query)
+
+    Uses admin auth if CONVEX_DEPLOY_KEY is available.
+    """
+    url = f"{CONVEX_URL}/api/run/{fn_path}"
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if CONVEX_DEPLOY_KEY:
+        headers["Authorization"] = f"Convex {CONVEX_DEPLOY_KEY}"
+
+    payload = json.dumps({"args": args}).encode()
+    req = urllib.request.Request(url, data=payload, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = resp.read()
+            data = json.loads(body)
+            # Convex HTTP API returns {"status": "success", "value": ...} or {"status": "error", ...}
+            if isinstance(data, dict) and data.get("status") == "error":
+                raise RuntimeError(f"Convex error from {fn_path}: {data}")
+            # value field holds the actual return, but raw response is fine for mutations
+            return data.get("value") if isinstance(data, dict) and "value" in data else data
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        raise RuntimeError(f"HTTP {exc.code} calling {fn_path}: {body}") from exc
+
+
+# Convenience aliases
+def _mutate(fn: str, args: dict[str, Any]) -> Any:
+    return _call(fn, args)
+
+def _query(fn: str, args: dict[str, Any]) -> Any:
+    return _call(fn, args)
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _days_ago_ms(days: float) -> int:
+    return int((_now_ms() - days * 86_400_000))
+
+
+def _tomorrow_at(hour: int) -> int:
+    """Return unix-ms for tomorrow at ``hour`` local time."""
+    import datetime
+    now = datetime.datetime.now()
+    tomorrow = now + datetime.timedelta(days=1)
+    target = tomorrow.replace(hour=hour, minute=0, second=0, microsecond=0)
+    return int(target.timestamp() * 1000)
+
+
+# ---------------------------------------------------------------------------
+# Seed data definitions
+# ---------------------------------------------------------------------------
+
+DEMO_PEOPLE = [
+    {
+        "display_name": "Demo: Sarah Chen",
+        "handles": [{"channel": "imessage", "value": "+15551110001", "verified": False, "primary": True}],
+        "status": "lead",
+        "whitelist_for_autoreply": False,
+        "courtship_stage": "early_chat",
+        "trust_score": 0.4,
+        "vibe_classification": "dating",
+        "vibe_confidence": 0.85,
+        "interests": ["climbing", "coffee", "indie films"],
+        "goals": ["find connection", "travel more"],
+        "values": ["authenticity", "adventure"],
+        "boundaries_stated": ["no late-night texts"],
+        "disc_primary": "I",
+        "disc_type": "I/S",
+        "cadence_profile": "warm",
+        "engagement_score": 0.55,
+        "response_rate": 0.7,
+        "conversation_temperature": "warm",
+        "things_she_loves": ["witty banter", "spontaneous plans"],
+        "green_flags": ["replies same day", "shares personal stories"],
+        "red_flags": [],
+        "context_notes": "Met on Hinge. Laughed at my pineapple-pizza take. Works in UX design.",
+        "active_hours_local": {"tz": "America/Los_Angeles", "start_hour": 9, "end_hour": 22},
+        # Demographics surfaced in Task A profile importer (not in schema yet — store in raw_profile)
+        "_meta": {"age": 27, "location": "San Francisco", "zodiac_sign": "Libra"},
+    },
+    {
+        "display_name": "Demo: Kate Morgan",
+        "handles": [{"channel": "imessage", "value": "+15551110002", "verified": False, "primary": True}],
+        "status": "lead",
+        "whitelist_for_autoreply": False,
+        "courtship_stage": "warming",
+        "trust_score": 0.6,
+        "vibe_classification": "dating",
+        "vibe_confidence": 0.78,
+        "interests": ["pottery", "running"],
+        "goals": ["build something with my hands", "half marathon PR"],
+        "values": ["consistency", "depth"],
+        "boundaries_stated": ["I don't drink"],
+        "disc_primary": "C",
+        "disc_type": "C/S",
+        "cadence_profile": "slow_burn",
+        "engagement_score": 0.68,
+        "response_rate": 0.82,
+        "conversation_temperature": "warm",
+        "things_she_loves": ["thoughtful questions", "follow-through"],
+        "green_flags": ["asks follow-up questions", "initiates sometimes"],
+        "red_flags": ["slow to open up"],
+        "context_notes": "Bumble match. Nurse practitioner. Runs 5 days a week.",
+        "active_hours_local": {"tz": "America/New_York", "start_hour": 7, "end_hour": 21},
+        "_meta": {"age": 29, "location": "Brooklyn", "zodiac_sign": "Virgo"},
+    },
+    {
+        "display_name": "Demo: Mia Rivera",
+        "handles": [{"channel": "imessage", "value": "+15551110003", "verified": False, "primary": True}],
+        "status": "lead",
+        "whitelist_for_autoreply": False,
+        "courtship_stage": "cooling",
+        "trust_score": 0.3,
+        "vibe_classification": "dating",
+        "vibe_confidence": 0.61,
+        "interests": ["DJ sets", "nightlife"],
+        "goals": ["launch an events brand"],
+        "values": ["freedom", "energy"],
+        "boundaries_stated": [],
+        "disc_primary": "D",
+        "disc_type": "D/I",
+        "cadence_profile": "dormant",
+        "engagement_score": 0.25,
+        "response_rate": 0.3,
+        "conversation_temperature": "cool",
+        "things_she_loves": ["bold moves", "live music"],
+        "green_flags": ["high energy when she does reply"],
+        "red_flags": ["erratic reply pattern", "goes silent for days"],
+        "context_notes": "Tinder match. Event promoter in Austin. Replies in bursts.",
+        "active_hours_local": {"tz": "America/Chicago", "start_hour": 14, "end_hour": 2},
+        "_meta": {"age": 24, "location": "Austin", "zodiac_sign": "Sagittarius"},
+    },
+]
+
+# Message threads: alternating inbound/outbound, spaced over last 10 days
+DEMO_MESSAGES: list[dict[str, Any]] = [
+    # Sarah Chen — 10 messages
+    {
+        "person_idx": 0, "direction": "outbound", "days_ago": 10.0,
+        "body": "Hey Sarah — that pineapple-pizza hill-dying energy you mentioned... was that a test?",
+        "source": "user",
+    },
+    {
+        "person_idx": 0, "direction": "inbound", "days_ago": 9.8,
+        "body": "Haha full test, you passed. Pineapple doesn't belong anywhere near a pizza.",
+        "source": "import",
+    },
+    {
+        "person_idx": 0, "direction": "outbound", "days_ago": 9.5,
+        "body": "Bold stance for someone who put avocado in their Taco Tuesday reel 😂 caught you.",
+        "source": "ai_suggestion_approved",
+    },
+    {
+        "person_idx": 0, "direction": "inbound", "days_ago": 9.2,
+        "body": "Okay okay FAIR. Avocado is different though. It's a lifestyle.",
+        "source": "import",
+    },
+    {
+        "person_idx": 0, "direction": "outbound", "days_ago": 7.0,
+        "body": "Tried that climbing gym on Valencia you mentioned. My forearms have retired.",
+        "source": "ai_auto_send",
+    },
+    {
+        "person_idx": 0, "direction": "inbound", "days_ago": 6.8,
+        "body": "Nooo which wall?? The 5.10s near the back destroy people the first time",
+        "source": "import",
+    },
+    {
+        "person_idx": 0, "direction": "outbound", "days_ago": 6.5,
+        "body": "Every single one. Walked out like a T-Rex. Worth it.",
+        "source": "user",
+    },
+    {
+        "person_idx": 0, "direction": "inbound", "days_ago": 5.0,
+        "body": "That's actually hilarious. I go Thursday mornings if you ever want a real guide 😄",
+        "source": "import",
+    },
+    {
+        "person_idx": 0, "direction": "outbound", "days_ago": 4.0,
+        "body": "Thursday mornings? I'll block my calendar. What's the T-Rex rehab protocol?",
+        "source": "ai_suggestion_approved",
+    },
+    {
+        "person_idx": 0, "direction": "inbound", "days_ago": 3.5,
+        "body": "Cold brew and ego death. See you there.",
+        "source": "import",
+    },
+
+    # Kate Morgan — 10 messages
+    {
+        "person_idx": 1, "direction": "outbound", "days_ago": 10.0,
+        "body": "Running question: do you track heart rate or just go by feel?",
+        "source": "user",
+    },
+    {
+        "person_idx": 1, "direction": "inbound", "days_ago": 9.9,
+        "body": "Both — I use a Garmin but when I'm really in the zone I forget to check it.",
+        "source": "import",
+    },
+    {
+        "person_idx": 1, "direction": "outbound", "days_ago": 9.5,
+        "body": "That's the good stuff. Zone 2 vs zone 4 debate — where do you land?",
+        "source": "ai_suggestion_approved",
+    },
+    {
+        "person_idx": 1, "direction": "inbound", "days_ago": 9.0,
+        "body": "80% zone 2, 20% suffering. Science + masochism.",
+        "source": "import",
+    },
+    {
+        "person_idx": 1, "direction": "outbound", "days_ago": 7.0,
+        "body": "Just signed up for a half. You said you're training for one too?",
+        "source": "user",
+    },
+    {
+        "person_idx": 1, "direction": "inbound", "days_ago": 6.5,
+        "body": "Yes! Brooklyn Half in May. Are you doing one in California?",
+        "source": "import",
+    },
+    {
+        "person_idx": 1, "direction": "outbound", "days_ago": 6.0,
+        "body": "San Francisco Half — we should compare training notes.",
+        "source": "ai_suggestion_approved",
+    },
+    {
+        "person_idx": 1, "direction": "inbound", "days_ago": 5.0,
+        "body": "I'd actually love that. I'll send you my Garmin plan.",
+        "source": "import",
+    },
+    {
+        "person_idx": 1, "direction": "outbound", "days_ago": 3.0,
+        "body": "Just did a 10 miler. Your zone 2 advice: actually works.",
+        "source": "user",
+    },
+    {
+        "person_idx": 1, "direction": "inbound", "days_ago": 2.5,
+        "body": "Told you 😊 How did the last 2 miles feel?",
+        "source": "import",
+    },
+
+    # Mia Rivera — 8 messages (sporadic, reflecting cooling stage)
+    {
+        "person_idx": 2, "direction": "outbound", "days_ago": 10.0,
+        "body": "Saw Disclosure was in Austin last week — you make it?",
+        "source": "user",
+    },
+    {
+        "person_idx": 2, "direction": "inbound", "days_ago": 8.0,
+        "body": "OBVIOUSLY. Front row. Was insane.",
+        "source": "import",
+    },
+    {
+        "person_idx": 2, "direction": "outbound", "days_ago": 7.5,
+        "body": "Front row respect. Set list?",
+        "source": "user",
+    },
+    {
+        "person_idx": 2, "direction": "inbound", "days_ago": 5.0,
+        "body": "Sorry been so busy with the event we're throwing next weekend",
+        "source": "import",
+    },
+    {
+        "person_idx": 2, "direction": "outbound", "days_ago": 4.5,
+        "body": "What's the event? Austin or traveling?",
+        "source": "ai_suggestion_approved",
+    },
+    {
+        "person_idx": 2, "direction": "inbound", "days_ago": 3.0,
+        "body": "Austin! East Side. I'm handling all the booking.",
+        "source": "import",
+    },
+    {
+        "person_idx": 2, "direction": "outbound", "days_ago": 2.5,
+        "body": "That's a real thing you're building. Who's headlining?",
+        "source": "user",
+    },
+    {
+        "person_idx": 2, "direction": "inbound", "days_ago": 2.0,
+        "body": "Can't say yet 🙈 will send you a link when it's live",
+        "source": "import",
+    },
+]
+
+# Scheduled touches
+DEMO_TOUCHES = [
+    {
+        "person_idx": 0,
+        "touch_type": "callback_reference",
+        "scheduled_for_fn": lambda: _tomorrow_at(14),  # Sarah: 2pm tomorrow
+        "draft_body": "Thursday climbing — still on? My T-Rex arms are at 60%.",
+        "status": "scheduled",
+    },
+    {
+        "person_idx": 1,
+        "touch_type": "reengage_low_temp",
+        "scheduled_for_fn": lambda: _tomorrow_at(11),  # Kate: 11am tomorrow
+        "draft_body": "Quick check-in — how did the long run go this week?",
+        "status": "scheduled",
+    },
+    {
+        "person_idx": 2,
+        "touch_type": "pattern_interrupt",
+        "scheduled_for_fn": lambda: _tomorrow_at(19),  # Mia: 7pm tomorrow
+        "draft_body": "Heads up — there's a rooftop thing Saturday if you want to scout post-event.",
+        "status": "scheduled",
+    },
+    {
+        "person_idx": 0,
+        "touch_type": "nudge",
+        # Already fired (in the past — 3 days ago)
+        "scheduled_for_fn": lambda: _days_ago_ms(3),
+        "draft_body": "Hey — just thinking of that UX rabbit hole you mentioned.",
+        "status": "fired",
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Seed / wipe logic
+# ---------------------------------------------------------------------------
+
+def _insert_person(p: dict[str, Any], user_id: str) -> str:
+    """Insert one demo person and return the Convex _id."""
+    meta = p.pop("_meta", {})
+    now = _now_ms()
+    row: dict[str, Any] = {
+        **p,
+        "user_id": user_id,
+        "raw_profile": meta,  # store age, location, zodiac here (Task A adds schema fields)
+        "created_at": now,
+        "updated_at": now,
+    }
+    result = _mutate("people:insertDemoRow", row)
+    return result
+
+
+def _insert_conversation(person_id: str, handle: str, user_id: str) -> str:
+    """Create a matching conversation row for the demo person."""
+    now = _now_ms()
+    row: dict[str, Any] = {
+        "user_id": user_id,
+        "platform": "imessage",
+        "external_match_id": f"demo-{handle}",
+        "match_name": None,
+        "status": "active",
+        "unread_count": 0,
+        "imessage_handle": handle,
+        "created_at": now,
+        "updated_at": now,
+    }
+    result = _mutate("conversations:insertDemoRow", row)
+    return result
+
+
+def _insert_message(
+    conversation_id: str,
+    user_id: str,
+    direction: str,
+    body: str,
+    days_ago: float,
+    source: str,
+) -> None:
+    sent_at = _days_ago_ms(days_ago)
+    _mutate("messages:append", {
+        "conversation_id": conversation_id,
+        "user_id": user_id,
+        "direction": direction,
+        "body": body,
+        "sent_at": sent_at,
+        "source": source,
+    })
+
+
+def _insert_touch(
+    person_id: str,
+    user_id: str,
+    touch_type: str,
+    scheduled_for: int,
+    draft_body: str,
+    status: str,
+) -> None:
+    _mutate("touches:insertDemoTouch", {
+        "user_id": user_id,
+        "person_id": person_id,
+        "touch_type": touch_type,
+        "scheduled_for": scheduled_for,
+        "draft_body": draft_body,
+        "status": status,
+    })
+
+
+def _insert_pending_link(conversation_id: str, person_ids: list[str], user_id: str) -> None:
+    now = _now_ms()
+    _mutate("pendingLinks:insertDemoRow", {
+        "user_id": user_id,
+        "conversation_id": conversation_id,
+        "handle_channel": "imessage",
+        "handle_value": "+15551112222",
+        "candidate_person_ids": person_ids,
+        "raw_context": "Hey it's me from the other night",
+        "status": "open",
+        "created_at": now,
+        "updated_at": now,
+    })
+
+
+def seed(user_id: str) -> None:
+    print(f"Seeding demo data into {CONVEX_URL} as user={user_id} ...")
+
+    inserted_people: list[str] = []
+    inserted_conversations: list[str] = []
+    message_count = 0
+
+    for person_data in DEMO_PEOPLE:
+        p = dict(person_data)  # copy so we don't mutate the const
+        handle = p["handles"][0]["value"]
+        name = p["display_name"]
+
+        print(f"  inserting person: {name} ({handle})")
+        person_id = _insert_person(p, user_id)
+        inserted_people.append(person_id)
+
+        print(f"    -> person_id={person_id}  inserting conversation ...")
+        conv_id = _insert_conversation(person_id, handle, user_id)
+        inserted_conversations.append(conv_id)
+
+    # Insert messages
+    for msg in DEMO_MESSAGES:
+        idx = msg["person_idx"]
+        conv_id = inserted_conversations[idx]
+        _insert_message(
+            conversation_id=conv_id,
+            user_id=user_id,
+            direction=msg["direction"],
+            body=msg["body"],
+            days_ago=msg["days_ago"],
+            source=msg["source"],
+        )
+        message_count += 1
+
+    # Insert touches
+    touch_count = 0
+    for t in DEMO_TOUCHES:
+        idx = t["person_idx"]
+        person_id = inserted_people[idx]
+        scheduled_for = t["scheduled_for_fn"]()
+        _insert_touch(
+            person_id=person_id,
+            user_id=user_id,
+            touch_type=t["touch_type"],
+            scheduled_for=scheduled_for,
+            draft_body=t["draft_body"],
+            status=t["status"],
+        )
+        touch_count += 1
+
+    # Insert 1 pending_link using the first two demo people as ambiguous candidates
+    _insert_pending_link(
+        conversation_id=inserted_conversations[0],
+        person_ids=inserted_people[:2],
+        user_id=user_id,
+    )
+
+    print()
+    print(
+        f"seeded: {len(inserted_people)} people, {message_count} messages, "
+        f"{touch_count} touches, 1 pending_link."
+    )
+    print()
+    print("To wipe:  python scripts/seed_demo_data.py --wipe")
+    print("People:   /admin/clapcheeks-ops/network (look for 'Demo:' prefix)")
+    print("Touches:  /admin/clapcheeks-ops/touches")
+    print("Links:    /admin/clapcheeks-ops/pending-links")
+
+
+def wipe(user_id: str) -> None:
+    """Delete all rows where display_name starts with 'Demo:'.
+
+    Avoids touching schema — uses the display_name prefix convention rather
+    than a seed_demo field so no schema change is required.
+
+    The Convex mutation people:deleteDemoRows handles the cascade:
+    it deletes matching people rows AND their linked conversations,
+    messages, touches, and pending_links.
+    """
+    print(f"Wiping demo rows from {CONVEX_URL} as user={user_id} ...")
+    result = _mutate("people:deleteDemoRows", {
+        "user_id": user_id,
+        "display_name_prefix": "Demo: ",
+    })
+    print(f"Wiped: {result}")
+    print("Done.")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Seed (or wipe) Clapcheeks demo data in Convex dev.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--wipe",
+        action="store_true",
+        help="Delete all rows with display_name starting with 'Demo: '.",
+    )
+    parser.add_argument(
+        "--user-id",
+        default=USER_ID,
+        help=f"Convex user_id to stamp on rows (default: {USER_ID!r})",
+    )
+    parser.add_argument(
+        "--convex-url",
+        default=CONVEX_URL,
+        help="Override Convex deployment URL.",
+    )
+    args = parser.parse_args()
+
+    global CONVEX_URL
+    CONVEX_URL = args.convex_url.rstrip("/")
+
+    if args.wipe:
+        wipe(args.user_id)
+    else:
+        seed(args.user_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/web/convex/messages.ts
+++ b/web/convex/messages.ts
@@ -93,6 +93,8 @@ export const upsertFromWebhook = mutation({
     attachments_summary: v.optional(v.any()),
     send_error: v.optional(v.any()),
     ai_metadata: v.optional(v.any()),
+    delivered_at: v.optional(v.number()),
+    read_at: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     // 1. Find or create conversation for this handle
@@ -136,6 +138,64 @@ export const upsertFromWebhook = mutation({
       .first();
     if (existingMsg) {
       return { conversation_id: convId, message_id: existingMsg._id };
+    }
+
+    // 2b. Backfill: REST proxy outbound sends insert "pending-<ts>" rows
+    // because mac CLI doesn't always return the BB guid synchronously. When
+    // the eventual updated-message webhook arrives with the real guid, find
+    // the pending row by (conversation, body, direction=outbound, last 10 min)
+    // and patch the external_guid + delivery fields rather than insert dupe.
+    if (args.direction === "outbound") {
+      const tenMinAgo = args.sent_at - 10 * 60 * 1000;
+      const pendingMatch = await ctx.db
+        .query("messages")
+        .withIndex("by_conversation", (q) =>
+          q.eq("conversation_id", convId).gte("sent_at", tenMinAgo),
+        )
+        .filter((q) =>
+          q.and(
+            q.eq(q.field("direction"), "outbound"),
+            q.eq(q.field("body"), args.body),
+          ),
+        )
+        .first();
+      if (
+        pendingMatch &&
+        typeof pendingMatch.external_guid === "string" &&
+        pendingMatch.external_guid.startsWith("pending-")
+      ) {
+        const patches: Record<string, unknown> = {
+          external_guid: args.external_guid,
+          attachments_summary: args.attachments_summary ?? pendingMatch.attachments_summary,
+          send_error: args.send_error ?? pendingMatch.send_error,
+        };
+        if (args.delivered_at !== undefined) patches.delivered_at = args.delivered_at;
+        if (args.read_at !== undefined) patches.read_at = args.read_at;
+        await ctx.db.patch(pendingMatch._id, patches);
+        return { conversation_id: convId, message_id: pendingMatch._id };
+      }
+
+      // 2c. If row already exists (already patched by earlier event), and
+      // this event carries newer delivered/read timestamps, patch them too.
+      const existingByGuid = await ctx.db
+        .query("messages")
+        .withIndex("by_external_guid", (q) =>
+          q.eq("external_guid", args.external_guid),
+        )
+        .first();
+      if (existingByGuid && (args.delivered_at || args.read_at)) {
+        const patches: Record<string, unknown> = {};
+        if (args.delivered_at !== undefined && !existingByGuid.delivered_at) {
+          patches.delivered_at = args.delivered_at;
+        }
+        if (args.read_at !== undefined && !existingByGuid.read_at) {
+          patches.read_at = args.read_at;
+        }
+        if (Object.keys(patches).length > 0) {
+          await ctx.db.patch(existingByGuid._id, patches);
+        }
+        return { conversation_id: convId, message_id: existingByGuid._id };
+      }
     }
 
     // 3. Insert message
@@ -220,5 +280,52 @@ export const recentForUser = query({
       .withIndex("by_user_recent", (q) => q.eq("user_id", args.user_id))
       .order("desc")
       .take(args.limit ?? 50);
+  },
+});
+
+// AI-9412 — REST proxy read endpoint. Lists recent messages for a given line
+// with optional handle/direction/since filter. Used by GET /api/v1/messages.
+export const listForProxy = query({
+  args: {
+    line: v.optional(v.number()),
+    user_id: v.optional(v.string()),
+    handle: v.optional(v.string()),
+    direction: v.optional(v.union(v.literal("inbound"), v.literal("outbound"))),
+    since: v.optional(v.number()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = Math.min(args.limit ?? 50, 200);
+    const since = args.since ?? 0;
+
+    // Choose the most selective index
+    let q;
+    if (args.line !== undefined) {
+      q = ctx.db
+        .query("messages")
+        .withIndex("by_line_recent", (idx) =>
+          idx.eq("line", args.line).gte("sent_at", since),
+        );
+    } else if (args.user_id) {
+      q = ctx.db
+        .query("messages")
+        .withIndex("by_user_recent", (idx) =>
+          idx.eq("user_id", args.user_id!).gte("sent_at", since),
+        );
+    } else {
+      q = ctx.db.query("messages");
+    }
+
+    let rows = await q.order("desc").take(limit * 2);
+    if (args.direction) rows = rows.filter((r) => r.direction === args.direction);
+    if (args.handle) {
+      const convs = await ctx.db
+        .query("conversations")
+        .withIndex("by_imessage_handle", (idx) => idx.eq("imessage_handle", args.handle))
+        .collect();
+      const convIds = new Set(convs.map((c) => c._id));
+      rows = rows.filter((r) => convIds.has(r.conversation_id));
+    }
+    return rows.slice(0, limit);
   },
 });

--- a/web/convex/people.ts
+++ b/web/convex/people.ts
@@ -1,0 +1,969 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// AI-9449 — Unified person record across iMessage / dating apps / email / Telegram.
+//
+// Obsidian is canonical for "who they are" (interests, goals, values,
+// communication_style, cadence_profile, whitelist_for_autoreply).
+// Convex is canonical for "live state" (last_inbound_at, last_outbound_at,
+// next_followup_at, style_profile).
+//
+// Sync is one-way: clapcheeks-local/intel/obsidian_sync.py walks the vault
+// and calls upsertFromObsidian on every changed file. The daemon never
+// writes back to Obsidian (no merge conflicts).
+//
+// Companion modules: messages.ts (extracts handles for person_linker),
+// conversations.ts (carries person_id once linked).
+
+// ----------------------------------------------------------------------------
+// Cadence profile -> minimum inter-message gap (ms). Used by dueForFollowup.
+// Conservative defaults; override per-person via Obsidian if needed.
+// ----------------------------------------------------------------------------
+const CADENCE_GAP_MS: Record<string, number> = {
+  hot: 5 * 60 * 1000,                  // 5 min
+  warm: 60 * 60 * 1000,                // 1 hour
+  slow_burn: 24 * 60 * 60 * 1000,      // 1 day
+  nurture: 3 * 24 * 60 * 60 * 1000,    // 3 days
+  dormant: 30 * 24 * 60 * 60 * 1000,   // 1 month
+};
+
+const HANDLE_CHANNEL = v.union(
+  v.literal("imessage"), v.literal("sms"), v.literal("hinge"),
+  v.literal("tinder"), v.literal("bumble"), v.literal("instagram"),
+  v.literal("telegram"), v.literal("email"), v.literal("whatsapp"),
+);
+
+const CADENCE_PROFILE = v.union(
+  v.literal("hot"), v.literal("warm"), v.literal("slow_burn"),
+  v.literal("nurture"), v.literal("dormant"),
+);
+
+const PERSON_STATUS = v.union(
+  v.literal("lead"), v.literal("active"), v.literal("paused"),
+  v.literal("ghosted"), v.literal("dating"), v.literal("ended"),
+);
+
+// ----------------------------------------------------------------------------
+// upsertFromObsidian
+//
+// Idempotent. Keyed by (user_id, obsidian_path). If the supplied md_hash
+// matches the stored hash, returns early — no DB write. Otherwise patches
+// every Obsidian-sourced field; preserves daemon-owned fields
+// (last_inbound_at, last_outbound_at, next_followup_at, style_profile).
+// ----------------------------------------------------------------------------
+export const upsertFromObsidian = mutation({
+  args: {
+    user_id: v.string(),
+    obsidian_path: v.string(),
+    obsidian_md_hash: v.string(),
+    display_name: v.string(),
+    handles: v.array(v.object({
+      channel: HANDLE_CHANNEL,
+      value: v.string(),
+      verified: v.optional(v.boolean()),
+      primary: v.optional(v.boolean()),
+    })),
+    interests: v.optional(v.array(v.string())),
+    goals: v.optional(v.array(v.string())),
+    values: v.optional(v.array(v.string())),
+    context_notes: v.optional(v.string()),
+    disc_primary: v.optional(v.string()),
+    vak_primary: v.optional(v.string()),
+    communication_style: v.optional(v.string()),
+    cadence_profile: v.optional(CADENCE_PROFILE),
+    active_hours_local: v.optional(v.object({
+      tz: v.string(),
+      start_hour: v.number(),
+      end_hour: v.number(),
+    })),
+    status: v.optional(PERSON_STATUS),
+    whitelist_for_autoreply: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("people")
+      .withIndex("by_obsidian_path", (q) => q.eq("obsidian_path", args.obsidian_path))
+      .first();
+
+    // Normalize handle defaults (verified=false, primary=false unless given).
+    const handles = args.handles.map((h) => ({
+      channel: h.channel,
+      value: h.value,
+      verified: h.verified ?? false,
+      primary: h.primary ?? false,
+    }));
+
+    if (existing && existing.obsidian_md_hash === args.obsidian_md_hash) {
+      return { person_id: existing._id, changed: false };
+    }
+
+    const patch = {
+      user_id: args.user_id,
+      display_name: args.display_name,
+      obsidian_path: args.obsidian_path,
+      obsidian_md_hash: args.obsidian_md_hash,
+      handles,
+      interests: args.interests ?? [],
+      goals: args.goals ?? [],
+      values: args.values ?? [],
+      context_notes: args.context_notes,
+      disc_primary: args.disc_primary,
+      vak_primary: args.vak_primary,
+      communication_style: args.communication_style,
+      cadence_profile: args.cadence_profile ?? "warm",
+      active_hours_local: args.active_hours_local,
+      status: args.status ?? "lead",
+      whitelist_for_autoreply: args.whitelist_for_autoreply ?? false,
+      updated_at: now,
+    };
+
+    if (existing) {
+      await ctx.db.patch(existing._id, patch);
+      return { person_id: existing._id, changed: true };
+    }
+
+    const id = await ctx.db.insert("people", {
+      ...patch,
+      created_at: now,
+    });
+    return { person_id: id, changed: true };
+  },
+});
+
+// ----------------------------------------------------------------------------
+// upsertFromGoogleContacts
+//
+// Source-of-truth for clapcheeks-network MEMBERSHIP. The local sync
+// (clapcheeks/intel/google_contacts_sync.py) walks both julianb233@gmail.com
+// and julian@aiacrobatics.com, filters by the "CC TECH" label, and calls
+// this mutation per contact.
+//
+// Match precedence (avoids duplicates with Obsidian-sourced rows):
+//   1. existing row with same google_contact_id
+//   2. existing row with overlapping email handle (case-insensitive)
+//   3. existing row with overlapping phone handle (E.164 normalized)
+//   4. else create a new row
+//
+// Whitelist for autoreply is NEVER auto-true — even when the label is set.
+// Julian flips it manually in the dashboard with full data-source context.
+// ----------------------------------------------------------------------------
+export const upsertFromGoogleContacts = mutation({
+  args: {
+    user_id: v.string(),
+    google_contact_id: v.string(),
+    google_contact_etag: v.optional(v.string()),
+    google_account_source: v.union(
+      v.literal("personal"), v.literal("workspace"), v.literal("both"),
+    ),
+    google_contacts_labels: v.array(v.string()),
+    display_name: v.string(),
+    handles: v.array(v.object({
+      channel: HANDLE_CHANNEL,
+      value: v.string(),
+      verified: v.optional(v.boolean()),
+      primary: v.optional(v.boolean()),
+    })),
+    interests: v.optional(v.array(v.string())),
+    context_notes: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+
+    // Normalize incoming handles for matching.
+    const incoming = args.handles.map((h) => ({
+      channel: h.channel,
+      value: h.value.trim().toLowerCase(),
+      verified: h.verified ?? false,
+      primary: h.primary ?? false,
+      _original: h.value,
+    }));
+
+    // 1. existing by google_contact_id
+    let match = (await ctx.db
+      .query("people")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .collect())
+      .find((p) => p.google_contact_id === args.google_contact_id) ?? null;
+
+    // 2. existing by email handle overlap
+    if (!match) {
+      const incomingEmails = incoming.filter((h) => h.channel === "email").map((h) => h.value);
+      if (incomingEmails.length) {
+        const all = await ctx.db
+          .query("people")
+          .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+          .collect();
+        match = all.find((p) =>
+          p.handles.some((h) =>
+            h.channel === "email" && incomingEmails.includes(h.value.trim().toLowerCase()),
+          ),
+        ) ?? null;
+      }
+    }
+
+    // 3. existing by phone handle overlap (imessage / sms / whatsapp share E.164 namespace)
+    if (!match) {
+      const incomingPhones = incoming
+        .filter((h) => ["imessage", "sms", "whatsapp"].includes(h.channel))
+        .map((h) => h.value);
+      if (incomingPhones.length) {
+        const all = await ctx.db
+          .query("people")
+          .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+          .collect();
+        match = all.find((p) =>
+          p.handles.some((h) =>
+            ["imessage", "sms", "whatsapp"].includes(h.channel) &&
+            incomingPhones.includes(h.value.trim().toLowerCase()),
+          ),
+        ) ?? null;
+      }
+    }
+
+    // Merge existing handles + new handles (dedup on (channel, value)).
+    const mergedHandles: typeof incoming = [];
+    const seen = new Set<string>();
+    if (match) {
+      for (const h of match.handles) {
+        const key = `${h.channel}:${h.value.trim().toLowerCase()}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          mergedHandles.push({
+            channel: h.channel,
+            value: h.value,
+            verified: h.verified,
+            primary: h.primary,
+            _original: h.value,
+          });
+        }
+      }
+    }
+    for (const h of incoming) {
+      const key = `${h.channel}:${h.value}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        mergedHandles.push(h);
+      }
+    }
+    const handlesForWrite = mergedHandles.map((h) => ({
+      channel: h.channel, value: h._original, verified: h.verified, primary: h.primary,
+    }));
+
+    // Merge labels (existing + new).
+    const labelSet = new Set<string>([
+      ...(match?.google_contacts_labels ?? []),
+      ...args.google_contacts_labels,
+    ]);
+
+    // Determine google_account_source: if previously set to a different
+    // source than this call, mark as "both".
+    let accountSource: "personal" | "workspace" | "both" = args.google_account_source;
+    if (match?.google_account_source && match.google_account_source !== args.google_account_source) {
+      accountSource = "both";
+    }
+
+    if (match) {
+      const patch: Record<string, unknown> = {
+        google_contact_id: args.google_contact_id,
+        google_contact_etag: args.google_contact_etag,
+        google_contacts_labels: Array.from(labelSet),
+        google_account_source: accountSource,
+        handles: handlesForWrite,
+        updated_at: now,
+      };
+      // Don't overwrite display_name if it was set by Obsidian (which often
+      // has richer naming conventions). Only fill if missing.
+      if (!match.display_name || match.display_name === "Unknown") {
+        patch.display_name = args.display_name;
+      }
+      // Merge interests (Obsidian may have set richer ones already).
+      if (args.interests?.length) {
+        const existing = new Set(match.interests || []);
+        for (const i of args.interests) existing.add(i);
+        patch.interests = Array.from(existing);
+      }
+      if (args.context_notes && !match.context_notes) {
+        patch.context_notes = args.context_notes;
+      }
+      await ctx.db.patch(match._id, patch);
+      return { person_id: match._id, created: false };
+    }
+
+    // No match — create new row. Default cadence=warm, status=active (since
+    // the contact carries the membership label), whitelist OFF (manual flip).
+    const id = await ctx.db.insert("people", {
+      user_id: args.user_id,
+      display_name: args.display_name,
+      google_contact_id: args.google_contact_id,
+      google_contact_etag: args.google_contact_etag,
+      google_contacts_labels: Array.from(labelSet),
+      google_account_source: accountSource,
+      handles: handlesForWrite,
+      interests: args.interests ?? [],
+      goals: [],
+      values: [],
+      context_notes: args.context_notes,
+      cadence_profile: "warm",
+      status: "active",
+      whitelist_for_autoreply: false,
+      created_at: now,
+      updated_at: now,
+    });
+    return { person_id: id, created: true };
+  },
+});
+
+// ----------------------------------------------------------------------------
+// findByHandle
+//
+// Look up people by exact (channel, value) match. Returns array — caller
+// decides what to do with 0 / 1 / many results. Used by person_linker on
+// every inbound message.
+//
+// O(N) over the user's people rows because Convex doesn't index inside
+// arrays-of-objects. Fine at human scale (<10k people per user).
+// ----------------------------------------------------------------------------
+export const findByHandle = query({
+  args: {
+    user_id: v.string(),
+    channel: HANDLE_CHANNEL,
+    value: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const all = await ctx.db
+      .query("people")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .collect();
+    const needle = args.value.trim().toLowerCase();
+    return all.filter((p) =>
+      p.handles.some(
+        (h) => h.channel === args.channel && h.value.trim().toLowerCase() === needle,
+      ),
+    );
+  },
+});
+
+// ----------------------------------------------------------------------------
+// dueForFollowup
+//
+// Returns whitelisted, active people whose next_followup_at has passed
+// AND whose minimum inter-message gap (per cadence_profile) has elapsed
+// since last_outbound_at. The cadence_runner iterates this list every 30s.
+//
+// Active-hours filtering is done client-side (daemon) because Convex
+// can't evaluate per-person tz windows efficiently in a query.
+// ----------------------------------------------------------------------------
+export const dueForFollowup = query({
+  args: {
+    user_id: v.string(),
+    now_ms: v.optional(v.number()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = args.now_ms ?? Date.now();
+    const limit = Math.min(args.limit ?? 50, 200);
+
+    const candidates = await ctx.db
+      .query("people")
+      .withIndex("by_user_status", (q) =>
+        q.eq("user_id", args.user_id).eq("status", "active"),
+      )
+      .collect();
+
+    const ready = candidates.filter((p) => {
+      if (!p.whitelist_for_autoreply) return false;
+      if (p.next_followup_at && p.next_followup_at > now) return false;
+      const gap = CADENCE_GAP_MS[p.cadence_profile] ?? CADENCE_GAP_MS.warm;
+      if (p.last_outbound_at && now - p.last_outbound_at < gap) return false;
+      return true;
+    });
+
+    // Oldest next_followup_at first (or oldest last_outbound_at if no followup).
+    ready.sort((a, b) => {
+      const ax = a.next_followup_at ?? a.last_outbound_at ?? 0;
+      const bx = b.next_followup_at ?? b.last_outbound_at ?? 0;
+      return ax - bx;
+    });
+    return ready.slice(0, limit);
+  },
+});
+
+// ----------------------------------------------------------------------------
+// linkConversation
+//
+// Atomically attach a conversation (and its messages, denormalized) to a
+// person. Idempotent — calling twice is a no-op once linked. Called by
+// person_linker.py on exact-match auto-link, or by the dashboard on manual
+// resolution of a pending_links row.
+// ----------------------------------------------------------------------------
+export const linkConversation = mutation({
+  args: {
+    conversation_id: v.id("conversations"),
+    person_id: v.id("people"),
+    backfill_messages: v.optional(v.boolean()),
+  },
+  handler: async (ctx, args) => {
+    const conv = await ctx.db.get(args.conversation_id);
+    if (!conv) throw new Error("conversation not found");
+    if (conv.person_id === args.person_id) {
+      return { conversation_id: conv._id, person_id: args.person_id, already_linked: true };
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(conv._id, { person_id: args.person_id, updated_at: now });
+
+    if (args.backfill_messages !== false) {
+      const msgs = await ctx.db
+        .query("messages")
+        .withIndex("by_conversation", (q) => q.eq("conversation_id", conv._id))
+        .collect();
+      for (const m of msgs) {
+        if (m.person_id !== args.person_id) {
+          await ctx.db.patch(m._id, { person_id: args.person_id });
+        }
+      }
+    }
+
+    // Pull last_inbound/outbound_at from conversation onto the person row
+    // so cadence_runner has fresh state.
+    const person = await ctx.db.get(args.person_id);
+    if (person) {
+      const patch: Record<string, unknown> = { updated_at: now };
+      if (conv.last_inbound_at && (!person.last_inbound_at || conv.last_inbound_at > person.last_inbound_at)) {
+        patch.last_inbound_at = conv.last_inbound_at;
+      }
+      if (conv.last_outbound_at && (!person.last_outbound_at || conv.last_outbound_at > person.last_outbound_at)) {
+        patch.last_outbound_at = conv.last_outbound_at;
+      }
+      if (Object.keys(patch).length > 1) await ctx.db.patch(args.person_id, patch);
+    }
+
+    return { conversation_id: conv._id, person_id: args.person_id, already_linked: false };
+  },
+});
+
+// ----------------------------------------------------------------------------
+// recordPendingLink
+//
+// Called by person_linker.py when an inbound message can't be auto-linked
+// (no handle match OR multiple matches). Inserts a pending_links row the
+// dashboard can surface for manual resolution.
+// ----------------------------------------------------------------------------
+export const recordPendingLink = mutation({
+  args: {
+    user_id: v.string(),
+    conversation_id: v.id("conversations"),
+    handle_channel: v.string(),
+    handle_value: v.string(),
+    candidate_person_ids: v.array(v.id("people")),
+    raw_context: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    // Dedup: if an open pending_link already exists for this conversation,
+    // append the new context but don't create a duplicate row.
+    const existing = await ctx.db
+      .query("pending_links")
+      .withIndex("by_conversation", (q) => q.eq("conversation_id", args.conversation_id))
+      .filter((q) => q.eq(q.field("status"), "open"))
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        candidate_person_ids: args.candidate_person_ids,
+        raw_context: args.raw_context ?? existing.raw_context,
+        updated_at: now,
+      });
+      return { pending_link_id: existing._id, deduped: true };
+    }
+    const id = await ctx.db.insert("pending_links", {
+      user_id: args.user_id,
+      conversation_id: args.conversation_id,
+      handle_channel: args.handle_channel,
+      handle_value: args.handle_value,
+      candidate_person_ids: args.candidate_person_ids,
+      raw_context: args.raw_context,
+      status: "open",
+      created_at: now,
+      updated_at: now,
+    });
+    return { pending_link_id: id, deduped: false };
+  },
+});
+
+// ----------------------------------------------------------------------------
+// listForUser
+//
+// Dashboard reader — sorted by next_followup_at (soonest first). Powers
+// the "who's coming up" panel in the Vercel UI.
+// ----------------------------------------------------------------------------
+export const listForUser = query({
+  args: {
+    user_id: v.string(),
+    status: v.optional(PERSON_STATUS),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = Math.min(args.limit ?? 100, 500);
+    if (args.status) {
+      return await ctx.db
+        .query("people")
+        .withIndex("by_user_status", (q) => q.eq("user_id", args.user_id).eq("status", args.status!))
+        .take(limit);
+    }
+    return await ctx.db
+      .query("people")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .take(limit);
+  },
+});
+
+// ----------------------------------------------------------------------------
+// deleteByObsidianPath
+//
+// Cleanup helper for redirect/merged Obsidian stubs that were sync'd before
+// the obsidian_sync._is_redirect() filter existed. Removes the orphan row
+// AND nulls person_id on any conversation/messages it was attached to so we
+// don't leave dangling refs.
+// ----------------------------------------------------------------------------
+export const deleteByObsidianPath = mutation({
+  args: {
+    user_id: v.string(),
+    obsidian_path: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("people")
+      .withIndex("by_obsidian_path", (q) => q.eq("obsidian_path", args.obsidian_path))
+      .first();
+    if (!row || row.user_id !== args.user_id) {
+      return { deleted: false, reason: "not_found" };
+    }
+
+    // Null out person_id on any attached conversations + messages.
+    const convs = await ctx.db
+      .query("conversations")
+      .withIndex("by_person", (q) => q.eq("person_id", row._id))
+      .collect();
+    for (const c of convs) {
+      await ctx.db.patch(c._id, { person_id: undefined, updated_at: Date.now() });
+    }
+    const msgs = await ctx.db
+      .query("messages")
+      .withIndex("by_person_recent", (q) => q.eq("person_id", row._id))
+      .collect();
+    for (const m of msgs) {
+      await ctx.db.patch(m._id, { person_id: undefined });
+    }
+
+    await ctx.db.delete(row._id);
+    return {
+      deleted: true,
+      person_id: row._id,
+      detached_conversations: convs.length,
+      detached_messages: msgs.length,
+    };
+  },
+});
+
+// ----------------------------------------------------------------------------
+// updateVibe
+//
+// Daemon-only. Called by the convex_runner classify_conversation_vibe job
+// after Claude scores a conversation. Records the classification +
+// confidence + a 1-sentence evidence string the dashboard can show as
+// "why we think this person is in the dating ecosystem".
+// ----------------------------------------------------------------------------
+export const updateVibe = mutation({
+  args: {
+    person_id: v.id("people"),
+    vibe_classification: v.union(
+      v.literal("dating"), v.literal("platonic"),
+      v.literal("professional"), v.literal("unclear"),
+    ),
+    vibe_confidence: v.number(),
+    vibe_evidence: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.person_id, {
+      vibe_classification: args.vibe_classification,
+      vibe_confidence: args.vibe_confidence,
+      vibe_evidence: args.vibe_evidence,
+      vibe_classified_at: Date.now(),
+      updated_at: Date.now(),
+    });
+  },
+});
+
+// ----------------------------------------------------------------------------
+// updateCourtship
+//
+// Daemon-only writer. Called by the convex_runner enrich_courtship job
+// after Gemini analyzes the conversation. Records trust + courtship-stage
+// signals + "next best move" suggestion the dashboard can show.
+// ----------------------------------------------------------------------------
+export const updateCourtship = mutation({
+  args: {
+    person_id: v.id("people"),
+    trust_score: v.optional(v.number()),
+    courtship_stage: v.optional(v.union(
+      v.literal("matched"), v.literal("early_chat"), v.literal("phone_swap"),
+      v.literal("pre_date"), v.literal("first_date_done"), v.literal("ongoing"),
+      v.literal("exclusive"), v.literal("ghosted"), v.literal("ended"),
+    )),
+    trust_signals_observed: v.optional(v.array(v.string())),
+    trust_signals_missing: v.optional(v.array(v.string())),
+    things_she_loves: v.optional(v.array(v.string())),
+    things_she_dislikes: v.optional(v.array(v.string())),
+    boundaries_stated: v.optional(v.array(v.string())),
+    green_flags: v.optional(v.array(v.string())),
+    red_flags: v.optional(v.array(v.string())),
+    compliments_that_landed: v.optional(v.array(v.string())),
+    references_to_callback: v.optional(v.array(v.string())),
+    her_love_languages: v.optional(v.array(v.string())),
+    next_best_move: v.optional(v.string()),
+    next_best_move_confidence: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const { person_id, ...rest } = args;
+    const patch: Record<string, unknown> = {
+      courtship_last_analyzed: Date.now(),
+      updated_at: Date.now(),
+    };
+    for (const [k, v] of Object.entries(rest)) {
+      if (v !== undefined) patch[k] = v;
+    }
+    await ctx.db.patch(person_id, patch);
+  },
+});
+
+// ----------------------------------------------------------------------------
+// listVibeCandidates
+//
+// Dashboard reader. Returns people whose latest vibe_classification is
+// 'dating' but who are NOT yet in the clapcheeks network (no CC TECH label
+// in google_contacts_labels). Sorted by vibe_confidence desc.
+// ----------------------------------------------------------------------------
+export const listVibeCandidates = query({
+  args: {
+    user_id: v.string(),
+    membership_label: v.optional(v.string()),
+    min_confidence: v.optional(v.number()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const label = args.membership_label ?? "CC TECH";
+    const minConf = args.min_confidence ?? 0.6;
+    const limit = Math.min(args.limit ?? 50, 200);
+    const all = await ctx.db
+      .query("people")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .collect();
+    const candidates = all.filter((p) => {
+      if (p.vibe_classification !== "dating") return false;
+      if ((p.vibe_confidence ?? 0) < minConf) return false;
+      if ((p.google_contacts_labels ?? []).includes(label)) return false;
+      return true;
+    });
+    candidates.sort((a, b) => (b.vibe_confidence ?? 0) - (a.vibe_confidence ?? 0));
+    return candidates.slice(0, limit);
+  },
+});
+
+// ----------------------------------------------------------------------------
+// upsertFromSupabase
+//
+// Bulk migration entry point. One row per public.people in Dashboard Daddy.
+// Match precedence: supabase_people_id -> email handle -> phone handle ->
+// create new. Pulls operator-set fields the Daddy CRM tracks (circle,
+// relationship_role, company, profession, interests, etc.) into Convex.
+//
+// Default lifecycle for newly-created rows: status="lead",
+// whitelist_for_autoreply=false. Network membership remains gated by the
+// Google Contacts "CC TECH" label per the architecture lock — pulling the
+// data in does NOT enroll someone in the clapcheeks autoreply set.
+// ----------------------------------------------------------------------------
+export const upsertFromSupabase = mutation({
+  args: {
+    user_id: v.string(),
+    supabase_people_id: v.string(),
+    display_name: v.string(),
+    handles: v.array(v.object({
+      channel: HANDLE_CHANNEL,
+      value: v.string(),
+      verified: v.optional(v.boolean()),
+      primary: v.optional(v.boolean()),
+    })),
+    // operator-set passthrough
+    interests: v.optional(v.array(v.string())),
+    company: v.optional(v.string()),
+    profession: v.optional(v.string()),
+    relationship_strength: v.optional(v.number()),
+    is_client: v.optional(v.boolean()),
+    is_discipleship: v.optional(v.boolean()),
+    business_potential: v.optional(v.string()),
+    // misc
+    context_notes: v.optional(v.string()),
+    ghl_contact_id: v.optional(v.string()),
+    notion_page_id: v.optional(v.string()),
+    cadence_profile: v.optional(CADENCE_PROFILE),
+    status: v.optional(PERSON_STATUS),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const incoming = args.handles.map((h) => ({
+      channel: h.channel,
+      value: h.value.trim().toLowerCase(),
+      _original: h.value,
+      verified: h.verified ?? false,
+      primary: h.primary ?? false,
+    }));
+
+    // Pull all of the user's people once, then match in memory (Convex
+    // doesn't index inside arrays of objects).
+    const all = await ctx.db
+      .query("people")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .collect();
+
+    let match =
+      all.find((p) => (p as any).supabase_people_id === args.supabase_people_id) ??
+      null;
+
+    if (!match) {
+      const incomingEmails = incoming.filter((h) => h.channel === "email").map((h) => h.value);
+      if (incomingEmails.length) {
+        match = all.find((p) =>
+          p.handles.some(
+            (h) => h.channel === "email" &&
+              incomingEmails.includes(h.value.trim().toLowerCase()),
+          ),
+        ) ?? null;
+      }
+    }
+
+    if (!match) {
+      const incomingPhones = incoming
+        .filter((h) => ["imessage", "sms", "whatsapp"].includes(h.channel))
+        .map((h) => h.value);
+      if (incomingPhones.length) {
+        match = all.find((p) =>
+          p.handles.some(
+            (h) => ["imessage", "sms", "whatsapp"].includes(h.channel) &&
+              incomingPhones.includes(h.value.trim().toLowerCase()),
+          ),
+        ) ?? null;
+      }
+    }
+
+    // Merge handles
+    const seen = new Set<string>();
+    const mergedHandles: Array<{ channel: any; value: string; verified: boolean; primary: boolean }> = [];
+    if (match) {
+      for (const h of match.handles) {
+        const key = `${h.channel}:${h.value.trim().toLowerCase()}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          mergedHandles.push({ channel: h.channel, value: h.value, verified: h.verified, primary: h.primary });
+        }
+      }
+    }
+    for (const h of incoming) {
+      const key = `${h.channel}:${h.value}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        mergedHandles.push({ channel: h.channel, value: h._original, verified: h.verified, primary: h.primary });
+      }
+    }
+
+    if (match) {
+      const patch: Record<string, unknown> = {
+        updated_at: now,
+        supabase_people_id: args.supabase_people_id,
+        handles: mergedHandles,
+      };
+      if (!match.display_name || match.display_name === "Unknown") patch.display_name = args.display_name;
+      if (args.interests?.length) {
+        const merged = new Set(match.interests || []);
+        for (const i of args.interests) merged.add(i);
+        patch.interests = Array.from(merged);
+      }
+      if (args.company && !match.company) patch.company = args.company;
+      if (args.profession && !match.profession) patch.profession = args.profession;
+      if (args.relationship_strength !== undefined && match.relationship_strength === undefined) {
+        patch.relationship_strength = args.relationship_strength;
+      }
+      if (args.is_client !== undefined && match.is_client === undefined) patch.is_client = args.is_client;
+      if (args.is_discipleship !== undefined && match.is_discipleship === undefined) {
+        patch.is_discipleship = args.is_discipleship;
+      }
+      if (args.business_potential && !match.business_potential) patch.business_potential = args.business_potential;
+      if (args.ghl_contact_id && !match.ghl_contact_id) patch.ghl_contact_id = args.ghl_contact_id;
+      if (args.context_notes && !match.context_notes) patch.context_notes = args.context_notes;
+      await ctx.db.patch(match._id, patch);
+      return { person_id: match._id, created: false };
+    }
+
+    const id = await ctx.db.insert("people", {
+      user_id: args.user_id,
+      display_name: args.display_name,
+      supabase_people_id: args.supabase_people_id,
+      handles: mergedHandles,
+      interests: args.interests ?? [],
+      goals: [],
+      values: [],
+      context_notes: args.context_notes,
+      company: args.company,
+      profession: args.profession,
+      relationship_strength: args.relationship_strength,
+      is_client: args.is_client,
+      is_discipleship: args.is_discipleship,
+      business_potential: args.business_potential,
+      ghl_contact_id: args.ghl_contact_id,
+      cadence_profile: args.cadence_profile ?? "warm",
+      status: args.status ?? "lead",
+      whitelist_for_autoreply: false,
+      created_at: now,
+      updated_at: now,
+    });
+    return { person_id: id, created: true };
+  },
+});
+
+// ----------------------------------------------------------------------------
+// patchEnrichment
+//
+// Generic enrichment writer. Used by the Supabase migration script + the
+// dashboard's manual edit panel + the comms_profiler enrich_person job.
+// Only fields explicitly passed are updated — no field can be cleared
+// accidentally (passing v.optional means "leave alone if absent" here).
+//
+// Looks up by phone-handle if person_id not given (so the migration can
+// match on E.164 without first resolving Convex ids).
+// ----------------------------------------------------------------------------
+export const patchEnrichment = mutation({
+  args: {
+    person_id: v.optional(v.id("people")),
+    user_id: v.optional(v.string()),
+    match_phone_e164: v.optional(v.string()),
+
+    // Operator-set fields
+    domain: v.optional(v.array(v.string())),
+    disc_primary: v.optional(v.string()),
+    disc_secondary: v.optional(v.string()),
+    disc_type: v.optional(v.string()),
+    vak_primary: v.optional(v.string()),
+    communication_style: v.optional(v.string()),
+    formality: v.optional(v.string()),
+    best_contact_time: v.optional(v.string()),
+    preferred_channel: v.optional(v.string()),
+    business_potential: v.optional(v.string()),
+    company: v.optional(v.string()),
+    profession: v.optional(v.string()),
+    faith_stage: v.optional(v.string()),
+    is_discipleship: v.optional(v.boolean()),
+    is_client: v.optional(v.boolean()),
+    client_project: v.optional(v.string()),
+    relationship_strength: v.optional(v.number()),
+    cialdini_principle: v.optional(v.string()),
+    rapport_phrases: v.optional(v.array(v.string())),
+    interest_categories: v.optional(v.array(v.string())),
+    passions: v.optional(v.array(v.string())),
+    dislikes: v.optional(v.array(v.string())),
+    topics_to_avoid: v.optional(v.array(v.string())),
+
+    // Auto-computed fields
+    motivation: v.optional(v.string()),
+    reference_style: v.optional(v.string()),
+    approach: v.optional(v.string()),
+    energy: v.optional(v.string()),
+    rapport_markers: v.optional(v.array(v.string())),
+    avg_message_length: v.optional(v.number()),
+    emoji_frequency: v.optional(v.number()),
+    recommendations: v.optional(v.array(v.string())),
+    raw_profile: v.optional(v.any()),
+    message_count: v.optional(v.number()),
+    last_analyzed: v.optional(v.number()),
+    observed_response_window: v.optional(v.any()),
+    julian_style_with_contact: v.optional(v.string()),
+    best_channels: v.optional(v.array(v.string())),
+    contact_history_summary: v.optional(v.string()),
+    relationship_dynamic: v.optional(v.string()),
+    sentiment_trend: v.optional(v.union(
+      v.literal("improving"), v.literal("stable"), v.literal("declining"),
+    )),
+    avg_sentiment_score: v.optional(v.number()),
+    last_sentiment_at: v.optional(v.number()),
+
+    // Activity indicators
+    is_actively_dating: v.optional(v.boolean()),
+    is_actively_talking: v.optional(v.boolean()),
+    engagement_score: v.optional(v.number()),
+    response_rate: v.optional(v.number()),
+    avg_response_time_minutes: v.optional(v.number()),
+    conversation_temperature: v.optional(v.union(
+      v.literal("hot"), v.literal("warm"), v.literal("cool"),
+      v.literal("cold"), v.literal("dormant"),
+    )),
+    days_since_last_reply: v.optional(v.number()),
+    total_messages_30d: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    let target: any = null;
+    if (args.person_id) {
+      target = await ctx.db.get(args.person_id);
+    } else if (args.match_phone_e164 && args.user_id) {
+      const all = await ctx.db
+        .query("people")
+        .withIndex("by_user", (q) => q.eq("user_id", args.user_id!))
+        .collect();
+      const phone = args.match_phone_e164.trim();
+      target = all.find((p) =>
+        p.handles.some(
+          (h) =>
+            ["imessage", "sms", "whatsapp"].includes(h.channel) &&
+            h.value.trim() === phone,
+        ),
+      ) ?? null;
+    }
+    if (!target) {
+      return { matched: false };
+    }
+
+    const patch: Record<string, unknown> = { updated_at: Date.now() };
+    const skipKeys = new Set(["person_id", "user_id", "match_phone_e164"]);
+    for (const [k, v] of Object.entries(args)) {
+      if (skipKeys.has(k)) continue;
+      if (v === undefined || v === null) continue;
+      patch[k] = v;
+    }
+    await ctx.db.patch(target._id, patch);
+    return { matched: true, person_id: target._id, fields_set: Object.keys(patch).length - 1 };
+  },
+});
+
+// ----------------------------------------------------------------------------
+// updateLiveState
+//
+// Daemon-only writer. Called whenever inbound/outbound activity occurs on
+// any of this person's channels. Bumps last_inbound_at/last_outbound_at
+// and (optionally) re-schedules next_followup_at based on cadence_profile.
+// ----------------------------------------------------------------------------
+export const updateLiveState = mutation({
+  args: {
+    person_id: v.id("people"),
+    last_inbound_at: v.optional(v.number()),
+    last_outbound_at: v.optional(v.number()),
+    next_followup_at: v.optional(v.number()),
+    style_profile: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const patch: Record<string, unknown> = { updated_at: now };
+    if (args.last_inbound_at !== undefined) patch.last_inbound_at = args.last_inbound_at;
+    if (args.last_outbound_at !== undefined) patch.last_outbound_at = args.last_outbound_at;
+    if (args.next_followup_at !== undefined) patch.next_followup_at = args.next_followup_at;
+    if (args.style_profile !== undefined) patch.style_profile = args.style_profile;
+    await ctx.db.patch(args.person_id, patch);
+  },
+});

--- a/web/convex/schema.ts
+++ b/web/convex/schema.ts
@@ -39,13 +39,16 @@ export default defineSchema({
     line: v.optional(v.number()),                  // 1-5 for fleet multi-line; sticky once set
     imessage_handle: v.optional(v.string()),       // E.164 phone or email tied to the contact
     ghl_contact_id: v.optional(v.string()),        // GoHighLevel contact UUID once linked
+    // Cross-channel person identity (AI-9449)
+    person_id: v.optional(v.id("people")),         // unified-person link; null until person_linker matches
   })
     .index("by_user", ["user_id"])
     .index("by_user_status", ["user_id", "status"])
     .index("by_user_external", ["user_id", "platform", "external_match_id"])
     .index("by_last_message", ["user_id", "last_message_at"])
     .index("by_line_recent", ["line", "last_message_at"])      // AI-9409: per-line queries
-    .index("by_imessage_handle", ["imessage_handle"]),         // AI-9409: sticky-line lookup
+    .index("by_imessage_handle", ["imessage_handle"])          // AI-9409: sticky-line lookup
+    .index("by_person", ["person_id"]),                         // AI-9449: cross-channel feed per person
 
   // Every message in or out, both for live UI updates and AI training context.
   messages: defineTable({
@@ -86,11 +89,16 @@ export default defineSchema({
       code: v.optional(v.number()),
       description: v.optional(v.string()),
     })),
+    // Cross-channel person identity (AI-9449) — denormalized from conversations.person_id
+    // so message-level queries (e.g. cadence runner reading "last 30 messages with this person")
+    // don't require a join.
+    person_id: v.optional(v.id("people")),
   })
     .index("by_conversation", ["conversation_id", "sent_at"])
     .index("by_user_recent", ["user_id", "sent_at"])
     .index("by_line_recent", ["line", "sent_at"])              // AI-9409: per-line feed
-    .index("by_external_guid", ["external_guid"]),             // AI-9409: dedup lookup
+    .index("by_external_guid", ["external_guid"])              // AI-9409: dedup lookup
+    .index("by_person_recent", ["person_id", "sent_at"]),      // AI-9449: cross-channel message feed
 
   // Replaces public.clapcheeks_scheduled_messages on Postgres.
   scheduled_messages: defineTable({
@@ -153,5 +161,251 @@ export default defineSchema({
     updated_at: v.number(),
   })
     .index("by_next_action", ["state", "next_action_at"])
+    .index("by_conversation", ["conversation_id"]),
+
+  // -----------------------------------------------------------------------
+  // AI-9449 — Unified person record across channels.
+  //
+  // One row per real human, regardless of how many platforms they reach you on
+  // (iMessage, Hinge, Tinder, Bumble, Telegram, email, etc.). Sourced from
+  // Obsidian frontmatter (interests/goals/values/cadence) and joined to
+  // conversations + messages via person_id. Obsidian is canonical for "who
+  // they are"; Convex is canonical for "live state" (last_inbound_at,
+  // next_followup_at, style_profile).
+  //
+  // Companion: people.ts (upsertFromObsidian, findByHandle, dueForFollowup,
+  // linkConversation). Local agent: clapcheeks-local/intel/obsidian_sync.py
+  // and clapcheeks-local/intel/person_linker.py.
+  // -----------------------------------------------------------------------
+  people: defineTable({
+    user_id: v.string(),                            // Supabase auth user (the operator)
+    display_name: v.string(),
+
+    // Obsidian linkage (one-way: Obsidian -> Convex). hash detects edits to
+    // skip no-op upserts.
+    obsidian_path: v.optional(v.string()),          // e.g. "People/Romantic/Sarah K.md"
+    obsidian_md_hash: v.optional(v.string()),
+
+    // Google Contacts linkage. Populated by intel/google_contacts_sync.py for
+    // every contact carrying the configured membership label (default: "CC TECH").
+    // The presence of the label name in google_contacts_labels is what flags
+    // a person as "in the clapcheeks network" — Obsidian no longer governs
+    // membership.
+    google_contact_id: v.optional(v.string()),                       // resourceName, e.g. "people/c123..."
+    google_contact_etag: v.optional(v.string()),                     // for change detection
+    google_contacts_labels: v.optional(v.array(v.string())),         // ["CC TECH", "Family", ...]
+    google_account_source: v.optional(v.union(                       // which gws profile this came from
+      v.literal("personal"),                                          // julianb233@gmail.com
+      v.literal("workspace"),                                         // julian@aiacrobatics.com
+      v.literal("both"),                                              // dedupe matched same person across both
+    )),
+
+    // Cross-system foreign keys (for backfill + bidirectional sync verification).
+    supabase_people_id: v.optional(v.string()),                       // public.people.id from Dashboard Daddy
+    ghl_contact_id: v.optional(v.string()),                           // GoHighLevel CRM
+    notion_page_id: v.optional(v.string()),                           // Notion person page
+
+    // Identity handles — every channel a message could land on.
+    handles: v.array(v.object({
+      channel: v.union(
+        v.literal("imessage"), v.literal("sms"), v.literal("hinge"),
+        v.literal("tinder"), v.literal("bumble"), v.literal("instagram"),
+        v.literal("telegram"), v.literal("email"), v.literal("whatsapp"),
+      ),
+      value: v.string(),                            // E.164 phone, lowercase email, or platform user id
+      verified: v.boolean(),
+      primary: v.boolean(),
+    })),
+
+    // -----------------------------------------------------------------
+    // OPERATOR-SET enrichment (sourced from Obsidian Templates/Person.md
+    // + Google Contacts user-defined fields + dashboard manual edits).
+    // -----------------------------------------------------------------
+    interests: v.array(v.string()),
+    goals: v.array(v.string()),
+    values: v.array(v.string()),
+    context_notes: v.optional(v.string()),          // free-form Obsidian body excerpt
+    domain: v.optional(v.array(v.string())),        // ["business", "personal", "creative", ...]
+    disc_primary: v.optional(v.string()),           // D / I / S / C
+    disc_secondary: v.optional(v.string()),
+    disc_type: v.optional(v.string()),              // composite, e.g. "I/D"
+    vak_primary: v.optional(v.string()),            // visual / auditory / kinesthetic
+    communication_style: v.optional(v.string()),
+    formality: v.optional(v.string()),              // casual / professional / formal
+    best_contact_time: v.optional(v.string()),
+    preferred_channel: v.optional(v.string()),
+    business_potential: v.optional(v.string()),     // low / medium / high
+    company: v.optional(v.string()),
+    profession: v.optional(v.string()),
+    faith_stage: v.optional(v.string()),
+    is_discipleship: v.optional(v.boolean()),
+    is_client: v.optional(v.boolean()),
+    client_project: v.optional(v.string()),
+    relationship_strength: v.optional(v.number()),  // 1-10
+    cialdini_principle: v.optional(v.string()),     // reciprocity / commitment / social_proof / authority / liking / scarcity / unity
+    rapport_phrases: v.optional(v.array(v.string())),  // operator-curated phrases that build rapport
+
+    // Interests refinement (Julian: "interests")
+    interest_categories: v.optional(v.array(v.string())),  // top-level: sports, music, food, travel, fitness, etc.
+    passions: v.optional(v.array(v.string())),             // deeper than interests
+    dislikes: v.optional(v.array(v.string())),
+    topics_to_avoid: v.optional(v.array(v.string())),
+
+    // -----------------------------------------------------------------
+    // AUTO-COMPUTED enrichment (mirrors Supabase contact_communication_profiles
+    // — populated by comms_profiler / convex_runner enrich_person job).
+    // -----------------------------------------------------------------
+    motivation: v.optional(v.string()),             // toward / away
+    reference_style: v.optional(v.string()),
+    approach: v.optional(v.string()),               // suggested communication approach
+    energy: v.optional(v.string()),                 // high / medium / low
+    rapport_markers: v.optional(v.array(v.string())),  // phrases observed to land well
+    avg_message_length: v.optional(v.number()),
+    emoji_frequency: v.optional(v.number()),        // 0.0 - 1.0
+    recommendations: v.optional(v.array(v.string())),  // coaching suggestions for next reply
+    raw_profile: v.optional(v.any()),               // full LLM analysis blob
+    message_count: v.optional(v.number()),
+    last_analyzed: v.optional(v.number()),          // unix ms
+    observed_response_window: v.optional(v.any()),  // {start_hour, end_hour, p50_minutes, ...}
+    julian_style_with_contact: v.optional(v.string()),  // how Julian's voice should mirror this person
+    best_channels: v.optional(v.array(v.string())),     // observed-best channels for this person
+    contact_history_summary: v.optional(v.string()),
+    relationship_dynamic: v.optional(v.string()),
+    sentiment_trend: v.optional(v.union(
+      v.literal("improving"), v.literal("stable"), v.literal("declining"),
+    )),
+    avg_sentiment_score: v.optional(v.number()),    // -1.0 to 1.0
+    last_sentiment_at: v.optional(v.number()),
+
+    // -----------------------------------------------------------------
+    // DATING / TALKING ACTIVITY INDICATORS (Julian: "dating and talking
+    // indicators"). Computed from Convex messages + observed reply patterns.
+    // Refreshed by enrich_person + a periodic sweep.
+    // -----------------------------------------------------------------
+    is_actively_dating: v.optional(v.boolean()),    // vibe=dating AND has reciprocal messages last 30d
+    is_actively_talking: v.optional(v.boolean()),   // any reciprocal messages last 30d
+    engagement_score: v.optional(v.number()),       // 0.0 - 1.0 composite
+    response_rate: v.optional(v.number()),          // 0.0 - 1.0 — fraction of your outbound that gets a reply
+    avg_response_time_minutes: v.optional(v.number()),
+    conversation_temperature: v.optional(v.union(   // OBSERVED state (not target — see cadence_profile)
+      v.literal("hot"), v.literal("warm"), v.literal("cool"),
+      v.literal("cold"), v.literal("dormant"),
+    )),
+    days_since_last_reply: v.optional(v.number()),
+    total_messages_30d: v.optional(v.number()),
+
+    // -----------------------------------------------------------------
+    // TRUST + COURTSHIP INTELLIGENCE (Julian: "build trust and court a
+    // girl and the things they like"). Populated by the convex_runner
+    // job enrich_courtship after the chat.db backfill — Gemini reads
+    // the last 100 messages and outputs structured signals about where
+    // the relationship is, what she values, and what your next move
+    // should be.
+    // -----------------------------------------------------------------
+    trust_score: v.optional(v.number()),              // 0.0 - 1.0 — observed trust level
+    courtship_stage: v.optional(v.union(
+      v.literal("matched"),                            // dating-app match, no number swap yet
+      v.literal("early_chat"),                         // exchanging messages, low context
+      v.literal("phone_swap"),                         // off the app, on iMessage
+      v.literal("pre_date"),                           // confirmed but date hasn't happened
+      v.literal("first_date_done"),                    // had one in-person meeting
+      v.literal("ongoing"),                            // dating actively, multiple meetings
+      v.literal("exclusive"),                          // monogamy / committed
+      v.literal("ghosted"),                            // unilateral silence on her end
+      v.literal("ended"),                              // explicit end
+    )),
+    trust_signals_observed: v.optional(v.array(v.string())),    // e.g. ["shares vulnerable details", "follows through on plans"]
+    trust_signals_missing: v.optional(v.array(v.string())),     // e.g. ["never initiates", "only talks late at night"]
+    things_she_loves: v.optional(v.array(v.string())),          // her stated favorite topics / hooks for the next message
+    things_she_dislikes: v.optional(v.array(v.string())),
+    boundaries_stated: v.optional(v.array(v.string())),         // explicit "I don't do X" lines she's drawn
+    green_flags: v.optional(v.array(v.string())),               // positives observed in the convo
+    red_flags: v.optional(v.array(v.string())),                 // warning signs to be aware of
+    compliments_that_landed: v.optional(v.array(v.string())),   // past compliments that got positive response
+    references_to_callback: v.optional(v.array(v.string())),    // inside jokes / shared memories to invoke
+    her_love_languages: v.optional(v.array(v.string())),        // words / time / gifts / acts / touch (1+ if mentioned)
+    next_best_move: v.optional(v.string()),                     // 1-sentence Gemini-suggested next message / move
+    next_best_move_confidence: v.optional(v.number()),          // 0.0 - 1.0
+    courtship_last_analyzed: v.optional(v.number()),            // unix ms of last enrich_courtship run
+
+    // Cadence + timing — drives the cadence_runner thread.
+    cadence_profile: v.union(
+      v.literal("hot"),                             // reply within 5-30m
+      v.literal("warm"),                            // reply within 1-4h
+      v.literal("slow_burn"),                       // 1/day
+      v.literal("nurture"),                         // 2-3/week
+      v.literal("dormant"),                         // 1/month re-engage
+    ),
+    active_hours_local: v.optional(v.object({
+      tz: v.string(),                               // e.g. "America/Los_Angeles"
+      start_hour: v.number(),                       // 0-23
+      end_hour: v.number(),
+    })),
+
+    // Live state (computed by daemon, NOT from Obsidian).
+    last_inbound_at: v.optional(v.number()),
+    last_outbound_at: v.optional(v.number()),
+    next_followup_at: v.optional(v.number()),
+    style_profile: v.optional(v.any()),             // output of comms_profiler
+
+    // Vibe classification — LLM-driven hint for "is this person in the
+    // dating ecosystem?". Computed by convex_runner job classify_conversation_vibe
+    // against the last 50 messages. Surfaces in the dashboard as a candidate
+    // suggestion (NOT auto-applied — Julian still has to add the CC TECH
+    // label in Google Contacts to make them a member of the network).
+    vibe_classification: v.optional(v.union(
+      v.literal("dating"),     // romantic / dating-app context
+      v.literal("platonic"),   // friend / family / coach style
+      v.literal("professional"),  // work / client / vendor
+      v.literal("unclear"),    // not enough signal
+    )),
+    vibe_confidence: v.optional(v.number()),        // 0.0 - 1.0
+    vibe_classified_at: v.optional(v.number()),     // unix ms — last time job ran
+    vibe_evidence: v.optional(v.string()),          // 1-2 sentences from Claude explaining
+
+    // Lifecycle
+    status: v.union(
+      v.literal("lead"), v.literal("active"), v.literal("paused"),
+      v.literal("ghosted"), v.literal("dating"), v.literal("ended"),
+    ),
+
+    // Safety brake — both Obsidian frontmatter AND this field must be true
+    // for daemon to autoreply. Default false.
+    whitelist_for_autoreply: v.boolean(),
+
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_user", ["user_id"])
+    .index("by_user_status", ["user_id", "status"])
+    .index("by_next_followup", ["status", "next_followup_at"])
+    .index("by_obsidian_path", ["obsidian_path"]),
+    // NOTE: no by_handles index — Convex doesn't index inside arrays-of-objects.
+    // findByHandle does an O(N) scan filtered by user_id; fine at human-scale (<10k people).
+
+  // -----------------------------------------------------------------------
+  // AI-9449 — Pending cross-channel link queue.
+  //
+  // When person_linker.py sees an inbound message but can't match exactly one
+  // person row (multi-match or no-match), it inserts a pending_links row. The
+  // Vercel dashboard surfaces these for manual disposition.
+  // -----------------------------------------------------------------------
+  pending_links: defineTable({
+    user_id: v.string(),
+    conversation_id: v.id("conversations"),
+    handle_channel: v.string(),                     // e.g. "imessage"
+    handle_value: v.string(),                       // e.g. "+15551234567"
+    candidate_person_ids: v.array(v.id("people")),  // empty = no match; multi = ambiguous
+    raw_context: v.optional(v.string()),            // first message text snippet
+    status: v.union(
+      v.literal("open"),
+      v.literal("resolved"),
+      v.literal("ignored"),
+    ),
+    resolved_person_id: v.optional(v.id("people")),
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_user_status", ["user_id", "status"])
     .index("by_conversation", ["conversation_id"]),
 });


### PR DESCRIPTION
## Summary

- New script `clapcheeks-local/scripts/seed_demo_data.py` seeds 3 fake people (Sarah Chen, Kate Morgan, Mia Rivera) with realistic profiles, 28 messages spread over 10 days, 4 scheduled touches (3 future + 1 already-fired), and 1 pending_links row with two ambiguous candidates
- All seeded people have `whitelist_for_autoreply=False` — AI will never auto-send to demo handles
- `--wipe` flag deletes all rows where `display_name` starts with `'Demo: '` via `people:deleteDemoRows` cascade mutation
- Uses Convex HTTP API directly; reads `CONVEX_URL` + `CONVEX_DEPLOY_KEY` from `web/.env.local` or `~/.clapcheeks/.env`
- Appended wipe procedure to `.planning/clapcheeks-wave-2.4-bussit.md` decommission section

## Usage

```bash
# Seed demo data
cd /opt/agency-workspace/clapcheeks.tech
python clapcheeks-local/scripts/seed_demo_data.py

# Wipe all demo rows
python clapcheeks-local/scripts/seed_demo_data.py --wipe
```

## Test plan

- [ ] Script runs without error against dev Convex (`valiant-oriole-651`)
- [ ] `/admin/clapcheeks-ops/network` shows 3 "Demo:" people
- [ ] `/admin/clapcheeks-ops/touches` shows 3-4 demo touches
- [ ] `/admin/clapcheeks-ops/pending-links` shows 1 ambiguous entry
- [ ] `--wipe` removes all Demo rows without touching real data

Closes AI-9506 (parent: AI-9500, epic: AI-9449)

🤖 Generated with [Claude Code](https://claude.com/claude-code)