### PR TITLE
AI-9500-J: Operator ratings + dashboard data + restore lost convex modules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Clapcheeks — AI Dating Co-Pilot
+# Clapcheeks — AI Dating Co-Pilot (Operator-Only)
 
 ## ⚠️ CRITICAL BRAND RULE — DO NOT CHANGE
 
@@ -11,47 +11,224 @@ This codebase was previously associated with a product called "Outward" but has 
 - Do NOT rename back to Outward
 - Do NOT change "Clapcheeks" to "Outward" in any file
 
+## What This System Is
+
+Clapcheeks is Julian's **personal AI dating co-pilot** running on Mac Mini + Convex + Vercel.
+The marketing site is at the root domain; the operator-only ops dashboard is at
+`/admin/clapcheeks-ops/*` (auth-gated to four admin emails).
+
+The system reads inbound iMessages from `chat.db` via BlueBubbles, analyzes them
+via an LLM cascade (Claude Sonnet → Gemini 2.0 Flash → DeepSeek → Grok 2),
+schedules per-person touches with strict safety brakes, suggests calibrated
+replies via the four hard rules, manages a media library of approved photos,
+imports dating-app profile screenshots into person rows with zodiac + DISC +
+opener calibration, and drives every send through a whitelist + active-hours +
+anti-loop + boundary-respect enforcement chain.
+
+**Outcome the system is built for:** Julian sees one digest per day, taps Send
+on suggestions he agrees with, and gets to dates without manually drafting
+every message — while never sending anything tone-deaf, repetitive, or
+boundary-violating.
+
+## Architecture (5 layers, top to bottom)
+
+1. **Operator dashboard** — Next.js 15 App Router pages under `web/app/admin/clapcheeks-ops/*`. Reads/writes Convex via `useQuery` / `useMutation`.
+2. **Convex** (`web/convex/*.ts`) — schema + queries + mutations + crons + httpActions. Source of truth for live state.
+3. **Mac Mini daemon** (`/Users/thewizzard/clapcheeks-local/clapcheeks/`) — long-running Python process under launchd. Polls `agent_jobs` queue, drafts replies via the LLM cascade, sends via BlueBubbles, reads chat.db for inbound, syncs Obsidian + Google Contacts, fetches gws calendar slots.
+4. **BlueBubbles** — Mac-resident HTTP/webhook server bridging iMessage to Convex. Inbound webhook → VPS receiver → `messages.upsertFromWebhook`. Outbound send via Mac BlueBubbles HTTP API.
+5. **Obsidian + Google Contacts** — operator's source of truth for "who they are" (interests, goals, values, communication style, boundaries). One-way sync into Convex; the daemon never writes back.
+
 ## Project Structure
 
 ```
-web/          — Next.js 15 SaaS app (landing page + dashboard)
-supabase/     — Database migrations
-api/          — Backend API (separate service)
+web/                                          — Next.js 15 SaaS app + ops dashboard
+  app/admin/clapcheeks-ops/                   — operator-only routes (auth-gated)
+    page.tsx                                  — overview
+    network/page.tsx                          — list of dating-relevant people
+    people/[id]/page.tsx                      — per-person dossier + Compose panel
+    media/page.tsx                            — media library approval queue
+    touches/page.tsx                          — upcoming + recent fires
+    calendar/page.tsx                         — calendar_slots cache view
+    pending-links/page.tsx                    — handle → person link queue
+    profile-imports/page.tsx                  — screenshot → person row review
+  convex/                                     — schema, queries, mutations, crons, httpActions
+clapcheeks-local/                             — separate repo on Mac Mini (Python daemon)
+supabase/migrations/                          — landing-site users/billing tables
 ```
 
-## Web App
+## Convex deployment
 
-- **Framework**: Next.js 15.5.12 (App Router)
-- **Auth**: Supabase Auth with SSR
-- **Payments**: Stripe (checkout + webhooks)
-- **Styling**: Tailwind CSS v4 dark mode (bg-black forced on body)
-- **Deployment**: Vercel (project: clapcheeks-tech)
+- **Dev deployment:** `valiant-oriole-651` (live)
+- **Convex URL:** https://valiant-oriole-651.convex.cloud
+- **Deploy key:** `op item get "CONVEX-clapcheeks-dev-admin-key" --vault API-Keys --fields credential --reveal`
+- **Deploy command:**
+  ```bash
+  cd web
+  CONVEX_DEPLOY_KEY="$(op item get 'CONVEX-clapcheeks-dev-admin-key' --vault API-Keys --fields credential --reveal)" \
+    npx convex deploy -y
+  ```
+- **Run a single function for verification:**
+  ```bash
+  CONVEX_DEPLOY_KEY="..." npx convex run people:listForUser '{"user_id":"fleet-julian","limit":10}'
+  ```
+- **Function inventory:** `npx convex function-spec --prod`
 
-## Deployment
+**IMPORTANT:** Convex deploys are full-source replacements. If you push source missing a module that's deployed live, those functions get DELETED. Always verify the local source has every module before `convex deploy`.
 
-```bash
-cd web
-VERCEL_TOKEN="..." npx vercel --prod --yes
-```
+## Vercel deployment
 
-The project is linked via `web/.vercel/project.json` to `prj_0Ra8fB9WK2RsKV31xUjnFXy2iAki`.
+- **Project:** `clapcheeks-tech` (linked via `web/.vercel/project.json` → `prj_0Ra8fB9WK2RsKV31xUjnFXy2iAki`)
+- **Auto-deploy** on push to main/integration branches.
+- **Manual deploy:** `cd web && VERCEL_TOKEN="..." npx vercel --prod --yes`
 
-## Key Files
+## Mac Mini daemon
 
-- `web/app/layout.tsx` — Root layout, has `dark` class + `bg-black` on body
-- `web/app/landing.css` — Orb blur, gradient-text, animation utilities
-- `web/lib/supabase/middleware.ts` — Auth + route protection
-- `web/app/(main)/` — Authenticated app routes (dashboard, billing, etc.)
-- `web/app/(main)/pricing/pricing-client.tsx` — Stripe checkout integration
+Lives at `/Users/thewizzard/clapcheeks-local/`. Three launchd jobs:
+- `tech.clapcheeks.runner` — main loop, claims `agent_jobs` from Convex
+- `tech.clapcheeks.mediawatcher` — polls Google Drive for new media uploads
+- `tech.clapcheeks.hingepoller` — pulls SendBird for new Hinge messages (when tokens captured)
 
-## Database (Supabase)
+**SSH:** `ssh thewizzard@100.108.83.124`. Logs at `~/.clapcheeks/daemon.log`.
+
+**Key handlers in `convex_runner.py`:**
+- `send_imessage` — outbound send via BlueBubbles, drafts via `_draft_with_template`
+- `draft_preview` — operator clicked Preview in dossier compose panel
+- `send_digest_to_julian` — daily morning digest delivery
+- `fetch_calendar_slots` — gws calendar pull → calendar_slots upsert
+- `enrich_courtship` — re-extract personal_details / curiosity / events / boundaries / emotional_state
+- `cadence_evaluate_one` — recompute next_followup_at, time_to_ask_score, conversation_temperature
+- `auto_tag_media` — Gemini Vision tags an uploaded photo
+- `analyze_profile_screenshot` — Gemini Vision extracts profile info from a screenshot
+- `classify_conversation_vibe` — dating | platonic | professional | unclear
+
+## Safety brakes (every send goes through ALL of these)
+
+Order of evaluation in `touches.fireOne`:
+1. **Whitelist:** `people.whitelist_for_autoreply` MUST be true. Default false. Operator flips manually in the dossier.
+2. **Status:** Person not paused / ended.
+3. **Active hours:** If `active_hours_local` is set, current hour in her tz must be within the window. Otherwise the touch reschedules itself to the next window start.
+4. **Anti-loop (Wave 2.4D):** `fired_body_shape = sha1(type + ":" + draft[0:50])`. If any other person for this user got the same shape in the last 7 days, skip with `anti_loop_collision`.
+5. **Cadence-mirror (Wave 2.4E):** If `cadence_overrides.min_reply_gap_ms` is set and we're firing too soon after her last reply, push the touch out by `min_reply_gap + 0..30s jitter`.
+6. **Boundary respect (Wave 2.4D, Mac Mini side):** `_draft_with_template` injects `boundaries_stated` as `## HARD RULES — DO NOT VIOLATE` at the top of the system prompt. Post-draft validation scans for banned tokens (`drink`, `wine`, `late night`, etc. mapped per boundary). One regen pass; if still violating, returns `__BOUNDARY_VIOLATION__` sentinel and the send is skipped.
+
+## The 4 Hard Rules (drafting on Mac Mini)
+
+Every reply template injects these at the top of the system prompt:
+1. **Reference at least one specific thing** from prior messages OR personal_details. No generic "how's your week".
+2. **Match her current emotional state** (`stressed/excited/playful/vulnerable/flirty/bored/tired/proud/anxious/neutral`).
+3. **End with one question OR observation.** If a question, it MUST reference something specific to her.
+4. **Don't pivot to Julian** unless she asked. Mirror-and-extend her topic.
+Plus: ≤240 chars, no em-dashes, no semicolons.
+
+## Date-ask flow (3 calendar slots)
+
+1. Sweep `enrichment.sweepAskCandidates` runs every 6h. Finds people whose `time_to_ask_score >= 0.7` AND no recent ask.
+2. Schedules a `date_ask` touch with template `date_ask_three_options`.
+3. Mac Mini drafter reads `calendar:listFreeSlots` for the next 14 days, filters preferred evening hours (default 18-20 local), dedupes by day, takes the **top 3** distinct slots.
+4. Drafts a single message proposing those 3 with a callback line. Example: "btw you mentioned that taco place… Thu 7pm, Sat 8pm, or Sun 6pm work for you?"
+5. On her confirmation, operator clicks Confirm → `calendar:markConfirmed` → calendar_slot becomes `date_confirmed`.
+
+## Touch types (`scheduled_touches.type`)
+
+| Type | Use case |
+|---|---|
+| `reply` | Standard cadence reply (most common) |
+| `nudge` | Soft re-engage when she's gone quiet but not silent |
+| `callback_reference` | "Did you end up doing X?" — surface a specific thing she mentioned |
+| `date_ask` | Propose a date with 3 calendar slots |
+| `date_confirm_24h` | T-24h check-in before a confirmed date |
+| `date_dayof` | T-3h day-of logistics confirm |
+| `date_postmortem` | Morning-after the date |
+| `reengage_low_temp` | Pattern interrupt at 5+ days silent |
+| `birthday_wish` | Birthday |
+| `event_day_check` | Her marathon/interview/etc. happening today |
+| `pattern_interrupt` | Unique soft restart (5 sub-styles per DISC: callback / meme / low-pressure / bold / seasonal) |
+| `phone_swap_followup` | First-call invite 24-72h post phone swap |
+| `first_call_invite` | Propose a phone/voice call |
+| `morning_text` | Casual morning check-in |
+| `digest_inclusion` | Include this person in tomorrow's digest |
+
+## Person schema — operator-editable fields (Wave 2.4 J)
+
+Use `people.patchPerson({person_id, ...fields})` to write. Fields safe to edit from the dashboard:
+
+| Field | Type | Notes |
+|---|---|---|
+| `display_name` | string | |
+| `status` | enum | `lead / active / paused / ghosted / dating / ended` |
+| `cadence_profile` | enum | `hot / warm / slow_burn / nurture / dormant` |
+| `whitelist_for_autoreply` | bool | Safety brake — must be true for AI to send |
+| `courtship_stage` | enum | `matched / early_chat / phone_swap / pre_date / first_date_done / ongoing / exclusive / ghosted / ended` |
+| `hotness_rating` | 1-10 | Operator's read on attractiveness; drives prioritization |
+| `effort_rating` | 1-5 | How much energy operator is willing to invest |
+| `nurture_state` | enum | `active_pursuit / steady / nurture / dormant / close` |
+| `next_followup_kind` | enum | What we should send next |
+| `operator_notes` | string | Free-form |
+| `interests` | string[] | |
+| `boundaries_stated` | string[] | Drives the HARD RULES injection — handle with care |
+| `things_she_loves` / `things_she_dislikes` | string[] | |
+| `active_hours_local` | object | `{tz, start_hour, end_hour}` |
+
+## Dashboard workflows
+
+### Add someone to the dating network
+1. Tag them with the **CC TECH** label in Google Contacts on either `julianb233@gmail.com` or `julian@aiacrobatics.com`.
+2. Wait for `google_contacts_sync` cron tick (or trigger manually via the daemon).
+3. They appear in `/admin/clapcheeks-ops/network`.
+4. Click their name → dossier.
+5. Set `hotness_rating`, `effort_rating`, `nurture_state`, `cadence_profile`.
+6. Flip `whitelist_for_autoreply` to `true` only when ready.
+
+### Import a profile from a dating-app screenshot
+1. iPhone Shortcut "Clapcheeks" with `x-cc-kind: profile` header → POST to `/clapcheeks/media-upload`.
+2. `analyzeAsProfile` fires Gemini Vision → extracts name, age, bio, prompts, photos described, zodiac, DISC, 3 calibrated openers, green/red flags, compatibility-with-Julian read.
+3. Operator visits `/admin/clapcheeks-ops/profile-imports`, reviews, clicks **Create person row**.
+4. New `people` row created with `status="lead"`, `whitelist_for_autoreply=false`.
+
+### Compose a one-off send (Wave 2.4 G)
+1. Open person's dossier.
+2. ComposePanel: pick template (context_aware_reply / hot_reply / callback_reference / pattern_interrupt / morning_text / ghost_recovery / date_ask_three_options / etc.).
+3. Click **Preview draft** → enqueues `draft_preview` agent_job → Mac Mini drafts via `_draft_with_template` → reactive subscription updates the textarea.
+4. Edit → Send → `commitPreview` flips `is_preview=false` and triggers `fireOne`.
+
+## Stale or "not accurate" dashboard — diagnosis checklist
+
+If `/admin/clapcheeks-ops/network` shows nothing or wrong people:
+
+1. **Convex deployed?** Check function inventory: `npx convex function-spec --prod`. If your new mutations aren't listed → run `npx convex deploy -y`.
+2. **People count:** `npx convex run people:listForUser '{"user_id":"fleet-julian","limit":500}'` should return 100+ rows.
+3. **CC TECH labelling:** if you want to use the strict CC TECH filter, ensure people in Google Contacts have the label AND `google_contacts_sync` has run.
+4. **person_id linkage:** `backfill.orphanStatus({user_id:"fleet-julian"})` shows orphaned conversations not linked to a person. Run `backfill.runChained` to patch.
+5. **vibe_classification:** if 0 people have `vibe_classification="dating"`, run `enrichment.sweepVibeCandidates` once (the cron does this every 6h but you can trigger manually).
+6. **Mac Mini daemon up?** `ssh thewizzard@100.108.83.124 "tail -50 ~/.clapcheeks/daemon.log"`. If silent, `launchctl load ~/Library/LaunchAgents/tech.clapcheeks.runner.plist`.
+
+## Bussit pattern — multi-terminal parallel execution
+
+Wave 2.4 used a "bussit" task package: split independent work units across multiple Claude Code terminals with isolated worktrees. See `.planning/clapcheeks-wave-2.4-bussit.md` for the convention.
+
+**Critical lesson learned (2026-05-06):** the SHARED `clapcheeks.tech` worktree gets thrashed when multiple parallel agents check out different branches under each other. Always work in **your own worktree** (`/tmp/cc-<agent>-<branch>`) to avoid lost work and zero out merge contention. Don't write untracked files in the shared worktree — they get wiped.
+
+## Database (Supabase, landing-site only — NOT Convex)
 
 - Project ref: `oouuoepmkeqdyzsxrnjh`
 - Host: `db.oouuoepmkeqdyzsxrnjh.supabase.co`
 - Migrations: `supabase/migrations/` and `web/scripts/`
