### PR TITLE
feat(clapcheeks/enrichment): AI-9500-E reply-velocity mirror

### DIFF
--- a/web/convex/schema.ts
+++ b/web/convex/schema.ts
@@ -389,6 +389,9 @@ export default defineSchema({
       banter_density_target: v.optional(v.number()),             // 0..1
       emoji_density_target: v.optional(v.number()),
       message_length_target: v.optional(v.number()),
+      // AI-9500-E: set by recalibrateCadenceForOne (reply-velocity mirror)
+      computed_at: v.optional(v.number()),                       // unix ms — last calibration run
+      sample_pairs: v.optional(v.number()),                      // reply pairs used for median
     })),
     time_to_ask_score: v.optional(v.number()),                   // 0..1 — when crosses 0.7 → schedule date-ask
     last_ask_attempted_at: v.optional(v.number()),               // unix ms — throttle re-asks
@@ -437,6 +440,9 @@ export default defineSchema({
       start_hour: v.number(),                       // 0-23
       end_hour: v.number(),
     })),
+    // AI-9500-E: Hour ints (0-23) where her inbound volume exceeds 1/3 of the
+    // peak hour. Derived from the same 30d window as cadence_overrides.
+    active_hours_computed: v.optional(v.array(v.float64())),
 
     // Live state (computed by daemon, NOT from Obsidian).
     last_inbound_at: v.optional(v.number()),


### PR DESCRIPTION
## Summary

Wave 2.4 Task E — Reply-velocity mirror + active-hours auto-tune (AI-9504, sub of AI-9500 / AI-9449).

**What ships in this PR (schema side):**

- `web/convex/schema.ts`: extends `people.cadence_overrides` with `computed_at` and `sample_pairs` fields (written by `recalibrateCadenceForOne` after fitting the median reply gap); adds `active_hours_computed: v.optional(v.array(v.float64()))` (hour ints 0-23 where her inbound volume exceeds 1/3 of peak).

**Already in main (shipped via PR #85 — AI-9449):**

- `enrichment.ts`: `recalibrateCadenceForOne` internalAction (reads 30d messages, pairs outbound→inbound, computes median gap, writes `cadence_overrides` at 0.7x/1.4x median clamped 30s–6h, writes `active_hours_computed`; skips if <10 pairs). `recalibrateCadenceSweep` mutation.
- `crons.ts`: `recalibrate-cadence-sweep` weekly cron (Monday 03:00 UTC).
- `touches.ts`: `fireOne` cadence-gap enforcement — if `elapsed < min_reply_gap_ms`, reschedule to `last_inbound_at + min_gap_ms + jitter(0..30s)`.

**Worked example:**

```
30 messages → 12 valid reply pairs
median gap = 390,000ms (~6.5 min)
min_reply_gap_ms = clamp(0.7 × 390k, 30s, 6h) = 273,000ms
max_reply_gap_ms = clamp(1.4 × 390k, 30s, 6h) = 546,000ms
computed_at = now(), sample_pairs = 12

If next outbound fires 3 min after her reply (< 4.55 min min gap):
  → rescheduled to last_inbound_at + 273s + jitter(0..30s)
  → {rescheduled: true, reason: "cadence_gap_too_soon", new_scheduled_for: ...}
```

## Linear

- Sub-issue: AI-9504
- Parent: AI-9500 (Wave 2.4 bussit)
- Epic: AI-9449

🤖 Generated with [Claude Code](https://claude.com/claude-code)