### PR TITLE
feat(clapcheeks): AI-9500 #1 curiosity-question scheduler

### DIFF
--- a/web/app/admin/clapcheeks-ops/network/page.tsx
+++ b/web/app/admin/clapcheeks-ops/network/page.tsx
@@ -165,13 +165,21 @@ export default function NetworkPage() {
 }
 
 function PersonRow({ p }: { p: any }) {
+  const now = Date.now()
   const lastInbound = p.last_inbound_at
-    ? `${Math.round((Date.now() - p.last_inbound_at) / 3600000)}h ago`
+    ? `${Math.round((now - p.last_inbound_at) / 3600000)}h ago`
     : "—"
   const trust = p.trust_score?.toFixed(2) ?? "—"
   const ttas = p.time_to_ask_score?.toFixed(2) ?? "—"
   const lastEmotion = (p.emotional_state_recent ?? []).slice(-1)[0]?.state ?? "—"
   const platforms = Array.from(new Set((p.handles ?? []).map((h: any) => h.channel)))
+
+  // AI-9500 #1 — quiet thread badge
+  const questionRatio: number | null = p.her_question_ratio_7d ?? null
+  const lastInboundAgo = p.last_inbound_at ? (now - p.last_inbound_at) / 3600000 : null
+  const isQuietThread = questionRatio !== null && questionRatio < 0.15
+    && lastInboundAgo !== null && lastInboundAgo > 24
+
   return (
     <Link
       href={`/admin/clapcheeks-ops/people/${p._id}`}
@@ -190,6 +198,15 @@ function PersonRow({ p }: { p: any }) {
             )}
             {p.nurture_state && (
               <span className="text-purple-300 text-xs uppercase">{p.nurture_state}</span>
+            )}
+            {/* AI-9500 #1 — quiet thread badge */}
+            {isQuietThread && (
+              <span
+                className="text-[10px] px-1.5 py-0.5 rounded bg-amber-900/40 text-amber-300 border border-amber-700/50"
+                title={`Question ratio: ${((questionRatio ?? 0) * 100).toFixed(0)}% (last 7d inbound) — silent ${Math.round(lastInboundAgo ?? 0)}h`}
+              >
+                💤 quiet thread
+              </span>
             )}
             {platforms.length > 0 && (
               <span className="text-xs text-gray-600">{platforms.join(" · ")}</span>

--- a/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
+++ b/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
@@ -24,6 +24,7 @@ const TEMPLATE_OPTIONS = [
   { value: "hot_reply", label: "Hot reply (high interest)" },
   { value: "callback_reference", label: "Callback to something she said" },
   { value: "pattern_interrupt", label: "Pattern interrupt (stale)" },
+  { value: "easy_question_revival", label: "💤 Easy yes/no question (quiet thread revival)" },
   { value: "morning_text", label: "Morning text" },
   { value: "ghost_recovery", label: "Ghost recovery" },
   { value: "date_ask_three_options", label: "Ask for the date" },
@@ -386,8 +387,53 @@ function MemoryTab({ person }: { person: any }) {
   const curiosity = (person.curiosity_ledger ?? []).filter((q: any) => q.status === "pending")
   const events = person.recent_life_events ?? []
   const lit = person.topics_that_lit_her_up ?? []
+
+  // AI-9500 #1 — curiosity-question ratio metric
+  const questionRatio: number | null = person.her_question_ratio_7d ?? null
+  const ratioComputedAt: number | null = person.her_question_ratio_computed_at ?? null
+  const isQuietThread = questionRatio !== null && questionRatio < 0.15
+  const lastInboundAgo = person.last_inbound_at
+    ? Math.round((Date.now() - person.last_inbound_at) / 3600000)
+    : null
+  const isSilent24h = lastInboundAgo !== null && lastInboundAgo > 24
+
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+
+      {/* AI-9500 #1 — Curiosity-question ratio badge */}
+      {questionRatio !== null && (
+        <div className={`col-span-full rounded-lg border p-3 mb-2 ${
+          isQuietThread && isSilent24h
+            ? "border-amber-700/60 bg-amber-900/10"
+            : "border-gray-700 bg-gray-800/40"
+        }`}>
+          <div className="flex items-center gap-3 text-sm">
+            <span className="text-lg">{isQuietThread && isSilent24h ? "💤" : "💬"}</span>
+            <div>
+              <span className="font-medium text-gray-200">
+                Question ratio (7d inbound):&nbsp;
+                <span className={isQuietThread ? "text-amber-300 font-bold" : "text-green-300"}>
+                  {(questionRatio * 100).toFixed(0)}%
+                </span>
+              </span>
+              {isQuietThread && isSilent24h ? (
+                <span className="ml-2 text-xs text-amber-400 font-semibold">
+                  — flagged for easy_question_revival (she's stopped asking questions &amp; hasn't replied in {lastInboundAgo}h)
+                </span>
+              ) : isQuietThread ? (
+                <span className="ml-2 text-xs text-gray-500">low ratio but still active</span>
+              ) : (
+                <span className="ml-2 text-xs text-gray-500">healthy engagement</span>
+              )}
+            </div>
+          </div>
+          {ratioComputedAt && (
+            <div className="text-[10px] text-gray-600 mt-1">
+              computed {new Date(ratioComputedAt).toLocaleString()}
+            </div>
+          )}
+        </div>
+      )}
       <Section title={`Personal details (${details.length})`}>
         {details.length === 0 ? <Empty /> : (
           <ul className="space-y-1 text-sm">

--- a/web/convex/enrichment.ts
+++ b/web/convex/enrichment.ts
@@ -651,6 +651,95 @@ export const _writeCadenceOverrides = internalMutation({
   },
 });
 
+// -------------------------------------------------------------------------
+// AI-9500 #1 — Curiosity-question scheduler helpers
+//
+// _computeHerQuestionRatio: reads her inbound messages in the last 7d and
+// returns { ratio, question_count, total_count } where ratio = ?-count / total.
+// Uses the by_person_recent index for efficiency.
+//
+// _writeHerQuestionRatio: patches the person row with the computed ratio and
+// timestamp. Also sets next_followup_kind = "easy_question_revival" when:
+//   - ratio < 0.15 (she's stopped asking questions)
+//   - last_inbound_at > 24h ago (conversation is quiet)
+//
+// These are called from recalibrateCadenceForOne so cadence + question-ratio
+// compute in a single sweep pass.
+// -------------------------------------------------------------------------
+
+/** Count question marks in a string (counts "?", "??", "???" as 1 each occurrence of "?"). */
+function _countQuestionMarks(text: string): number {
+  return (text.match(/\?/g) || []).length;
+}
+
+export const _computeHerQuestionRatio = internalQuery({
+  args: { person_id: v.id("people") },
+  handler: async (ctx, args) => {
+    const sevenDaysAgo = Date.now() - 7 * 24 * 3600_000;
+
+    // Primary: by_person_recent index with since filter
+    let inboundMsgs = await ctx.db
+      .query("messages")
+      .withIndex("by_person_recent", (q) =>
+        q.eq("person_id", args.person_id).gte("sent_at", sevenDaysAgo),
+      )
+      .filter((q) => q.eq(q.field("direction"), "inbound"))
+      .collect();
+
+    // Fallback: walk conversations if index returned nothing
+    if (inboundMsgs.length === 0) {
+      const convs = await ctx.db
+        .query("conversations")
+        .withIndex("by_person", (q) => q.eq("person_id", args.person_id))
+        .collect();
+      for (const c of convs) {
+        const msgs = await ctx.db
+          .query("messages")
+          .withIndex("by_conversation", (q) =>
+            q.eq("conversation_id", c._id).gte("sent_at", sevenDaysAgo),
+          )
+          .filter((q) => q.eq(q.field("direction"), "inbound"))
+          .collect();
+        inboundMsgs.push(...msgs);
+      }
+    }
+
+    const total = inboundMsgs.length;
+    if (total === 0) return { ratio: null, question_count: 0, total_count: 0 };
+
+    let questionCount = 0;
+    for (const m of inboundMsgs) {
+      if (_countQuestionMarks(m.body || "") > 0) questionCount++;
+    }
+
+    return {
+      ratio: questionCount / total,
+      question_count: questionCount,
+      total_count: total,
+    };
+  },
+});
+
+export const _writeHerQuestionRatio = internalMutation({
+  args: {
+    person_id: v.id("people"),
+    her_question_ratio_7d: v.number(),
+    set_easy_question_revival: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const patch: Record<string, unknown> = {
+      her_question_ratio_7d: args.her_question_ratio_7d,
+      her_question_ratio_computed_at: now,
+      updated_at: now,
+    };
+    if (args.set_easy_question_revival) {
+      patch.next_followup_kind = "easy_question_revival";
+    }
+    await ctx.db.patch(args.person_id, patch);
+  },
+});
+
 // Main action: compute and write cadence overrides for one person.
 export const recalibrateCadenceForOne = internalAction({
   args: { person_id: v.id("people") },
@@ -754,7 +843,7 @@ export const recalibrateCadenceForOne = internalAction({
     }
 
     // -----------------------------------------------------------------------
-    // Step 4: Write back
+    // Step 4: Write back cadence overrides
     // -----------------------------------------------------------------------
     const cadenceOverrides = {
       min_reply_gap_ms: minGap,
@@ -769,6 +858,35 @@ export const recalibrateCadenceForOne = internalAction({
       active_hours_computed: activeHours,
     });
 
+    // -----------------------------------------------------------------------
+    // Step 5: AI-9500 #1 — Curiosity-question ratio
+    //
+    // Compute her ?-count / total-messages ratio for the last 7d inbound messages.
+    // If ratio < 0.15 AND last_inbound_at > 24h ago → flag for easy_question_revival
+    // so the fatigue sweep sends a yes/no question instead of a generic interrupt.
+    // -----------------------------------------------------------------------
+    const QUESTION_RATIO_THRESHOLD = 0.15;
+    const TWENTY_FOUR_H_MS = 24 * 3600_000;
+    const lastInboundAt: number = person.last_inbound_at ?? 0;
+    const isSilent = lastInboundAt > 0 && (now - lastInboundAt) > TWENTY_FOUR_H_MS;
+
+    const questionRatioResult: any = await ctx.runQuery(
+      internal.enrichment._computeHerQuestionRatio,
+      { person_id: args.person_id },
+    );
+
+    let questionRatioWritten: number | null = null;
+    if (questionRatioResult.ratio !== null) {
+      const ratio: number = questionRatioResult.ratio;
+      const setRevival = ratio < QUESTION_RATIO_THRESHOLD && isSilent;
+      await ctx.runMutation(internal.enrichment._writeHerQuestionRatio, {
+        person_id: args.person_id,
+        her_question_ratio_7d: ratio,
+        set_easy_question_revival: setRevival,
+      });
+      questionRatioWritten = ratio;
+    }
+
     return {
       person_id: args.person_id,
       reply_pairs: replyGaps.length,
@@ -776,6 +894,9 @@ export const recalibrateCadenceForOne = internalAction({
       min_reply_gap_ms: minGap,
       max_reply_gap_ms: maxGap,
       active_hours: activeHours,
+      her_question_ratio_7d: questionRatioWritten,
+      easy_question_revival_flagged: questionRatioWritten !== null
+        && questionRatioWritten < QUESTION_RATIO_THRESHOLD && isSilent,
     };
   },
 });

--- a/web/convex/touches.ts
+++ b/web/convex/touches.ts
@@ -41,6 +41,7 @@ const TOUCH_TYPE = v.union(
   v.literal("date_dayof"),
   v.literal("date_postmortem"),
   v.literal("reengage_low_temp"),
+  v.literal("easy_question_revival"),  // AI-9500 #1 — low-effort yes/no question
   v.literal("birthday_wish"),
   v.literal("event_day_check"),
   v.literal("pattern_interrupt"),


### PR DESCRIPTION
## Summary

- **enrichment.ts** — `_computeHerQuestionRatio` internalQuery: reads last 7d inbound messages via `by_person_recent` index, returns `{ratio, question_count, total_count}`. `_writeHerQuestionRatio` internalMutation patches `her_question_ratio_7d`, `her_question_ratio_computed_at`, and sets `next_followup_kind = "easy_question_revival"` when ratio < 0.15 AND last_inbound_at > 24h. `recalibrateCadenceForOne` calls both helpers at Step 5 (after cadence overrides are written).
- **touches.ts** — `easy_question_revival` added to `TOUCH_TYPE` union so `scheduleOne` + `cancelForPerson` accept it.
- **network/page.tsx** — `PersonRow` shows a `💤 quiet thread` amber badge when `her_question_ratio_7d < 0.15` AND `last_inbound_at > 24h`.
- **people/[id]/page.tsx** — `MemoryTab` shows a full-width `her_question_ratio_7d` metric card (amber when flagged for revival, green when healthy). `TEMPLATE_OPTIONS` gains `easy_question_revival` for the operator compose panel.

**Mac Mini daemon** (`/opt/agency-workspace/clapcheeks-local/clapcheeks/convex_runner.py`) — also updated (separate repo, not in this PR):
- `easy_question_revival` template added to `template_prompts` dict with strict constraints: 1 sentence, yes/no, <80 chars, references something from her last 5 inbound messages, no Julian pivot, no gap mention.
- Touch-type fallback routing: if `prompt_template` is unset but `touch_type == "easy_question_revival"`, the template is set automatically.

## Verification

Smoke test after deploy:
```
_computeHerQuestionRatio("jx75jjfwcar74tt88byhkysskn8675kq")
→ {ratio: 0.333, question_count: 1, total_count: 3} ✓

_computeHerQuestionRatio("jx7c4rp3csjqnz3yfdgeetf07h8671f8")
→ {ratio: 0.0, total_count: 20}
→ Blake: silent 27h → would be flagged for easy_question_revival ✓
```

## Test plan

- [ ] Verify `_computeHerQuestionRatio` returns a number in [0,1] for a person with recent inbound messages
- [ ] After `recalibrateCadenceForOne` runs for a person with ratio < 0.15 + silent >24h, confirm `next_followup_kind = "easy_question_revival"` on the person row
- [ ] Network page: confirm `💤 quiet thread` badge appears for flagged people
- [ ] Dossier Memory tab: confirm question ratio card renders with correct color
- [ ] Compose panel: confirm `easy_question_revival` option appears in template dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)