+- Used for: SaaS users / billing / Stripe webhooks. **NOT** the dating engine — that's all Convex.
 
-## User Roles
+## User Roles (admin gating for the ops dashboard)
 
-- `user` — default
-- `admin` — admin access
-- `super_admin` — full access (julianb233@gmail.com, julian@aiacrobatics.com)
+`web/app/admin/layout.tsx` allows: `julian@clapcheeks.tech`, `admin@clapcheeks.tech`, `julianb233@gmail.com`, `julian@aiacrobatics.com`. Anyone else gets redirected to `/dashboard`.
+
+## Linear
+
+Epic: **AI-9449** (Clapcheeks AI dating co-pilot, full system).
+Wave 2.4 sub-epic: **AI-9500**. All sub-issues created via the bussit task package land here.
+
+## Don't break
+
+- The 4 hard rules. They're the difference between sounding human and sounding bot.
+- The whitelist brake. Default-deny is the only safe stance.
+- The boundary HARD RULES injection. If she said "I don't drink", the AI must never propose wine.
+- The anti-loop check. Same template + same draft shape across two girls within 7 days = ban-worthy if either compares notes.
+- The active-hours respect. Don't text her at 3am.
+- One-way Obsidian → Convex sync. Never write back to Obsidian; merge conflicts are unrecoverable.

--- a/web/app/admin/clapcheeks-ops/calendar/page.tsx
+++ b/web/app/admin/clapcheeks-ops/calendar/page.tsx
@@ -1,0 +1,57 @@
+/**
+ * Calendar — see upcoming free slots the AI can propose for date_ask.
+ * Refreshed every 30 min by the Mac Mini daemon's fetch_calendar_slots job.
+ */
+"use client"
+
+import { useQuery } from "convex/react"
+import { api } from "@/convex/_generated/api"
+
+const FLEET_USER_ID = "fleet-julian"
+
+export default function CalendarPage() {
+  const slots = useQuery(api.calendar.listFreeSlots, {
+    user_id: FLEET_USER_ID, horizon_days: 14, limit: 100,
+  })
+
+  if (slots === undefined) return <div className="p-8 text-gray-500">Loading…</div>
+
+  const grouped: Record<string, any[]> = {}
+  for (const s of slots) {
+    const day = new Date(s.slot_start_ms).toLocaleDateString()
+    grouped[day] ||= []
+    grouped[day].push(s)
+  }
+
+  return (
+    <div className="p-8 max-w-7xl">
+      <h1 className="text-3xl font-bold mb-2">Free Slots</h1>
+      <p className="text-gray-400 mb-6">
+        AI proposes date times only from these. {slots.length} 1-hour windows in next 14 days.
+        Refreshed every 30 min from <span className="text-purple-300">julian@aiacrobatics.com primary</span>
+        {" + "}<span className="text-purple-300">Dating</span> calendar. Confirmed dates land on the Dating calendar.
+        Override via <code className="text-xs bg-gray-800 px-1 rounded">CC_BUSY_CALENDARS</code> env on Mac Mini.
+      </p>
+
+      {Object.entries(grouped).map(([day, ss]) => (
+        <section key={day} className="mb-6">
+          <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide mb-2">{day}</h2>
+          <div className="flex flex-wrap gap-2">
+            {ss.map((s: any) => (
+              <span key={s._id} className="bg-gray-900 border border-gray-800 rounded-lg px-3 py-1 text-sm">
+                {s.label_local || new Date(s.slot_start_ms).toLocaleTimeString([], { hour: "numeric" })}
+              </span>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      {slots.length === 0 && (
+        <div className="text-gray-500 text-sm">
+          No slots cached yet. The Mac Mini daemon&apos;s fetch_calendar_slots cron runs every
+          30 min — first run populates this within an hour.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/app/admin/clapcheeks-ops/media/page.tsx
+++ b/web/app/admin/clapcheeks-ops/media/page.tsx
@@ -1,0 +1,94 @@
+/**
+ * Media library — approve / deprecate / re-tag.
+ */
+"use client"
+
+import { useQuery, useMutation } from "convex/react"
+import { api } from "@/convex/_generated/api"
+import { useState } from "react"
+
+const FLEET_USER_ID = "fleet-julian"
+
+export default function MediaLibrary() {
+  const [tab, setTab] = useState<"pending" | "approved">("pending")
+  const pending = useQuery(api.media.listForApproval, { user_id: FLEET_USER_ID })
+  const approved = useQuery(api.media.listApproved, { user_id: FLEET_USER_ID, limit: 100 })
+  const approve = useMutation(api.media.approve)
+  const deprecate = useMutation(api.media.deprecate)
+
+  const items = tab === "pending" ? pending : approved
+
+  return (
+    <div className="p-8 max-w-7xl">
+      <h1 className="text-3xl font-bold mb-2">Media Library</h1>
+      <p className="text-gray-400 mb-6">
+        Photos / videos / memes the AI can attach to outbound messages when context fits.
+      </p>
+
+      <div className="flex gap-2 mb-6">
+        <button onClick={() => setTab("pending")}
+                className={`px-4 py-2 rounded-lg text-sm ${tab === "pending" ? "bg-purple-600 text-white" : "bg-gray-800 text-gray-300"}`}>
+          Pending ({pending?.length ?? "—"})
+        </button>
+        <button onClick={() => setTab("approved")}
+                className={`px-4 py-2 rounded-lg text-sm ${tab === "approved" ? "bg-purple-600 text-white" : "bg-gray-800 text-gray-300"}`}>
+          Approved ({approved?.length ?? "—"})
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {items === undefined && <div className="text-gray-500">Loading…</div>}
+        {items && items.length === 0 && (
+          <div className="text-gray-500 col-span-full">
+            {tab === "pending"
+              ? "No pending media. Drop photos into ~/Google Drive/Other computers/Mac mini/Clapcheeks Media."
+              : "No approved media yet."}
+          </div>
+        )}
+        {items?.map((m: any) => (
+          <div key={m._id} className="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
+            {m.thumbnail_url || m.storage_url ? (
+              <img src={m.thumbnail_url || m.storage_url} alt={m.caption || ""}
+                   className="w-full h-48 object-cover" />
+            ) : (
+              <div className="w-full h-48 bg-gray-800 flex items-center justify-center text-gray-500">
+                no preview
+              </div>
+            )}
+            <div className="p-3 space-y-1">
+              <div className="text-sm font-medium truncate">{m.caption || m.asset_id}</div>
+              <div className="text-xs text-gray-500">
+                {m.kind} · vibe={m.vibe ?? "—"} · flex={m.flex_level ?? "—"} · used={m.used_count ?? 0}
+              </div>
+              <div className="text-xs text-gray-400 line-clamp-2">
+                {(m.tags ?? []).slice(0, 6).join(", ") || "(untagged — auto-tag pending)"}
+              </div>
+              <div className="text-xs text-gray-500 line-clamp-2">
+                hooks: {(m.context_hooks ?? []).slice(0, 4).join(", ") || "—"}
+              </div>
+              <div className="flex gap-2 pt-2">
+                {tab === "pending" ? (
+                  <>
+                    <button onClick={() => approve({ asset_id: m._id })}
+                            className="flex-1 bg-green-600 hover:bg-green-500 text-white px-3 py-1 rounded text-xs">
+                      Approve
+                    </button>
+                    <button onClick={() => deprecate({ asset_id: m._id })}
+                            className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-300 px-3 py-1 rounded text-xs">
+                      Skip
+                    </button>
+                  </>
+                ) : (
+                  <button onClick={() => deprecate({ asset_id: m._id })}
+                          className="flex-1 bg-gray-800 hover:bg-red-700 text-gray-300 px-3 py-1 rounded text-xs">
+                    Deprecate
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/app/admin/clapcheeks-ops/network/page.tsx
+++ b/web/app/admin/clapcheeks-ops/network/page.tsx
@@ -1,13 +1,20 @@
 /**
- * Network — CC TECH people, ranked by recency + courtship signals.
- * Click a person → /admin/clapcheeks-ops/people/[id] for the full dossier
- * (timeline / memory / schedule / media / profile / notes + compose panel).
+ * Network — operator's dating-relevant people, ranked by hotness × recency.
+ * Click a person → /admin/clapcheeks-ops/people/[id] for the full dossier.
+ *
+ * Filter (default ON): only show people who are dating-relevant —
+ *   - status in {lead, active, dating, paused} AND
+ *   - (has any iMessage/dating-app handle OR last_inbound_at within 90d
+ *     OR explicitly hotness_rating set OR vibe_classification=="dating")
+ *
+ * Toggle the "Everyone" switch to drop the filter and see all 500+ rows.
  */
 "use client"
 
 import { useQuery } from "convex/react"
 import { api } from "@/convex/_generated/api"
 import Link from "next/link"
+import { useState } from "react"
 
 const FLEET_USER_ID = "fleet-julian"
 
@@ -16,31 +23,94 @@ const STAGE_ORDER = [
   "first_date_done", "ongoing", "exclusive", "ghosted", "ended",
 ]
 
+const NINETY_DAYS = 90 * 24 * 60 * 60 * 1000
+
+function isDatingRelevant(p: any): boolean {
+  if (!["lead", "active", "dating", "paused"].includes(p.status)) return false
+  const hasHandle = (p.handles ?? []).some((h: any) =>
+    ["imessage", "hinge", "tinder", "bumble", "instagram"].includes(h.channel)
+  )
+  const hasRecentInbound = p.last_inbound_at && (Date.now() - p.last_inbound_at) < NINETY_DAYS
+  const hasOperatorRating = p.hotness_rating !== undefined || p.effort_rating !== undefined
+  const isDatingVibe = p.vibe_classification === "dating"
+  const isImported = p.imported_from_profile_screenshot === true
+  return Boolean(hasHandle || hasRecentInbound || hasOperatorRating || isDatingVibe || isImported)
+}
+
+function priorityScore(p: any): number {
+  let score = 0
+  if (p.hotness_rating) score += p.hotness_rating * 10
+  if (p.last_inbound_at) {
+    const hoursAgo = (Date.now() - p.last_inbound_at) / 3600000
+    score += Math.max(0, 50 - hoursAgo)
+  }
+  if (p.next_followup_at && p.next_followup_at < Date.now()) score += 20
+  if (p.time_to_ask_score) score += p.time_to_ask_score * 30
+  if (p.whitelist_for_autoreply) score += 5
+  return score
+}
+
 export default function NetworkPage() {
+  const [showAll, setShowAll] = useState(false)
+  const [search, setSearch] = useState("")
   const people = useQuery(api.people.listForUser, {
-    user_id: FLEET_USER_ID, limit: 200, only_cc_tech: true,
+    user_id: FLEET_USER_ID, limit: 500, only_cc_tech: false,
   })
 
   if (people === undefined) return <div className="p-8 text-gray-500">Loading…</div>
 
+  const filtered = people.filter((p: any) => {
+    if (search) {
+      const q = search.toLowerCase()
+      if (!p.display_name?.toLowerCase().includes(q) &&
+          !p.context_notes?.toLowerCase().includes(q)) return false
+    }
+    return showAll ? true : isDatingRelevant(p)
+  })
+
   const byStage: Record<string, any[]> = {}
-  for (const p of people) {
-    const stage = p.courtship_stage || "early_chat"
+  for (const p of filtered) {
+    const stage = p.courtship_stage || (p.status === "lead" ? "matched" : "early_chat")
     byStage[stage] ||= []
     byStage[stage].push(p)
   }
 
   return (
     <div className="p-8 max-w-7xl">
-      <h1 className="text-3xl font-bold mb-2">CC TECH Network</h1>
-      <p className="text-gray-400 mb-6">
-        {people.length} people · ranked within courtship stage by last_inbound_at.
-      </p>
+      <div className="flex justify-between items-start mb-2">
+        <div>
+          <h1 className="text-3xl font-bold">Network</h1>
+          <p className="text-gray-400">
+            {filtered.length} of {people.length} people · ranked by hotness × recency
+          </p>
+        </div>
+        <div className="flex gap-3 items-center">
+          <input
+            type="text"
+            value={search}
+            placeholder="search name…"
+            onChange={(e) => setSearch(e.target.value)}
+            className="bg-gray-950 border border-gray-800 rounded px-3 py-1.5 text-sm w-48"
+          />
+          <label className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer">
+            <input type="checkbox" checked={showAll} onChange={(e) => setShowAll(e.target.checked)} />
+            show all (incl. non-dating)
+          </label>
+        </div>
+      </div>
+
+      <div className="text-xs text-gray-600 mb-6">
+        Default view: lead/active/dating/paused with dating-channel handle, recent inbound, operator rating, or dating vibe.
+      </div>
+
+      {filtered.length === 0 && (
+        <div className="text-center py-12 text-gray-500">
+          {search ? "No matches." : "No dating-relevant people yet — toggle 'show all' to see everyone."}
+        </div>
+      )}
 
       {STAGE_ORDER.map((stage) => {
-        const ppl = (byStage[stage] || []).sort(
-          (a, b) => (b.last_inbound_at ?? 0) - (a.last_inbound_at ?? 0),
-        )
+        const ppl = (byStage[stage] || []).sort((a, b) => priorityScore(b) - priorityScore(a))
         if (ppl.length === 0) return null
         return (
           <section key={stage} className="mb-8">
@@ -66,30 +136,53 @@ function PersonRow({ p }: { p: any }) {
   const trust = p.trust_score?.toFixed(2) ?? "—"
   const ttas = p.time_to_ask_score?.toFixed(2) ?? "—"
   const lastEmotion = (p.emotional_state_recent ?? []).slice(-1)[0]?.state ?? "—"
+  const platforms = Array.from(new Set((p.handles ?? []).map((h: any) => h.channel)))
   return (
     <Link
       href={`/admin/clapcheeks-ops/people/${p._id}`}
       className="block bg-gray-900 border border-gray-800 rounded-lg p-3 hover:border-purple-700 hover:bg-gray-800/60 transition-colors"
     >
-      <div className="flex justify-between items-start">
-        <div className="flex-1">
-          <div className="font-medium">{p.display_name}</div>
+      <div className="flex justify-between items-start gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span className="font-medium">{p.display_name}</span>
+            {p.age && <span className="text-gray-500 text-xs">· {p.age}</span>}
+            {p.hotness_rating && (
+              <span className="text-pink-300 text-xs font-mono">🔥 {p.hotness_rating}/10</span>
+            )}
+            {p.effort_rating && (
+              <span className="text-amber-300 text-xs font-mono">⚡ {p.effort_rating}/5</span>
+            )}
+            {p.nurture_state && (
+              <span className="text-purple-300 text-xs uppercase">{p.nurture_state}</span>
+            )}
+            {platforms.length > 0 && (
+              <span className="text-xs text-gray-600">{platforms.join(" · ")}</span>
+            )}
+          </div>
           <div className="text-xs text-gray-500 mt-1">
-            inbound {lastInbound} · trust {trust} · ask {ttas} · {lastEmotion}
+            inbound {lastInbound} · trust {trust} · ask {ttas} · emo {lastEmotion}
+            {p.zodiac_sign && <span className="ml-2 capitalize">♈ {p.zodiac_sign}</span>}
           </div>
           {p.next_best_move && (
-            <div className="text-sm text-purple-300 mt-2">
-              💡 {p.next_best_move}
-            </div>
+            <div className="text-sm text-purple-300 mt-2 line-clamp-1">💡 {p.next_best_move}</div>
           )}
           {p.curiosity_ledger && p.curiosity_ledger.filter((q: any) => q.status === "pending").length > 0 && (
-            <div className="text-xs text-gray-400 mt-1">
+            <div className="text-xs text-gray-400 mt-1 line-clamp-1">
               Q: {p.curiosity_ledger.filter((q: any) => q.status === "pending")[0]?.question}
             </div>
           )}
         </div>
-        <div className="text-right text-xs text-gray-500">
-          {p.cadence_profile} · {p.whitelist_for_autoreply ? "✓ whitelisted" : "○ manual"}
+        <div className="text-right text-xs text-gray-500 flex-shrink-0">
+          <div>{p.cadence_profile}</div>
+          <div className={p.whitelist_for_autoreply ? "text-green-400" : "text-gray-600"}>
+            {p.whitelist_for_autoreply ? "✓ whitelisted" : "○ manual"}
+          </div>
+          {p.next_followup_at && (
+            <div className="text-amber-400 mt-1">
+              follow-up {new Date(p.next_followup_at).toLocaleDateString()}
+            </div>
+          )}
         </div>
       </div>
     </Link>

--- a/web/app/admin/clapcheeks-ops/page.tsx
+++ b/web/app/admin/clapcheeks-ops/page.tsx
@@ -1,0 +1,122 @@
+/**
+ * AI-9449 Wave 2.2 — Clapcheeks operator overview.
+ *
+ * Live snapshot of Julian's dating ops:
+ *   - CC TECH network size + courtship-stage breakdown
+ *   - Pending media awaiting approval
+ *   - Scheduled touches in next 24h
+ *   - Latest digest items
+ *   - Backfill orphan status
+ *
+ * Read-only. Action surfaces live in /admin/clapcheeks-ops/{network,media,touches,calendar}.
+ */
+"use client"
+
+import { useQuery } from "convex/react"
+import { api } from "@/convex/_generated/api"
+import Link from "next/link"
+
+const FLEET_USER_ID = "fleet-julian"
+
+export default function ClapcheeksOpsOverview() {
+  const vibeCandidates = useQuery(api.people.listVibeCandidates, {
+    user_id: FLEET_USER_ID, limit: 5,
+  })
+  const pendingMedia = useQuery(api.media.listForApproval, { user_id: FLEET_USER_ID })
+  const orphanStatus = useQuery(api.backfill.orphanStatus, { user_id: FLEET_USER_ID })
+
+  return (
+    <div className="p-8 max-w-7xl">
+      <h1 className="text-3xl font-bold mb-2">Clapcheeks Ops</h1>
+      <p className="text-gray-400 mb-8">
+        Your dating co-pilot — live state, ranked surfaces, one-tap controls.
+      </p>
+
+      <div className="grid grid-cols-2 gap-4 mb-8">
+        <Card title="Pending media for approval"
+              value={pendingMedia?.length ?? "—"}
+              href="/admin/clapcheeks-ops/media" />
+        <Card title="Orphan conversations (un-linked)"
+              value={orphanStatus?.orphan_conversations_visible ?? "—"} />
+        <Card title="Vibe candidates not yet in network"
+              value={vibeCandidates?.length ?? "—"}
+              href="/admin/clapcheeks-ops/network" />
+        <Card title="Scheduled touches (next 24h)"
+              value={"—"}
+              href="/admin/clapcheeks-ops/touches" />
+      </div>
+
+      <section className="mb-8">
+        <h2 className="text-xl font-semibold mb-3">Vibe candidates</h2>
+        <p className="text-sm text-gray-500 mb-3">
+          Conversations the AI thinks are dating-vibe but you haven&apos;t added to CC TECH yet.
+        </p>
+        <div className="space-y-2">
+          {vibeCandidates && vibeCandidates.length > 0 ? (
+            vibeCandidates.slice(0, 5).map((c: any) => (
+              <div key={c._id} className="bg-gray-900 border border-gray-800 rounded-lg p-3">
+                <div className="flex justify-between items-start">
+                  <div>
+                    <div className="font-medium">{c.display_name}</div>
+                    <div className="text-xs text-gray-500 mt-1">
+                      vibe: {c.vibe_classification} · conf {(c.vibe_confidence ?? 0).toFixed(2)}
+                    </div>
+                    {c.vibe_evidence && (
+                      <div className="text-sm text-gray-400 mt-2 italic">&quot;{c.vibe_evidence}&quot;</div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="text-sm text-gray-500">
+              No candidates yet. Vibe sweep runs every 6h — populates as backfill catches up.
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold mb-3">Pending media</h2>
+        <div className="space-y-2">
+          {pendingMedia && pendingMedia.length > 0 ? (
+            pendingMedia.slice(0, 8).map((m: any) => (
+              <div key={m._id} className="bg-gray-900 border border-gray-800 rounded-lg p-3 flex gap-3">
+                {m.thumbnail_url || m.storage_url ? (
+                  <img src={m.thumbnail_url || m.storage_url} alt={m.caption || ""}
+                       className="w-16 h-16 object-cover rounded" />
+                ) : (
+                  <div className="w-16 h-16 bg-gray-800 rounded flex items-center justify-center text-xs text-gray-500">no preview</div>
+                )}
+                <div className="flex-1">
+                  <div className="text-sm font-medium">{m.caption || m.asset_id}</div>
+                  <div className="text-xs text-gray-500">
+                    {m.kind} · vibe={m.vibe ?? "—"} · flex={m.flex_level ?? "—"}
+                  </div>
+                  <div className="text-xs text-gray-400 mt-1">
+                    tags: {(m.tags ?? []).slice(0, 5).join(", ") || "(untagged)"}
+                  </div>
+                </div>
+              </div>
+            ))
+          ) : (
+            <div className="text-sm text-gray-500">
+              No pending media. Drop photos into your &quot;Clapcheeks Media&quot; Drive folder
+              to populate the library.
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function Card({ title, value, href }: { title: string; value: any; href?: string }) {
+  const inner = (
+    <div className="bg-gray-900 border border-gray-800 rounded-lg p-5 hover:border-gray-700 transition">
+      <div className="text-sm text-gray-400">{title}</div>
+      <div className="text-3xl font-bold mt-1">{value}</div>
+    </div>
+  )
+  return href ? <Link href={href}>{inner}</Link> : inner
+}

--- a/web/app/admin/clapcheeks-ops/pending-links/page.tsx
+++ b/web/app/admin/clapcheeks-ops/pending-links/page.tsx
@@ -1,0 +1,86 @@
+/**
+ * Pending links — conversations whose handle didn't auto-link to a single
+ * person row. Manual disambiguation: pick a candidate, or ignore.
+ */
+"use client"
+
+import { useQuery, useMutation } from "convex/react"
+import { api } from "@/convex/_generated/api"
+
+const FLEET_USER_ID = "fleet-julian"
+
+export default function PendingLinksPage() {
+  const links = useQuery(api.people.listPendingLinks, { user_id: FLEET_USER_ID, limit: 100 })
+  const resolve = useMutation(api.people.resolvePendingLink)
+  const ignore = useMutation(api.people.ignorePendingLink)
+
+  if (links === undefined) return <div className="p-8 text-gray-500">Loading…</div>
+
+  return (
+    <div className="p-8 max-w-5xl">
+      <h1 className="text-3xl font-bold mb-2">Pending Links</h1>
+      <p className="text-gray-400 mb-6">
+        {links.length} conversations with ambiguous matches. Pick the right person
+        or ignore (spam/unknown). Resolves the conversation + all its messages.
+      </p>
+
+      {links.length === 0 && (
+        <div className="text-gray-500 text-sm">
+          No pending links. The auto-linker resolved every recent conversation
+          to exactly one person — no human intervention needed.
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {links.map((link: any) => (
+          <div key={link._id} className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+            <div className="flex justify-between items-start mb-3">
+              <div>
+                <div className="font-mono text-sm">{link.handle_value}</div>
+                <div className="text-xs text-gray-500">
+                  {link.handle_channel} · {new Date(link.created_at).toLocaleString()}
+                </div>
+              </div>
+              <button onClick={() => ignore({ pending_id: link._id })}
+                      className="text-xs text-gray-500 hover:text-red-400">
+                ignore
+              </button>
+            </div>
+
+            {link.raw_context && (
+              <div className="bg-gray-950 rounded p-2 text-sm text-gray-300 mb-3 italic">
+                &quot;{link.raw_context}&quot;
+              </div>
+            )}
+
+            <div className="text-xs text-gray-500 mb-2">
+              {link.candidates.length === 0
+                ? "No candidate matches — would need to create a new people row first."
+                : `${link.candidates.length} candidate match${link.candidates.length === 1 ? "" : "es"}:`}
+            </div>
+
+            <div className="space-y-2">
+              {link.candidates.map((c: any) => (
+                <div key={c._id} className="flex justify-between items-center bg-gray-950 rounded p-2">
+                  <div>
+                    <div className="text-sm font-medium">{c.display_name}</div>
+                    <div className="text-xs text-gray-500">
+                      {c.courtship_stage || "—"} · {c.status || "—"}
+                    </div>
+                    <div className="text-xs text-gray-600 mt-0.5">
+                      {(c.handles ?? []).map((h: any) => `${h.channel}:${h.value}`).join(" · ")}
+                    </div>
+                  </div>
+                  <button onClick={() => resolve({ pending_id: link._id, person_id: c._id })}
+                          className="bg-purple-600 hover:bg-purple-500 text-white px-3 py-1 rounded text-xs">
+                    use this
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/app/admin/clapcheeks-ops/profile-imports/page.tsx
+++ b/web/app/admin/clapcheeks-ops/profile-imports/page.tsx
@@ -1,0 +1,184 @@
+/**
+ * Profile imports — review screenshots of dating-app profiles, AI extracts
+ * everything (bio, photos, prompts, zodiac, DISC, openers), one-click create
+ * a person row from the analysis.
+ */
+"use client"
+
+import { useQuery, useMutation } from "convex/react"
+import { api } from "@/convex/_generated/api"
+import { useState } from "react"
+
+const FLEET_USER_ID = "fleet-julian"
+
+export default function ProfileImportsPage() {
+  const screenshots = useQuery(api.profile_import.listForReview, {
+    user_id: FLEET_USER_ID, limit: 50,
+  })
+  const reanalyze = useMutation(api.profile_import.reanalyze)
+  const createPerson = useMutation(api.profile_import.createPersonFromProfile)
+  const dismiss = useMutation(api.profile_import.dismissProfileScreenshot)
+
+  if (screenshots === undefined) return <div className="p-8 text-gray-500">Loading…</div>
+
+  return (
+    <div className="p-8 max-w-7xl">
+      <h1 className="text-3xl font-bold mb-2">Profile Imports</h1>
+      <p className="text-gray-400 mb-6">
+        {screenshots.length} screenshots awaiting review. Drop a profile screenshot
+        in your iPhone Shortcut with <code className="bg-gray-800 px-1 rounded text-xs">x-cc-kind: profile</code>
+        header (or upload via dashboard once that's wired) and AI extracts everything below.
+      </p>
+
+      {screenshots.length === 0 && (
+        <div className="text-gray-500 text-sm">
+          No pending profile imports. Send any Tinder/Bumble/Hinge/IG screenshot via
+          your Clapcheeks Shortcut with the profile flag and it'll show up here within ~10s.
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {screenshots.map((m: any) => (
+          <ScreenshotCard
+            key={m._id}
+            m={m}
+            onCreate={(overrides: any) =>
+              createPerson({ media_id: m._id, user_id: FLEET_USER_ID, overrides })
+            }
+            onReanalyze={() => reanalyze({ media_id: m._id })}
+            onDismiss={() => dismiss({ media_id: m._id })}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ScreenshotCard({ m, onCreate, onReanalyze, onDismiss }: any) {
+  const [busy, setBusy] = useState(false)
+  const data = m.profile_screenshot_data
+  const analyzing = !data
+  const [overrideName, setOverrideName] = useState<string | null>(null)
+  const [overridePlatform, setOverridePlatform] = useState<string | null>(null)
+
+  async function handleCreate() {
+    setBusy(true)
+    try {
+      const overrides: any = {}
+      if (overrideName) overrides.display_name = overrideName
+      if (overridePlatform) overrides.platform = overridePlatform
+      await onCreate(overrides)
+    } finally { setBusy(false) }
+  }
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-lg overflow-hidden">
+      <div className="flex">
+        <div className="w-1/3 bg-gray-950">
+          {m.thumbnail_url || m.storage_url ? (
+            <img src={m.thumbnail_url || m.storage_url}
+                 alt="profile screenshot"
+                 className="w-full h-full object-cover" />
+          ) : (
+            <div className="h-full flex items-center justify-center text-xs text-gray-500 p-4">no preview</div>
+          )}
+        </div>
+        <div className="flex-1 p-4 space-y-2 text-sm">
+          {analyzing ? (
+            <>
+              <div className="text-gray-500">Analyzing with Gemini Vision…</div>
+              <button onClick={onReanalyze} className="text-xs text-purple-400 hover:text-purple-300">
+                retry analyze
+              </button>
+            </>
+          ) : (
+            <>
+              <div className="flex justify-between items-start">
+                <div>
+                  <div className="font-bold text-lg">
+                    {data.name || "(name not visible)"}
+                    {data.age ? <span className="text-gray-500 font-normal"> · {data.age}</span> : null}
+                  </div>
+                  <div className="text-xs text-gray-500">
+                    {data.platform || "?"} · {data.location || "?"} · {data.occupation || "?"}
+                  </div>
+                </div>
+                <span className="text-xs text-gray-600">
+                  conf {(data.confidence ?? 0).toFixed(2)}
+                </span>
+              </div>
+
+              {data.bio_text && (
+                <div className="bg-gray-950 rounded p-2 text-xs text-gray-300 italic max-h-20 overflow-y-auto">
+                  &quot;{data.bio_text}&quot;
+                </div>
+              )}
+
+              {data.likely_zodiac_sign && (
+                <div>
+                  <div className="text-purple-300 text-xs font-semibold uppercase mt-2">
+                    {data.likely_zodiac_sign} · {data.disc || "?"}
+                  </div>
+                  <div className="text-xs text-gray-400 mt-1">{data.zodiac_block}</div>
+                </div>
+              )}
+
+              {data.opener_suggestions && data.opener_suggestions.length > 0 && (
+                <div className="mt-2">
+                  <div className="text-xs font-semibold text-gray-400 uppercase">Suggested openers</div>
+                  <ul className="text-xs space-y-1 mt-1">
+                    {data.opener_suggestions.slice(0, 3).map((o: string, i: number) => (
+                      <li key={i} className="bg-gray-950 rounded px-2 py-1 text-gray-300">{o}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {data.green_flags && data.green_flags.length > 0 && (
+                <div className="text-xs text-green-400 mt-1">
+                  ✓ {data.green_flags.slice(0, 3).join(" · ")}
+                </div>
+              )}
+              {data.red_flags && data.red_flags.length > 0 && (
+                <div className="text-xs text-red-400">
+                  ⚠ {data.red_flags.slice(0, 3).join(" · ")}
+                </div>
+              )}
+
+              {data.compatibility_with_julian && (
+                <div className="text-xs text-gray-400 italic mt-2">
+                  Compat read: {data.compatibility_with_julian}
+                </div>
+              )}
+
+              <div className="flex gap-2 pt-3">
+                <input type="text" placeholder={data.name || "Name"}
+                       defaultValue={data.name || ""}
+                       onChange={(e) => setOverrideName(e.target.value)}
+                       className="flex-1 bg-gray-950 border border-gray-800 rounded px-2 py-1 text-xs" />
+                <select value={overridePlatform ?? data.platform ?? "other"}
+                        onChange={(e) => setOverridePlatform(e.target.value)}
+                        className="bg-gray-950 border border-gray-800 rounded px-2 py-1 text-xs">
+                  <option value="tinder">tinder</option>
+                  <option value="bumble">bumble</option>
+                  <option value="hinge">hinge</option>
+                  <option value="instagram">instagram</option>
+                  <option value="other">other</option>
+                </select>
+              </div>
+              <div className="flex gap-2 pt-2">
+                <button onClick={handleCreate} disabled={busy}
+                        className="flex-1 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white px-3 py-1 rounded text-xs">
+                  {busy ? "Creating…" : "Create person row"}
+                </button>
+                <button onClick={onDismiss} className="bg-gray-800 hover:bg-red-700 text-gray-300 px-3 py-1 rounded text-xs">
+                  Skip
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/app/admin/clapcheeks-ops/touches/page.tsx
+++ b/web/app/admin/clapcheeks-ops/touches/page.tsx
@@ -1,0 +1,95 @@
+/**
+ * Touches preview — what's scheduled to fire in the next N hours.
+ * Cancel buttons for queued non-urgent items.
+ */
+"use client"
+
+import { useQuery, useMutation } from "convex/react"
+import { api } from "@/convex/_generated/api"
+import { useState } from "react"
+
+const FLEET_USER_ID = "fleet-julian"
+
+export default function TouchesPage() {
+  const [horizon, setHorizon] = useState(72)
+  const upcoming = useQuery(api.touches.listUpcoming, {
+    user_id: FLEET_USER_ID, horizon_hours: horizon, limit: 200,
+  })
+  const cancel = useMutation(api.touches.cancelOne)
+
+  if (upcoming === undefined) return <div className="p-8 text-gray-500">Loading…</div>
+
+  const grouped: Record<string, any[]> = {}
+  for (const t of upcoming) {
+    const day = new Date(t.scheduled_for).toLocaleDateString()
+    grouped[day] ||= []
+    grouped[day].push(t)
+  }
+
+  return (
+    <div className="p-8 max-w-7xl">
+      <h1 className="text-3xl font-bold mb-2">Scheduled Touches</h1>
+      <p className="text-gray-400 mb-6">
+        {upcoming.length} touches in next {horizon}h.
+      </p>
+
+      <div className="flex gap-2 mb-6">
+        {[24, 72, 168].map((h) => (
+          <button key={h} onClick={() => setHorizon(h)}
+                  className={`px-4 py-2 rounded-lg text-sm ${horizon === h ? "bg-purple-600 text-white" : "bg-gray-800 text-gray-300"}`}>
+            {h === 168 ? "1 week" : `${h}h`}
+          </button>
+        ))}
+      </div>
+
+      {Object.entries(grouped).map(([day, ts]) => (
+        <section key={day} className="mb-6">
+          <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide mb-2">{day}</h2>
+          <div className="space-y-2">
+            {ts.map((t: any) => (
+              <div key={t._id} className="bg-gray-900 border border-gray-800 rounded-lg p-3 flex justify-between items-start">
+                <div className="flex-1">
+                  <div className="flex gap-2 items-center text-sm">
+                    <span className="font-medium">{t.type}</span>
+                    <span className="text-gray-500">·</span>
+                    <span className="text-gray-400">
+                      {new Date(t.scheduled_for).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}
+                    </span>
+                    {t.urgency && (
+                      <span className={`ml-2 text-xs px-2 py-0.5 rounded ${
+                        t.urgency === "hot" ? "bg-red-900 text-red-200"
+                          : t.urgency === "warm" ? "bg-yellow-900 text-yellow-200"
+                          : "bg-gray-800 text-gray-400"
+                      }`}>
+                        {t.urgency}
+                      </span>
+                    )}
+                  </div>
+                  {t.draft_body && (
+                    <div className="text-sm text-gray-400 mt-1 line-clamp-2">{t.draft_body}</div>
+                  )}
+                  {t.prompt_template && !t.draft_body && (
+                    <div className="text-xs text-gray-500 mt-1 italic">
+                      regenerate at fire time · template={t.prompt_template}
+                    </div>
+                  )}
+                </div>
+                <button onClick={() => cancel({ touch_id: t._id, reason: "manual_cancel" })}
+                        className="ml-3 text-xs text-gray-500 hover:text-red-400">
+                  cancel
+                </button>
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+
+      {upcoming.length === 0 && (
+        <div className="text-gray-500 text-sm">
+          Nothing scheduled. Touches are auto-created by the inbound interpreter
+          when she texts, and by the date-ask sweep every 6h.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/convex/_generated/api.d.ts
+++ b/web/convex/_generated/api.d.ts
@@ -9,12 +9,21 @@
  */
 
 import type * as agent_jobs from "../agent_jobs.js";
+import type * as backfill from "../backfill.js";
+import type * as calendar from "../calendar.js";
 import type * as conversations from "../conversations.js";
 import type * as crons from "../crons.js";
+import type * as digest from "../digest.js";
 import type * as drip from "../drip.js";
+import type * as enrichment from "../enrichment.js";
+import type * as http from "../http.js";
+import type * as inbound from "../inbound.js";
+import type * as media from "../media.js";
 import type * as messages from "../messages.js";
 import type * as people from "../people.js";
+import type * as profile_import from "../profile_import.js";
 import type * as scheduled_messages from "../scheduled_messages.js";
+import type * as touches from "../touches.js";
 
 import type {
   ApiFromModules,
@@ -24,12 +33,21 @@ import type {
 
 declare const fullApi: ApiFromModules<{
   agent_jobs: typeof agent_jobs;
+  backfill: typeof backfill;
+  calendar: typeof calendar;
   conversations: typeof conversations;
   crons: typeof crons;
+  digest: typeof digest;
   drip: typeof drip;
+  enrichment: typeof enrichment;
+  http: typeof http;
+  inbound: typeof inbound;
+  media: typeof media;
   messages: typeof messages;
   people: typeof people;
+  profile_import: typeof profile_import;
   scheduled_messages: typeof scheduled_messages;
+  touches: typeof touches;
 }>;
 
 /**

--- a/web/convex/backfill.ts
+++ b/web/convex/backfill.ts
@@ -1,0 +1,175 @@
+/**
+ * AI-9500 Wave 2.1A — One-shot backfill helpers.
+ *
+ * After person_linker shipped, conversations + messages from before the
+ * linker had no person_id. backfillBatch walks orphan rows and patches in
+ * person_id when an exact-match handle resolves.
+ *
+ * runChained calls _runChainedStep on a self-recursive scheduler so the
+ * backfill spreads across many small batches instead of one giant mutation.
+ *
+ * Read-only orphanStatus exposes "how many rows still need backfilling" so
+ * the dashboard can show progress.
+ */
+import { v } from "convex/values";
+import { mutation, internalAction, query } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+const BATCH_SIZE = 100;
+
+// ---------------------------------------------------------------------------
+// backfillBatch — walk one batch of orphan messages + conversations.
+// ---------------------------------------------------------------------------
+export const backfillBatch = mutation({
+  args: {
+    user_id: v.string(),
+    limit: v.optional(v.number()),
+    cursor: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const batch = Math.min(args.limit ?? BATCH_SIZE, 500);
+    let patchedConvos = 0;
+    let patchedMessages = 0;
+
+    const convos = await ctx.db
+      .query("conversations")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .collect();
+    const orphanConvos = convos
+      .filter((c) => !c.person_id && c.imessage_handle)
+      .slice(0, batch);
+
+    for (const c of orphanConvos) {
+      // Find people whose handles include this E.164 phone.
+      const candidates = await ctx.db
+        .query("people")
+        .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+        .collect();
+      const matches = candidates.filter((p) =>
+        p.handles.some(
+          (h) => h.value.trim().toLowerCase() === c.imessage_handle!.trim().toLowerCase(),
+        ),
+      );
+      if (matches.length === 1) {
+        await ctx.db.patch(c._id, { person_id: matches[0]._id });
+        patchedConvos++;
+        // Also patch messages for this conversation.
+        const msgs = await ctx.db
+          .query("messages")
+          .withIndex("by_conversation", (q) => q.eq("conversation_id", c._id))
+          .collect();
+        for (const m of msgs) {
+          if (!m.person_id) {
+            await ctx.db.patch(m._id, { person_id: matches[0]._id });
+            patchedMessages++;
+          }
+        }
+      }
+    }
+
+    return {
+      scanned_conversations: orphanConvos.length,
+      patched_conversations: patchedConvos,
+      patched_messages: patchedMessages,
+      done: orphanConvos.length < batch,
+    };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// runChained — kicks off self-scheduling backfill.
+// ---------------------------------------------------------------------------
+export const runChained = mutation({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    await ctx.scheduler.runAfter(0, internal.backfill._runChainedStep, {
+      user_id: args.user_id,
+      iter: 0,
+    });
+    return { kicked_off: true };
+  },
+});
+
+export const _runChainedStep = internalAction({
+  args: { user_id: v.string(), iter: v.number() },
+  handler: async (ctx, args): Promise<any> => {
+    if (args.iter > 200) return { stopped: "iteration_cap" };
+    const result: any = await ctx.runMutation(internal.backfill._batchInternal, {
+      user_id: args.user_id,
+      limit: BATCH_SIZE,
+    });
+    if (!result.done) {
+      await ctx.scheduler.runAfter(2000, internal.backfill._runChainedStep, {
+        user_id: args.user_id,
+        iter: args.iter + 1,
+      });
+    }
+    return result;
+  },
+});
+
+// Internal mutation copy of backfillBatch — same logic, internal-only access
+// so the action can call it without going through the public API.
+import { internalMutation } from "./_generated/server";
+export const _batchInternal = internalMutation({
+  args: { user_id: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const batch = Math.min(args.limit ?? BATCH_SIZE, 500);
+    let patchedConvos = 0;
+    let patchedMessages = 0;
+    const convos = await ctx.db
+      .query("conversations")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .collect();
+    const orphanConvos = convos
+      .filter((c) => !c.person_id && c.imessage_handle)
+      .slice(0, batch);
+    for (const c of orphanConvos) {
+      const candidates = await ctx.db
+        .query("people")
+        .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+        .collect();
+      const matches = candidates.filter((p) =>
+        p.handles.some(
+          (h) => h.value.trim().toLowerCase() === c.imessage_handle!.trim().toLowerCase(),
+        ),
+      );
+      if (matches.length === 1) {
+        await ctx.db.patch(c._id, { person_id: matches[0]._id });
+        patchedConvos++;
+        const msgs = await ctx.db
+          .query("messages")
+          .withIndex("by_conversation", (q) => q.eq("conversation_id", c._id))
+          .collect();
+        for (const m of msgs) {
+          if (!m.person_id) {
+            await ctx.db.patch(m._id, { person_id: matches[0]._id });
+            patchedMessages++;
+          }
+        }
+      }
+    }
+    return {
+      scanned_conversations: orphanConvos.length,
+      patched_conversations: patchedConvos,
+      patched_messages: patchedMessages,
+      done: orphanConvos.length < batch,
+    };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// orphanStatus — read-only progress query.
+// ---------------------------------------------------------------------------
+export const orphanStatus = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    const convos = await ctx.db
+      .query("conversations")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .collect();
+    const orphans = convos.filter((c) => !c.person_id && c.imessage_handle).length;
+    const linked = convos.filter((c) => c.person_id).length;
+    return { orphans, linked, total: convos.length };
+  },
+});

--- a/web/convex/calendar.ts
+++ b/web/convex/calendar.ts
@@ -1,0 +1,177 @@
+/**
+ * AI-9449 Wave 2.2 — Calendar slot cache.
+ *
+ * The Mac Mini daemon (clapcheeks-local convex_runner) handles the
+ * `fetch_calendar_slots` agent_job by calling `gws calendar events list` against
+ * Julian's primary + Dating + CONSULTING + SALES CALLS calendars and writing the
+ * resulting free-busy windows into `calendar_slots`.
+ *
+ * This module exposes:
+ *   - enqueueFetchJob (internalMutation) — fired by the cron; inserts an
+ *     agent_job for Mac Mini to claim.
+ *   - upsertSlots — Mac Mini calls this to write free-busy windows.
+ *   - listFreeSlots — Mac Mini draft engine reads this for date_ask templates;
+ *     returns up to N upcoming free windows in preferred evening hours.
+ *   - markProposed / markConfirmed — when a slot is offered to a person and
+ *     when she confirms, so the same slot isn't proposed twice.
+ *   - clearStale — removes free slots whose start has passed.
+ */
+import { v } from "convex/values";
+import { mutation, query, internalMutation } from "./_generated/server";
+
+// ---------------------------------------------------------------------------
+// Cron entry point — enqueue an agent_job for Mac Mini.
+// ---------------------------------------------------------------------------
+export const enqueueFetchJob = internalMutation({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    // Dedup: skip if there's already a queued/running fetch_calendar_slots
+    // job for this user, so a slow Mac Mini doesn't pile up duplicates.
+    const existing = await ctx.db
+      .query("agent_jobs")
+      .withIndex("by_user_type", (q) =>
+        q.eq("user_id", args.user_id).eq("job_type", "fetch_calendar_slots"),
+      )
+      .collect();
+    const inFlight = existing.find(
+      (j) => j.status === "queued" || j.status === "running",
+    );
+    if (inFlight) return { skipped: true, reason: "already_in_flight", job_id: inFlight._id };
+    await ctx.db.insert("agent_jobs", {
+      user_id: args.user_id,
+      job_type: "fetch_calendar_slots",
+      payload: { user_id: args.user_id, horizon_days: 14 },
+      status: "queued",
+      priority: 5,
+      attempts: 0,
+      max_attempts: 3,
+      created_at: now,
+      updated_at: now,
+    } as any);
+    return { enqueued: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// upsertSlots — Mac Mini writes free-busy windows here.
+// ---------------------------------------------------------------------------
+export const upsertSlots = mutation({
+  args: {
+    user_id: v.string(),
+    slots: v.array(v.object({
+      slot_start_ms: v.number(),
+      slot_end_ms: v.number(),
+      slot_kind: v.union(
+        v.literal("free"), v.literal("busy"),
+        v.literal("date_proposed"), v.literal("date_confirmed"),
+      ),
+      label_local: v.optional(v.string()),
+    })),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    let inserted = 0;
+    for (const s of args.slots) {
+      // Dedup on (user_id, slot_start_ms).
+      const existing = await ctx.db
+        .query("calendar_slots")
+        .withIndex("by_user_start", (q) =>
+          q.eq("user_id", args.user_id).eq("slot_start_ms", s.slot_start_ms),
+        )
+        .first();
+      if (existing) {
+        await ctx.db.patch(existing._id, {
+          slot_end_ms: s.slot_end_ms,
+          slot_kind: s.slot_kind,
+          label_local: s.label_local,
+          fetched_at_ms: now,
+        });
+      } else {
+        await ctx.db.insert("calendar_slots", {
+          user_id: args.user_id,
+          slot_start_ms: s.slot_start_ms,
+          slot_end_ms: s.slot_end_ms,
+          slot_kind: s.slot_kind,
+          label_local: s.label_local,
+          fetched_at_ms: now,
+        });
+        inserted++;
+      }
+    }
+    return { inserted, total: args.slots.length };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// listFreeSlots — Mac Mini draft engine reads this for date_ask drafts.
+// Returns N upcoming free slots in preferred evening hours, deduped by day.
+// ---------------------------------------------------------------------------
+export const listFreeSlots = query({
+  args: {
+    user_id: v.string(),
+    horizon_days: v.optional(v.number()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const horizonMs = (args.horizon_days ?? 14) * 24 * 60 * 60 * 1000;
+    const rows = await ctx.db
+      .query("calendar_slots")
+      .withIndex("by_user_kind", (q) =>
+        q.eq("user_id", args.user_id).eq("slot_kind", "free"),
+      )
+      .collect();
+    return rows
+      .filter((r) => r.slot_start_ms >= now && r.slot_start_ms <= now + horizonMs)
+      .sort((a, b) => a.slot_start_ms - b.slot_start_ms)
+      .slice(0, Math.min(args.limit ?? 60, 200));
+  },
+});
+
+// ---------------------------------------------------------------------------
+// markProposed / markConfirmed — date_ask flow tracks offered slots.
+// ---------------------------------------------------------------------------
+export const markProposed = mutation({
+  args: {
+    slot_id: v.id("calendar_slots"),
+    person_id: v.id("people"),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.slot_id, {
+      slot_kind: "date_proposed",
+      proposed_to_person_id: args.person_id,
+    });
+  },
+});
+
+export const markConfirmed = mutation({
+  args: { slot_id: v.id("calendar_slots") },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.slot_id, { slot_kind: "date_confirmed" });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// clearStale — remove free-but-past slots so list queries stay tight.
+// ---------------------------------------------------------------------------
+export const clearStale = internalMutation({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const stale = await ctx.db
+      .query("calendar_slots")
+      .withIndex("by_user_kind", (q) =>
+        q.eq("user_id", args.user_id).eq("slot_kind", "free"),
+      )
+      .collect();
+    let removed = 0;
+    for (const s of stale) {
+      if (s.slot_start_ms < now) {
+        await ctx.db.delete(s._id);
+        removed++;
+      }
+    }
+    return { removed };
+  },
+});

--- a/web/convex/digest.ts
+++ b/web/convex/digest.ts
@@ -1,0 +1,107 @@
+/**
+ * AI-9449 — Daily morning digest engine.
+ *
+ * generateDaily runs at 9am Pacific. Produces a ranked list of conversations
+ * needing attention + scheduled touches firing today + manual one-tap drafts
+ * the operator can approve before BlueBubbles sends them.
+ *
+ * The heavy LLM-driven composition runs Mac Mini-side via the
+ * send_digest_to_julian agent_job. This module enqueues the job and exposes
+ * a generateNow mutation for one-shot manual triggering from the dashboard.
+ */
+import { v } from "convex/values";
+import { internalAction, mutation, internalMutation, query } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+// ---------------------------------------------------------------------------
+// generateDaily — fired by the cron at 9am Pacific (17:00 UTC).
+// ---------------------------------------------------------------------------
+export const generateDaily = internalAction({
+  args: {},
+  handler: async (ctx): Promise<{ enqueued: boolean; reason?: string }> => {
+    return await ctx.runMutation(internal.digest._enqueueDigestJob, {
+      user_id: "fleet-julian",
+      reason: "daily_cron",
+    });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// generateNow — operator-triggered (dashboard "Run digest now" button).
+// ---------------------------------------------------------------------------
+export const generateNow = mutation({
+  args: { user_id: v.optional(v.string()) },
+  handler: async (ctx, args) => {
+    return await ctx.runMutation(internal.digest._enqueueDigestJob, {
+      user_id: args.user_id ?? "fleet-julian",
+      reason: "manual_dashboard",
+    });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// _enqueueDigestJob — internal helper, dedups in-flight digest jobs.
+// ---------------------------------------------------------------------------
+export const _enqueueDigestJob = internalMutation({
+  args: { user_id: v.string(), reason: v.string() },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("agent_jobs")
+      .withIndex("by_user_type", (q) =>
+        q.eq("user_id", args.user_id).eq("job_type", "send_digest_to_julian"),
+      )
+      .collect();
+    const inFlight = existing.find(
+      (j) => j.status === "queued" || j.status === "running",
+    );
+    if (inFlight) return { enqueued: false, reason: "already_in_flight" };
+    await ctx.db.insert("agent_jobs", {
+      user_id: args.user_id,
+      job_type: "send_digest_to_julian",
+      payload: { user_id: args.user_id, reason: args.reason, generated_at: now },
+      status: "queued",
+      priority: 3,
+      attempts: 0,
+      max_attempts: 3,
+      created_at: now,
+      updated_at: now,
+    } as any);
+    return { enqueued: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// _activeConversations — read for the digest preview UI. Returns the top N
+// people whose courtship is alive (active + has recent inbound or scheduled
+// touch within 7 days).
+// ---------------------------------------------------------------------------
+export const _activeConversations = query({
+  args: { user_id: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const sevenDaysAgo = now - 7 * 24 * 60 * 60 * 1000;
+    const people = await ctx.db
+      .query("people")
+      .withIndex("by_user_status", (q) =>
+        q.eq("user_id", args.user_id).eq("status", "active"),
+      )
+      .collect();
+    const active = people
+      .filter((p) =>
+        (p.last_inbound_at ?? 0) > sevenDaysAgo ||
+        (p.next_followup_at ?? 0) > now,
+      )
+      .sort((a, b) => (b.last_inbound_at ?? 0) - (a.last_inbound_at ?? 0));
+    return active.slice(0, Math.min(args.limit ?? 20, 50));
+  },
+});
+
+// ---------------------------------------------------------------------------
+// _compose — placeholder action retained for backwards compatibility with the
+// previous deployment. Mac Mini does the actual composition; this is a no-op.
+// ---------------------------------------------------------------------------
+export const _compose = internalAction({
+  args: { user_id: v.string() },
+  handler: async () => ({ ok: true, note: "Mac Mini composes via send_digest_to_julian" }),
+});

--- a/web/convex/http.ts
+++ b/web/convex/http.ts
@@ -1,0 +1,109 @@
+/**
+ * AI-9449 Wave 2.3C — Convex HTTP endpoints.
+ *
+ * Public iPhone-Shortcut + webhook surfaces:
+ *   POST /clapcheeks/media-upload  — iPhone Shortcut posts an image with
+ *                                    a caption + optional kind hint header.
+ *                                    Auto-routes to autoTagMedia (default) or
+ *                                    profile-screenshot analysis when kind=profile.
+ *
+ * Auth: shared HMAC token in `x-cc-token` header (env CC_MEDIA_UPLOAD_TOKEN).
+ */
+import { httpRouter } from "convex/server";
+import { httpAction } from "./_generated/server";
+import { internal, api } from "./_generated/api";
+
+const http = httpRouter();
+
+http.route({
+  path: "/clapcheeks/media-upload",
+  method: "POST",
+  handler: httpAction(async (ctx, req) => {
+    const expected = process.env.CC_MEDIA_UPLOAD_TOKEN;
+    const provided = req.headers.get("x-cc-token");
+    if (!expected) {
+      return new Response(JSON.stringify({ error: "server_token_unset" }), {
+        status: 500, headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (provided !== expected) {
+      return new Response(JSON.stringify({ error: "auth" }), {
+        status: 401, headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const caption = req.headers.get("x-cc-caption") ?? "";
+    const kind_hint = (req.headers.get("x-cc-kind") ?? "media").toLowerCase();
+    const platform = req.headers.get("x-cc-platform") ?? "";
+    const mime = req.headers.get("content-type") ?? "image/jpeg";
+    const blob = await req.blob();
+    if (!blob.size) {
+      return new Response(JSON.stringify({ error: "empty_body" }), {
+        status: 400, headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const storageId = await ctx.storage.store(blob);
+    const storageUrl = await ctx.storage.getUrl(storageId);
+    if (!storageUrl) {
+      return new Response(JSON.stringify({ error: "storage_url_failed" }), {
+        status: 500, headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const assetId = `iphone-${storageId.toString().slice(0, 24)}`;
+    const kind = mime.startsWith("video/") ? "video"
+              : mime.includes("gif") ? "gif" : "image";
+
+    const isProfile = kind_hint === "profile" || kind_hint === "profile_screenshot";
+
+    const result: any = await ctx.runMutation(api.media.upload, {
+      user_id: process.env.CONVEX_FLEET_USER_ID ?? "fleet-julian",
+      asset_id: assetId,
+      kind: kind as any,
+      storage_url: storageUrl,
+      mime_type: mime,
+      file_size_bytes: blob.size,
+      caption: isProfile
+        ? `Profile screenshot${platform ? ` (${platform})` : ""}: ${caption}`
+        : caption,
+      upload_source: "iphone",
+    });
+
+    if (isProfile && result?.asset_id) {
+      await ctx.runMutation(api.media.markAsProfileScreenshot, {
+        asset_id: result.asset_id,
+        platform: platform || undefined,
+      });
+      await ctx.scheduler.runAfter(0, internal.profile_import.analyzeAsProfile, {
+        media_id: result.asset_id,
+      });
+    }
+
+    return new Response(JSON.stringify({
+      asset_id: assetId,
+      convex_id: result?._id,
+      storage_url: storageUrl,
+      bytes: blob.size,
+      caption,
+      kind: isProfile ? "profile_screenshot" : "media",
+    }), {
+      status: 200, headers: { "Content-Type": "application/json" },
+    });
+  }),
+});
+
+http.route({
+  path: "/clapcheeks/media-upload",
+  method: "OPTIONS",
+  handler: httpAction(async () => new Response(null, {
+    status: 200,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, x-cc-token, x-cc-caption, x-cc-kind, x-cc-platform",
+    },
+  })),
+});
+
+export default http;

--- a/web/convex/inbound.ts
+++ b/web/convex/inbound.ts
@@ -1,0 +1,174 @@
+/**
+ * AI-9449 — Inbound interpretation pipeline.
+ *
+ * messages.upsertFromWebhook fires interpretInboundForOne after every inbound
+ * iMessage. The action reads context (last 30 messages, person row), decides
+ * if anything new should be appended to the long-term ledgers
+ * (personal_details / curiosity_ledger / recent_life_events / lit topics /
+ * boundaries_stated / emotional_state_recent), and asks the cadence engine
+ * what to schedule next.
+ *
+ * The heavy LLM read happens on Mac Mini via the enrich_courtship +
+ * cadence_evaluate_one agent_jobs. This module enqueues those jobs and
+ * exposes the small append/get helpers the Mac Mini calls back into.
+ */
+import { v } from "convex/values";
+import { internalAction, internalMutation, internalQuery } from "./_generated/server";
+
+// ---------------------------------------------------------------------------
+// interpretInboundForOne — fired from messages.upsertFromWebhook.
+//
+// Fires two agent_jobs that the Mac Mini handles:
+//   1. enrich_courtship — re-extract personal_details / curiosity / events /
+//      boundaries / emotional state. Throttled to 1 run per person per 30 min
+//      so a noisy thread doesn't burn LLM credits.
+//   2. cadence_evaluate_one — recompute next_followup_at, time_to_ask_score,
+//      conversation_temperature.
+// ---------------------------------------------------------------------------
+export const interpretInboundForOne = internalAction({
+  args: {
+    person_id: v.id("people"),
+    conversation_id: v.id("conversations"),
+    message_external_guid: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<{ enqueued: number }> => {
+    const person = await ctx.runQuery(internal.inbound._getPerson, {
+      person_id: args.person_id,
+    });
+    if (!person) return { enqueued: 0 };
+
+    const now = Date.now();
+    const last = (person as any).courtship_last_analyzed ?? 0;
+    let enqueued = 0;
+
+    // Throttle enrich_courtship to once per 30 min per person.
+    if (now - last > 30 * 60 * 1000) {
+      await ctx.runMutation(internal.inbound._enqueueEnrichJob, {
+        user_id: person.user_id,
+        person_id: args.person_id,
+        conversation_id: args.conversation_id,
+      });
+      enqueued++;
+    }
+
+    // Always re-evaluate cadence; cheap.
+    await ctx.runMutation(internal.inbound._enqueueCadenceJob, {
+      user_id: person.user_id,
+      person_id: args.person_id,
+    });
+    enqueued++;
+
+    return { enqueued };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// _appendInsights — Mac Mini calls this after enrich_courtship completes.
+// Appends to the long-term ledgers without overwriting existing entries.
+// ---------------------------------------------------------------------------
+export const _appendInsights = internalMutation({
+  args: {
+    person_id: v.id("people"),
+    personal_details: v.optional(v.array(v.any())),
+    curiosity_ledger: v.optional(v.array(v.any())),
+    recent_life_events: v.optional(v.array(v.any())),
+    topics_that_lit_her_up: v.optional(v.array(v.any())),
+    emotional_state_recent: v.optional(v.array(v.any())),
+    boundaries_stated: v.optional(v.array(v.string())),
+  },
+  handler: async (ctx, args) => {
+    const person = await ctx.db.get(args.person_id);
+    if (!person) return { not_found: true };
+    const patch: any = { updated_at: Date.now() };
+    if (args.personal_details?.length) {
+      const existing = (person as any).personal_details ?? [];
+      patch.personal_details = [...existing, ...args.personal_details].slice(-50);
+    }
+    if (args.curiosity_ledger?.length) {
+      const existing = (person as any).curiosity_ledger ?? [];
+      patch.curiosity_ledger = [...existing, ...args.curiosity_ledger].slice(-50);
+    }
+    if (args.recent_life_events?.length) {
+      const existing = (person as any).recent_life_events ?? [];
+      patch.recent_life_events = [...existing, ...args.recent_life_events].slice(-30);
+    }
+    if (args.topics_that_lit_her_up?.length) {
+      patch.topics_that_lit_her_up = args.topics_that_lit_her_up;
+    }
+    if (args.emotional_state_recent?.length) {
+      const existing = (person as any).emotional_state_recent ?? [];
+      patch.emotional_state_recent = [...existing, ...args.emotional_state_recent].slice(-20);
+    }
+    if (args.boundaries_stated?.length) {
+      const existing = (person as any).boundaries_stated ?? [];
+      patch.boundaries_stated = Array.from(new Set([...existing, ...args.boundaries_stated])).slice(-15);
+    }
+    await ctx.db.patch(args.person_id, patch);
+    return { ok: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Internal helpers used by the action above.
+// ---------------------------------------------------------------------------
+import { internal } from "./_generated/api";
+
+export const _getPerson = internalQuery({
+  args: { person_id: v.id("people") },
+  handler: async (ctx, args) => await ctx.db.get(args.person_id),
+});
+
+export const _recentMessages = internalQuery({
+  args: { person_id: v.id("people"), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("messages")
+      .withIndex("by_person_recent", (q) => q.eq("person_id", args.person_id))
+      .order("desc")
+      .take(Math.min(args.limit ?? 30, 100));
+    return rows.reverse();
+  },
+});
+
+export const _enqueueEnrichJob = internalMutation({
+  args: {
+    user_id: v.string(),
+    person_id: v.id("people"),
+    conversation_id: v.id("conversations"),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    await ctx.db.insert("agent_jobs", {
+      user_id: args.user_id,
+      job_type: "enrich_courtship",
+      payload: {
+        person_id: args.person_id,
+        conversation_id: args.conversation_id,
+      },
+      status: "queued",
+      priority: 4,
+      attempts: 0,
+      max_attempts: 3,
+      created_at: now,
+      updated_at: now,
+    } as any);
+  },
+});
+
+export const _enqueueCadenceJob = internalMutation({
+  args: { user_id: v.string(), person_id: v.id("people") },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    await ctx.db.insert("agent_jobs", {
+      user_id: args.user_id,
+      job_type: "cadence_evaluate_one",
+      payload: { person_id: args.person_id },
+      status: "queued",
+      priority: 5,
+      attempts: 0,
+      max_attempts: 3,
+      created_at: now,
+      updated_at: now,
+    } as any);
+  },
+});

--- a/web/convex/media.ts
+++ b/web/convex/media.ts
@@ -1,0 +1,310 @@
+/**
+ * AI-9449 — Media library.
+ *
+ * Photos / videos / voice memos / memes Julian has approved for AI to send
+ * in context (puppy, beach, gym selfie, memes that match her humor, etc.).
+ * AI selects from this library based on conversation signals + a context-hook
+ * match.
+ *
+ * Upload pathway:
+ *   1. iPhone Shortcut hits /clapcheeks/media-upload (httpAction in http.ts)
+ *      OR Mac Mini media_drive_watcher polls Google Drive folder
+ *   2. media:upload mutation creates the row + fires autoTagMedia
+ *   3. autoTagMedia (Gemini Vision) populates tags, vibe, smile_detected, etc.
+ *   4. Operator approves in /admin/clapcheeks-ops/media
+ *   5. AI sends pull from listApproved + findByContext
+ */
+import { v } from "convex/values";
+import { mutation, query, internalMutation, internalAction, internalQuery } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+const KIND = v.union(
+  v.literal("image"), v.literal("video"),
+  v.literal("voice_memo"), v.literal("meme"), v.literal("gif"),
+);
+
+// ---------------------------------------------------------------------------
+// upload — create a new media_assets row. Fires autoTagMedia for Vision-based
+// auto-tagging unless explicit tags are provided.
+// ---------------------------------------------------------------------------
+export const upload = mutation({
+  args: {
+    user_id: v.string(),
+    asset_id: v.string(),
+    kind: KIND,
+    storage_url: v.string(),
+    thumbnail_url: v.optional(v.string()),
+    file_size_bytes: v.optional(v.number()),
+    mime_type: v.optional(v.string()),
+    caption: v.optional(v.string()),
+    tags: v.optional(v.array(v.string())),
+    context_hooks: v.optional(v.array(v.string())),
+    upload_source: v.optional(v.union(
+      v.literal("iphone"), v.literal("google_drive"),
+      v.literal("manual"), v.literal("vps_cli"),
+    )),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    // Dedup on (user_id, asset_id).
+    const existing = await ctx.db
+      .query("media_assets")
+      .withIndex("by_asset_id", (q) => q.eq("asset_id", args.asset_id))
+      .first();
+    if (existing) return { asset_id: existing.asset_id, _id: existing._id, deduped: true };
+
+    const tags = args.tags ?? [];
+    const _id = await ctx.db.insert("media_assets", {
+      user_id: args.user_id,
+      asset_id: args.asset_id,
+      kind: args.kind,
+      storage_url: args.storage_url,
+      thumbnail_url: args.thumbnail_url,
+      file_size_bytes: args.file_size_bytes,
+      mime_type: args.mime_type,
+      caption: args.caption,
+      tags,
+      context_hooks: args.context_hooks ?? [],
+      upload_source: args.upload_source,
+      approval_status: "pending",
+      created_at: now,
+      updated_at: now,
+    });
+    // Fire Vision auto-tag if no manual tags provided.
+    if (tags.length === 0 && args.kind === "image") {
+      await ctx.scheduler.runAfter(0, internal.media.autoTagMedia, { _id });
+    }
+    return { asset_id: args.asset_id, _id };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// findByContext — Mac Mini draft engine asks for media matching a hook.
+// Filters by approved + matches at least one context_hook substring.
+// ---------------------------------------------------------------------------
+export const findByContext = query({
+  args: {
+    user_id: v.string(),
+    hooks: v.array(v.string()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const all = await ctx.db
+      .query("media_assets")
+      .withIndex("by_user_status", (q) =>
+        q.eq("user_id", args.user_id).eq("approval_status", "approved"),
+      )
+      .collect();
+    const needles = args.hooks.map((h) => h.toLowerCase());
+    const scored = all
+      .map((a) => {
+        const haystack = [...(a.context_hooks || []), ...(a.tags || [])].map((s) => s.toLowerCase());
+        const matches = needles.filter((n) => haystack.some((h) => h.includes(n) || n.includes(h)));
+        return { asset: a, score: matches.length };
+      })
+      .filter((x) => x.score > 0)
+      .sort((a, b) => b.score - a.score);
+    return scored.slice(0, Math.min(args.limit ?? 5, 20)).map((x) => x.asset);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// recordUse — Mac Mini records every send.
+// ---------------------------------------------------------------------------
+export const recordUse = mutation({
+  args: {
+    user_id: v.string(),
+    asset_id: v.id("media_assets"),
+    person_id: v.id("people"),
+    conversation_id: v.optional(v.id("conversations")),
+    sent_at: v.number(),
+    message_external_guid: v.optional(v.string()),
+    fire_context: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const asset = await ctx.db.get(args.asset_id);
+    if (!asset) return { not_found: true };
+    await ctx.db.insert("media_uses", {
+      user_id: args.user_id,
+      asset_id: args.asset_id,
+      person_id: args.person_id,
+      conversation_id: args.conversation_id,
+      sent_at: args.sent_at,
+      message_external_guid: args.message_external_guid,
+      fire_context: args.fire_context,
+    });
+    await ctx.db.patch(args.asset_id, {
+      used_count: ((asset as any).used_count ?? 0) + 1,
+      last_used_at_ms: args.sent_at,
+      last_used_with_person_id: args.person_id,
+      updated_at: Date.now(),
+    });
+    return { ok: true };
+  },
+});
+
+export const approve = mutation({
+  args: { _id: v.id("media_assets") },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args._id, { approval_status: "approved", updated_at: Date.now() });
+  },
+});
+
+export const deprecate = mutation({
+  args: { _id: v.id("media_assets") },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args._id, { approval_status: "deprecated", updated_at: Date.now() });
+  },
+});
+
+export const get = query({
+  args: { _id: v.id("media_assets") },
+  handler: async (ctx, args) => await ctx.db.get(args._id),
+});
+
+export const listForApproval = query({
+  args: { user_id: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("media_assets")
+      .withIndex("by_user_status", (q) =>
+        q.eq("user_id", args.user_id).eq("approval_status", "pending"),
+      )
+      .order("desc")
+      .take(Math.min(args.limit ?? 50, 200));
+    return rows;
+  },
+});
+
+export const listApproved = query({
+  args: { user_id: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("media_assets")
+      .withIndex("by_user_status", (q) =>
+        q.eq("user_id", args.user_id).eq("approval_status", "approved"),
+      )
+      .order("desc")
+      .take(Math.min(args.limit ?? 50, 200));
+    return rows;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Convex storage upload helpers.
+// ---------------------------------------------------------------------------
+export const generateUploadUrl = mutation({
+  args: {},
+  handler: async (ctx) => await ctx.storage.generateUploadUrl(),
+});
+
+export const storageUrl = query({
+  args: { storage_id: v.string() },
+  handler: async (ctx, args) => await ctx.storage.getUrl(args.storage_id),
+});
+
+export const markAsProfileScreenshot = mutation({
+  args: {
+    asset_id: v.string(),
+    platform: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const asset = await ctx.db
+      .query("media_assets")
+      .withIndex("by_asset_id", (q) => q.eq("asset_id", args.asset_id))
+      .first();
+    if (!asset) return { not_found: true };
+    await ctx.db.patch(asset._id, {
+      analysis_kind: "profile_screenshot",
+      ...(args.platform ? { caption: `Profile screenshot (${args.platform})` } : {}),
+      updated_at: Date.now(),
+    });
+    return { ok: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// autoTagMedia — Vision-based tagging. The actual Gemini Vision call is
+// proxied through the Mac Mini convex_runner via an agent_job because Convex
+// V8 doesn't have the SDK. This action enqueues the job and returns; the job
+// handler calls back into _patchTags with the result.
+// ---------------------------------------------------------------------------
+export const autoTagMedia = internalAction({
+  args: { _id: v.id("media_assets") },
+  handler: async (ctx, args) => {
+    const asset = await ctx.runQuery(internal.media._getMedia, { _id: args._id });
+    if (!asset) return { skipped: true, reason: "not_found" };
+    if ((asset as any).analysis_kind === "profile_screenshot") {
+      // Profile screenshots are analyzed differently (profile_import.analyzeAsProfile).
+      return { skipped: true, reason: "is_profile_screenshot" };
+    }
+    const now = Date.now();
+    await ctx.runMutation(internal.media._enqueueAutoTagJob, {
+      _id: args._id,
+      user_id: asset.user_id,
+      storage_url: asset.storage_url,
+      mime_type: asset.mime_type,
+    });
+    return { enqueued: true, queued_at: now };
+  },
+});
+
+export const _getMedia = internalQuery({
+  args: { _id: v.id("media_assets") },
+  handler: async (ctx, args) => await ctx.db.get(args._id),
+});
+
+export const _patchTags = internalMutation({
+  args: {
+    _id: v.id("media_assets"),
+    tags: v.array(v.string()),
+    context_hooks: v.array(v.string()),
+    vibe: v.optional(v.string()),
+    flex_level: v.optional(v.number()),
+    smile_detected: v.optional(v.boolean()),
+    with_friends: v.optional(v.boolean()),
+    with_pet: v.optional(v.boolean()),
+    auto_tag_run_id: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const patch: any = {
+      tags: args.tags,
+      context_hooks: args.context_hooks,
+      updated_at: Date.now(),
+    };
+    if (args.vibe) patch.vibe = args.vibe;
+    if (args.flex_level !== undefined) patch.flex_level = args.flex_level;
+    if (args.smile_detected !== undefined) patch.smile_detected = args.smile_detected;
+    if (args.with_friends !== undefined) patch.with_friends = args.with_friends;
+    if (args.with_pet !== undefined) patch.with_pet = args.with_pet;
+    if (args.auto_tag_run_id) patch.auto_tag_run_id = args.auto_tag_run_id;
+    await ctx.db.patch(args._id, patch);
+  },
+});
+
+export const _enqueueAutoTagJob = internalMutation({
+  args: {
+    _id: v.id("media_assets"),
+    user_id: v.string(),
+    storage_url: v.string(),
+    mime_type: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    await ctx.db.insert("agent_jobs", {
+      user_id: args.user_id,
+      job_type: "auto_tag_media",
+      payload: {
+        media_id: args._id,
+        storage_url: args.storage_url,
+        mime_type: args.mime_type,
+      },
+      status: "queued",
+      priority: 6,
+      attempts: 0,
+      max_attempts: 3,
+      created_at: now,
+      updated_at: now,
+    } as any);
+  },
+});

--- a/web/convex/people.ts
+++ b/web/convex/people.ts
@@ -552,6 +552,10 @@ export const listForUser = query({
     user_id: v.string(),
     status: v.optional(PERSON_STATUS),
     limit: v.optional(v.number()),
+    // Wave 2.4 — accepted for backwards compat with the old dashboard call.
+    // The current network page filters dating-relevance client-side; this flag
+    // is currently a no-op but the validator must accept it.
+    only_cc_tech: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const limit = Math.min(args.limit ?? 100, 500);
@@ -989,6 +993,75 @@ export const patchEnrichment = mutation({
     }
     await ctx.db.patch(target._id, patch);
     return { matched: true, person_id: target._id, fields_set: Object.keys(patch).length - 1 };
+  },
+});
+
+// ----------------------------------------------------------------------------
+// AI-9500 Wave 2.4 Task J — patchPerson
+//
+// Operator-facing edit mutation. The dossier page uses this to update any
+// editable field (hotness_rating, effort_rating, nurture_state, status,
+// whitelist_for_autoreply, cadence_profile, operator_notes, etc.) without
+// touching daemon-owned live state.
+// ----------------------------------------------------------------------------
+export const patchPerson = mutation({
+  args: {
+    person_id: v.id("people"),
+    display_name: v.optional(v.string()),
+    status: v.optional(v.union(
+      v.literal("lead"), v.literal("active"), v.literal("paused"),
+      v.literal("ghosted"), v.literal("dating"), v.literal("ended"),
+    )),
+    cadence_profile: v.optional(CADENCE_PROFILE),
+    whitelist_for_autoreply: v.optional(v.boolean()),
+    courtship_stage: v.optional(v.union(
+      v.literal("matched"), v.literal("early_chat"), v.literal("phone_swap"),
+      v.literal("pre_date"), v.literal("first_date_done"), v.literal("ongoing"),
+      v.literal("exclusive"), v.literal("ghosted"), v.literal("ended"),
+    )),
+    hotness_rating: v.optional(v.number()),
+    effort_rating: v.optional(v.number()),
+    nurture_state: v.optional(v.union(
+      v.literal("active_pursuit"), v.literal("steady"), v.literal("nurture"),
+      v.literal("dormant"), v.literal("close"),
+    )),
+    next_followup_kind: v.optional(v.union(
+      v.literal("reply"), v.literal("nudge"), v.literal("date_ask"),
+      v.literal("pattern_interrupt"), v.literal("event_followup"), v.literal("none"),
+    )),
+    operator_notes: v.optional(v.string()),
+    interests: v.optional(v.array(v.string())),
+    boundaries_stated: v.optional(v.array(v.string())),
+    things_she_loves: v.optional(v.array(v.string())),
+    things_she_dislikes: v.optional(v.array(v.string())),
+    active_hours_local: v.optional(v.object({
+      tz: v.string(),
+      start_hour: v.number(),
+      end_hour: v.number(),
+    })),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const patch: Record<string, any> = { updated_at: now };
+    const allowed = [
+      "display_name", "status", "cadence_profile", "whitelist_for_autoreply",
+      "courtship_stage", "hotness_rating", "effort_rating", "nurture_state",
+      "next_followup_kind", "operator_notes", "interests", "boundaries_stated",
+      "things_she_loves", "things_she_dislikes", "active_hours_local",
+    ];
+    for (const k of allowed) {
+      const v_ = (args as any)[k];
+      if (v_ !== undefined) patch[k] = v_;
+    }
+    // Validate ranges.
+    if (patch.hotness_rating !== undefined) {
+      patch.hotness_rating = Math.max(1, Math.min(10, Math.round(patch.hotness_rating)));
+    }
+    if (patch.effort_rating !== undefined) {
+      patch.effort_rating = Math.max(1, Math.min(5, Math.round(patch.effort_rating)));
+    }
+    await ctx.db.patch(args.person_id, patch);
+    return { ok: true, fields_set: Object.keys(patch).length - 1 };
   },
 });
 

--- a/web/convex/profile_import.ts
+++ b/web/convex/profile_import.ts
@@ -1,0 +1,222 @@
+/**
+ * AI-9500 Wave 2.4A — Profile screenshot importer.
+ *
+ * Julian screenshots a Tinder/Bumble/Hinge/IG profile, drops it via the iPhone
+ * Shortcut with `x-cc-kind: profile` header. http.ts marks the asset
+ * analysis_kind=profile_screenshot and fires analyzeAsProfile.
+ *
+ * analyzeAsProfile uses Gemini Vision to extract: name, age, occupation,
+ * location, bio, prompts, photos described, zodiac inference, DISC inference,
+ * 3 calibrated openers, green/red flags, compatibility-with-julian read.
+ *
+ * Operator reviews on /admin/clapcheeks-ops/profile-imports and clicks
+ * "Create person row" → createPersonFromProfile creates a people row with
+ * status=lead and whitelist_for_autoreply=false (safety default).
+ *
+ * Note: the Gemini Vision call runs through the Mac Mini convex_runner
+ * because Convex V8 lacks the SDK. analyzeAsProfile here enqueues the
+ * agent_job; runner calls back into _writeProfileData.
+ */
+import { v } from "convex/values";
+import { internalAction, mutation, query, internalMutation, internalQuery } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+// ---------------------------------------------------------------------------
+// analyzeAsProfile — fires Mac Mini Gemini Vision via agent_job.
+// ---------------------------------------------------------------------------
+export const analyzeAsProfile = internalAction({
+  args: { media_id: v.string() },
+  handler: async (ctx, args) => {
+    const asset = await ctx.runQuery(internal.profile_import._getMedia, {
+      asset_id: args.media_id,
+    });
+    if (!asset) return { skipped: true, reason: "not_found" };
+    await ctx.runMutation(internal.profile_import._enqueueAnalyzeJob, {
+      _id: asset._id,
+      user_id: asset.user_id,
+      storage_url: asset.storage_url,
+      mime_type: asset.mime_type,
+    });
+    return { enqueued: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// listForReview — dashboard query.
+// ---------------------------------------------------------------------------
+export const listForReview = query({
+  args: { user_id: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const all = await ctx.db
+      .query("media_assets")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .collect();
+    return all
+      .filter((a) =>
+        (a as any).analysis_kind === "profile_screenshot" &&
+        !(a as any).profile_imported_to_person_id,
+      )
+      .sort((a, b) => b.created_at - a.created_at)
+      .slice(0, Math.min(args.limit ?? 50, 200));
+  },
+});
+
+// ---------------------------------------------------------------------------
+// reanalyze — operator clicked "retry analyze".
+// ---------------------------------------------------------------------------
+export const reanalyze = mutation({
+  args: { media_id: v.id("media_assets") },
+  handler: async (ctx, args) => {
+    const asset = await ctx.db.get(args.media_id);
+    if (!asset) return { not_found: true };
+    await ctx.scheduler.runAfter(0, internal.profile_import.analyzeAsProfile, {
+      media_id: (asset as any).asset_id,
+    });
+    return { enqueued: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// dismissProfileScreenshot — operator clicked Skip; deprecate the asset.
+// ---------------------------------------------------------------------------
+export const dismissProfileScreenshot = mutation({
+  args: { media_id: v.id("media_assets") },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.media_id, {
+      approval_status: "deprecated",
+      updated_at: Date.now(),
+    });
+    return { ok: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// createPersonFromProfile — operator clicked "Create person row".
+// Creates a people row with status="lead" and whitelist_for_autoreply=false
+// (safety default — operator has to flip whitelist before AI sends).
+// ---------------------------------------------------------------------------
+export const createPersonFromProfile = mutation({
+  args: {
+    media_id: v.id("media_assets"),
+    user_id: v.string(),
+    overrides: v.optional(v.object({
+      display_name: v.optional(v.string()),
+      platform: v.optional(v.string()),
+    })),
+  },
+  handler: async (ctx, args) => {
+    const asset = await ctx.db.get(args.media_id);
+    if (!asset) return { not_found: true };
+    const data = (asset as any).profile_screenshot_data as any;
+    if (!data) return { not_analyzed: true };
+
+    const now = Date.now();
+    const display = args.overrides?.display_name || data.name || "(unnamed)";
+    const platform = (args.overrides?.platform || data.platform || "other") as
+      "tinder" | "bumble" | "hinge" | "instagram" | "other";
+
+    const handles: any[] = [];
+    if (data.platform_user_id) {
+      handles.push({
+        channel: ["tinder","bumble","hinge","instagram"].includes(platform) ? platform : "other",
+        value: String(data.platform_user_id),
+        verified: false,
+        primary: true,
+      });
+    }
+
+    const personId = await ctx.db.insert("people", {
+      user_id: args.user_id,
+      display_name: display,
+      handles,
+      interests: data.interests || [],
+      goals: [],
+      values: [],
+      cadence_profile: "warm",
+      status: "lead",
+      whitelist_for_autoreply: false,
+      // Wave 2.4A profile-screenshot enrichment
+      age: data.age,
+      bio_text: data.bio_text,
+      location_observed: data.location,
+      occupation_observed: data.occupation,
+      zodiac_sign: data.likely_zodiac_sign,
+      zodiac_analysis: data.zodiac_block,
+      disc_inference: data.disc,
+      disc_inference_reasoning: data.disc_reasoning,
+      opener_suggestions: data.opener_suggestions || [],
+      profile_prompts_observed: data.prompts || [],
+      photos_observed: data.photos_described || [],
+      green_flags: data.green_flags || [],
+      red_flags: data.red_flags || [],
+      imported_from_profile_screenshot: true,
+      imported_from_platform: platform,
+      created_at: now,
+      updated_at: now,
+    } as any);
+
+    await ctx.db.patch(args.media_id, {
+      profile_imported_to_person_id: personId,
+      approval_status: "approved",
+      updated_at: now,
+    });
+    return { person_id: personId };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// _writeProfileData — Mac Mini calls back here after Gemini Vision returns.
+// ---------------------------------------------------------------------------
+export const _writeProfileData = internalMutation({
+  args: {
+    _id: v.id("media_assets"),
+    profile_screenshot_data: v.any(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args._id, {
+      profile_screenshot_data: args.profile_screenshot_data,
+      updated_at: Date.now(),
+    });
+    return { ok: true };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Internal helpers.
+// ---------------------------------------------------------------------------
+export const _getMedia = internalQuery({
+  args: { asset_id: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("media_assets")
+      .withIndex("by_asset_id", (q) => q.eq("asset_id", args.asset_id))
+      .first();
+  },
+});
+
+export const _enqueueAnalyzeJob = internalMutation({
+  args: {
+    _id: v.id("media_assets"),
+    user_id: v.string(),
+    storage_url: v.string(),
+    mime_type: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    await ctx.db.insert("agent_jobs", {
+      user_id: args.user_id,
+      job_type: "analyze_profile_screenshot",
+      payload: {
+        media_id: args._id,
+        storage_url: args.storage_url,
+        mime_type: args.mime_type,
+      },
+      status: "queued",
+      priority: 4,
+      attempts: 0,
+      max_attempts: 3,
+      created_at: now,
+      updated_at: now,
+    } as any);
+  },
+});

--- a/web/convex/schema.ts
+++ b/web/convex/schema.ts
@@ -328,6 +328,118 @@ export default defineSchema({
     next_best_move_confidence: v.optional(v.number()),          // 0.0 - 1.0
     courtship_last_analyzed: v.optional(v.number()),            // unix ms of last enrich_courtship run
 
+    // -----------------------------------------------------------------
+    // FEELS-SEEN-HEARD intelligence — populated by enrich_courtship.
+    // -----------------------------------------------------------------
+    personal_details: v.optional(v.array(v.object({
+      fact: v.string(),
+      source_msg_external_guid: v.optional(v.string()),
+      learned_at: v.number(),
+      validated_by_julian: v.optional(v.boolean()),
+    }))),
+    recent_life_events: v.optional(v.array(v.object({
+      event: v.string(),
+      date_mentioned_ms: v.number(),
+      event_date_estimated_ms: v.optional(v.number()),
+      status: v.union(
+        v.literal("pending"), v.literal("happened"),
+        v.literal("missed"), v.literal("faded"),
+      ),
+    }))),
+    topics_that_lit_her_up: v.optional(v.array(v.object({
+      topic: v.string(),
+      signal_count: v.number(),
+      last_lit_at_ms: v.number(),
+      signal_strength: v.optional(v.number()),
+    }))),
+    curiosity_ledger: v.optional(v.array(v.object({
+      question: v.string(),
+      topic: v.optional(v.string()),
+      priority: v.number(),
+      status: v.union(
+        v.literal("pending"), v.literal("asked"),
+        v.literal("answered"), v.literal("retired"),
+      ),
+      added_at_ms: v.number(),
+      asked_at_ms: v.optional(v.number()),
+    }))),
+    emotional_state_recent: v.optional(v.array(v.object({
+      state: v.union(
+        v.literal("stressed"), v.literal("excited"), v.literal("playful"),
+        v.literal("vulnerable"), v.literal("flirty"), v.literal("bored"),
+        v.literal("tired"), v.literal("proud"), v.literal("anxious"), v.literal("neutral"),
+      ),
+      intensity: v.number(),
+      observed_at_ms: v.number(),
+      message_external_guid: v.optional(v.string()),
+    }))),
+
+    // -----------------------------------------------------------------
+    // Wave 2.4A — Profile-screenshot import enrichment (set when imported).
+    // -----------------------------------------------------------------
+    age: v.optional(v.number()),
+    zodiac_sign: v.optional(v.union(
+      v.literal("aries"), v.literal("taurus"), v.literal("gemini"),
+      v.literal("cancer"), v.literal("leo"), v.literal("virgo"),
+      v.literal("libra"), v.literal("scorpio"), v.literal("sagittarius"),
+      v.literal("capricorn"), v.literal("aquarius"), v.literal("pisces"),
+    )),
+    zodiac_analysis: v.optional(v.string()),
+    disc_inference: v.optional(v.string()),
+    disc_inference_reasoning: v.optional(v.string()),
+    opener_suggestions: v.optional(v.array(v.string())),
+    location_observed: v.optional(v.string()),
+    occupation_observed: v.optional(v.string()),
+    bio_text: v.optional(v.string()),
+    profile_prompts_observed: v.optional(v.array(v.object({
+      prompt: v.string(),
+      answer: v.string(),
+    }))),
+    photos_observed: v.optional(v.array(v.string())),
+    imported_from_profile_screenshot: v.optional(v.boolean()),
+    imported_from_platform: v.optional(v.union(
+      v.literal("tinder"), v.literal("bumble"), v.literal("hinge"),
+      v.literal("instagram"), v.literal("other"),
+    )),
+
+    // -----------------------------------------------------------------
+    // AI-9500-E — Per-person cadence overrides (auto-tuned weekly).
+    // -----------------------------------------------------------------
+    cadence_overrides: v.optional(v.object({
+      min_reply_gap_ms: v.optional(v.number()),
+      max_reply_gap_ms: v.optional(v.number()),
+      preferred_send_hour_local: v.optional(v.number()),
+      compliment_throttle_ms: v.optional(v.number()),
+      banter_density_target: v.optional(v.number()),
+      emoji_density_target: v.optional(v.number()),
+      message_length_target: v.optional(v.number()),
+    })),
+    time_to_ask_score: v.optional(v.number()),
+    last_ask_attempted_at: v.optional(v.number()),
+
+    // -----------------------------------------------------------------
+    // Wave 2.4 Task J — Operator-facing ratings + nurture state.
+    // Editable from the dossier page; AI uses these to prioritize attention.
+    // -----------------------------------------------------------------
+    hotness_rating: v.optional(v.number()),       // 1-10, operator-set
+    effort_rating: v.optional(v.number()),        // 1-5, operator's effort budget
+    nurture_state: v.optional(v.union(            // explicit nurture mode
+      v.literal("active_pursuit"),                // chase, fast cadence, willing to put in
+      v.literal("steady"),                        // consistent but not aggressive
+      v.literal("nurture"),                       // light-touch keep-warm
+      v.literal("dormant"),                       // re-awaken occasionally
+      v.literal("close"),                         // wind down — stop sending
+    )),
+    next_followup_kind: v.optional(v.union(       // what we should send next
+      v.literal("reply"),
+      v.literal("nudge"),
+      v.literal("date_ask"),
+      v.literal("pattern_interrupt"),
+      v.literal("event_followup"),
+      v.literal("none"),
+    )),
+    operator_notes: v.optional(v.string()),       // free-form notes from dashboard
+
     // Cadence + timing — drives the cadence_runner thread.
     cadence_profile: v.union(
       v.literal("hot"),                             // reply within 5-30m
@@ -495,17 +607,76 @@ export default defineSchema({
     caption: v.optional(v.string()),
     tags: v.array(v.string()),
     context_hooks: v.array(v.string()),
+    vibe: v.optional(v.union(
+      v.literal("playful"), v.literal("flex"), v.literal("vulnerable"),
+      v.literal("funny"), v.literal("adventurous"), v.literal("romantic"),
+      v.literal("mundane"),
+    )),
+    flex_level: v.optional(v.number()),
+    smile_detected: v.optional(v.boolean()),
+    with_friends: v.optional(v.boolean()),
+    with_pet: v.optional(v.boolean()),
+    upload_source: v.optional(v.union(
+      v.literal("iphone"), v.literal("google_drive"),
+      v.literal("manual"), v.literal("vps_cli"),
+    )),
     approval_status: v.union(
       v.literal("pending"),
       v.literal("approved"),
       v.literal("deprecated"),
     ),
+    auto_tag_run_id: v.optional(v.string()),
+    // Wave 2.4A — profile screenshot mode.
+    analysis_kind: v.optional(v.union(
+      v.literal("media"),
+      v.literal("profile_screenshot"),
+    )),
+    profile_screenshot_data: v.optional(v.any()),
+    profile_imported_to_person_id: v.optional(v.id("people")),
     used_count: v.optional(v.number()),
     last_used_at_ms: v.optional(v.number()),
+    last_used_with_person_id: v.optional(v.id("people")),
     created_at: v.number(),
     updated_at: v.number(),
   })
     .index("by_user", ["user_id"])
     .index("by_user_status", ["user_id", "approval_status"])
     .index("by_asset_id", ["asset_id"]),
+
+  // -----------------------------------------------------------------------
+  // AI-9449 Wave 2.2 — calendar_slots cache.
+  // Mac Mini periodically pulls Julian's gws calendars and writes free-busy
+  // windows here. Date-ask drafts read from this so AI never proposes a
+  // time he's already booked.
+  // -----------------------------------------------------------------------
+  calendar_slots: defineTable({
+    user_id: v.string(),
+    slot_start_ms: v.number(),
+    slot_end_ms: v.number(),
+    slot_kind: v.union(
+      v.literal("free"),
+      v.literal("busy"),
+      v.literal("date_proposed"),
+      v.literal("date_confirmed"),
+    ),
+    label_local: v.optional(v.string()),
+    proposed_to_person_id: v.optional(v.id("people")),
+    fetched_at_ms: v.number(),
+  })
+    .index("by_user_start", ["user_id", "slot_start_ms"])
+    .index("by_user_kind", ["user_id", "slot_kind"]),
+
+  // Tracks asset usage to prevent repeats per girl + cool-down across girls.
+  media_uses: defineTable({
+    user_id: v.string(),
+    asset_id: v.id("media_assets"),
+    person_id: v.id("people"),
+    conversation_id: v.optional(v.id("conversations")),
+    sent_at: v.number(),
+    message_external_guid: v.optional(v.string()),
+    fire_context: v.optional(v.string()),
+  })
+    .index("by_user_recent", ["user_id", "sent_at"])
+    .index("by_asset", ["asset_id"])
+    .index("by_person", ["person_id"]),
 });


### PR DESCRIPTION
## Summary

Three things bundled because all unblock the same path (deploy + populate dashboard):

### 1. Restore lost convex modules
The integration branch was missing \`calendar.ts\`, \`digest.ts\`, \`inbound.ts\`, \`media.ts\`, \`profile_import.ts\`, \`backfill.ts\`, \`http.ts\` — they were on disk last session but never committed, then wiped by concurrent bussit agents. Without them, \`npx convex deploy\` would DELETE the live functions (Convex is full-source replacement). Restored with the agent_jobs offload pattern so Mac Mini still does heavy work. **Convex now deploys clean.**

### 2. Wave 2.4 J — operator-editable ratings + nurture state
- People schema gains \`hotness_rating\` (1-10), \`effort_rating\` (1-5), \`nurture_state\` (active_pursuit / steady / nurture / dormant / close), \`next_followup_kind\`, \`operator_notes\`.
- Plus Wave 2.4A profile-screenshot enrichment fields (zodiac/DISC/openers), Wave 2.4E cadence_overrides, and the missing FEELS-SEEN-HEARD ledger validators (personal_details, curiosity_ledger, recent_life_events, topics_that_lit_her_up, emotional_state_recent) which had been on live data but missing from the validator.
- New \`patchPerson\` mutation for editing any of these from the dashboard. Range-validates ratings.

### 3. Network page actually populates
Was filtering by \`only_cc_tech: true\` → 0 people have the CC TECH label → empty page. Switched to client-side dating-relevance filter. **Now: 66 of 500 people surface as default view.**

### 4. CLAUDE.md
Replaced 57-line stub with comprehensive architecture / workflows / safety brakes / 4 hard rules / date-ask flow / schema editing guide / stale-dashboard diagnosis checklist.

## Verification (already done)
- \`npx convex deploy\` succeeds against \`valiant-oriole-651\`
- \`npx convex run people:listForUser\` returns 500 rows
- 66 dating-relevant after filter

## Test plan
- [ ] Vercel auto-deploy completes
- [ ] /admin/clapcheeks-ops/network shows 66+ people
- [ ] /admin/clapcheeks-ops/people/[id] dossier renders
- [ ] /admin/clapcheeks-ops/profile-imports renders
- [ ] Compose panel preview → Mac Mini drafts → Send commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)