### PR TITLE
feat(clapcheeks): AI-9500 #6 post-date calibrator

### DIFF
--- a/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
+++ b/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
@@ -469,16 +469,207 @@ function MemoryTab({ person }: { person: any }) {
 }
 
 // ---------------------------------------------------------------------------
-// Schedule tab — pending touches and recent fires
+// Schedule tab — pending touches, post-date calibration, and recent fires
 // ---------------------------------------------------------------------------
 function ScheduleTab({ person, touches }: { person: any; touches: any[] }) {
   const cancelMut = useMutation(api.touches.cancelOne)
+  const markDateDone = useMutation(api.touches.markDateDone)
+  const commitPostDateChoice = useMutation(api.touches.commitPostDateChoice)
+  const FLEET_USER_ID = "fleet-julian"
+
+  const [showDateDoneForm, setShowDateDoneForm] = useState(false)
+  const [dateNotesText, setDateNotesText] = useState("")
+  const [dateMarkingId, setDateMarkingId] = useState<string | null>(null)
+  const [markingBusy, setMarkingBusy] = useState(false)
+  const [choiceError, setChoiceError] = useState<string | null>(null)
+
   const upcoming = touches.filter((t) => t.status === "scheduled" && !t.is_preview)
   const fired = touches.filter((t) => t.status === "fired").slice(0, 10)
   const skipped = touches.filter((t) => t.status === "skipped").slice(0, 10)
 
+  // Post-date calibration touches with candidates awaiting operator choice.
+  const pendingCalibrations = upcoming.filter(
+    (t: any) => t.type === "post_date_calibration" && t.candidate_drafts?.length > 0 && !t.draft_body
+  )
+
+  // Date-ask or date-dayof touches that could be "marked done".
+  const dateCandidates = [...upcoming, ...fired].filter(
+    (t: any) => t.type === "date_ask" || t.type === "date_dayof" || t.type === "date_confirm_24h"
+  ).slice(0, 5)
+
+  async function handleMarkDateDone(sourceTouchId?: string) {
+    setMarkingBusy(true)
+    try {
+      await markDateDone({
+        user_id: FLEET_USER_ID,
+        person_id: person._id,
+        source_touch_id: sourceTouchId as any,
+        date_done_at: Date.now(),
+        date_notes_text: dateNotesText || undefined,
+      })
+      setShowDateDoneForm(false)
+      setDateNotesText("")
+      setDateMarkingId(null)
+    } catch (e: any) {
+      alert("Error: " + (e?.message ?? String(e)))
+    } finally {
+      setMarkingBusy(false)
+    }
+  }
+
+  async function handleCommitChoice(touchId: string, kind: "callback" | "photo" | "generic") {
+    setChoiceError(null)
+    try {
+      await commitPostDateChoice({ touch_id: touchId as any, chosen_kind: kind })
+    } catch (e: any) {
+      setChoiceError(e?.message ?? String(e))
+    }
+  }
+
   return (
     <div className="space-y-6">
+
+      {/* ------------------------------------------------------------------ */}
+      {/* AI-9500 #6 — Post-date calibration candidate pickers                */}
+      {/* ------------------------------------------------------------------ */}
+      {pendingCalibrations.length > 0 && (
+        <Section title={`Post-date follow-up — choose a message (${pendingCalibrations.length})`}>
+          {choiceError && (
+            <div className="text-red-400 text-xs mb-2">{choiceError}</div>
+          )}
+          {pendingCalibrations.map((t: any) => (
+            <div key={t._id} className="mb-6 border border-purple-800 rounded-lg p-4 bg-purple-950/20">
+              <div className="text-xs text-purple-300 mb-1">
+                Calibration scheduled for {new Date(t.scheduled_for).toLocaleString()}
+                {t.date_notes_text && (
+                  <span className="ml-2 text-gray-400 italic">· "{t.date_notes_text}"</span>
+                )}
+              </div>
+              <div className="text-xs text-gray-500 mb-3">
+                Pick one — operator choice committed immediately. Auto-picks "callback" in 6h if no choice made.
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                {(t.candidate_drafts ?? []).map((draft: any) => (
+                  <div key={draft.kind} className="border border-gray-700 rounded-lg p-3 bg-gray-900 flex flex-col justify-between">
+                    <div>
+                      <div className={`text-[10px] font-semibold mb-1 uppercase tracking-wider ${
+                        draft.kind === "callback" ? "text-green-400" :
+                        draft.kind === "photo" ? "text-blue-400" : "text-amber-400"
+                      }`}>
+                        {draft.kind}
+                        {draft.kind === "callback" && " ★ 3x conversion"}
+                      </div>
+                      <p className="text-sm text-white mb-2">{draft.body}</p>
+                      {draft.reasoning && (
+                        <p className="text-[10px] text-gray-500 italic">{draft.reasoning}</p>
+                      )}
+                    </div>
+                    <button
+                      onClick={() => handleCommitChoice(t._id, draft.kind)}
+                      className={`mt-3 w-full text-xs py-1.5 rounded font-semibold ${
+                        draft.kind === "callback"
+                          ? "bg-green-700 hover:bg-green-600 text-white"
+                          : draft.kind === "photo"
+                          ? "bg-blue-700 hover:bg-blue-600 text-white"
+                          : "bg-amber-700 hover:bg-amber-600 text-white"
+                      }`}
+                    >
+                      Use this
+                    </button>
+                  </div>
+                ))}
+              </div>
+              <button
+                onClick={() => cancelMut({ touch_id: t._id, reason: "operator_declined_all_candidates" })}
+                className="mt-2 text-xs text-red-400 hover:text-red-300"
+              >
+                Skip — don't send any of these
+              </button>
+            </div>
+          ))}
+        </Section>
+      )}
+
+      {/* ------------------------------------------------------------------ */}
+      {/* AI-9500 #6 — Mark date done (schedules calibration touch)           */}
+      {/* ------------------------------------------------------------------ */}
+      <Section title="Date completed?">
+        {!showDateDoneForm ? (
+          <div className="text-xs text-gray-500 space-y-2">
+            <p>
+              If you just came back from a date, mark it done to schedule a +18h post-date follow-up with 3 AI-drafted candidate messages.
+            </p>
+            <button
+              onClick={() => setShowDateDoneForm(true)}
+              className="px-3 py-1.5 text-xs rounded bg-purple-800 hover:bg-purple-700 text-white font-semibold"
+            >
+              Mark date done
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div>
+              <label className="text-xs text-gray-400 block mb-1">
+                Date notes (optional — specific moments = 3x 2nd-date booking rate)
+              </label>
+              <textarea
+                value={dateNotesText}
+                onChange={(e) => setDateNotesText(e.target.value)}
+                placeholder="e.g. laughed at the raccoon story, she brought up hiking, mentioned her sister's wedding"
+                rows={3}
+                className="w-full text-xs bg-gray-950 border border-gray-700 rounded p-2 text-white placeholder-gray-600 resize-none"
+              />
+            </div>
+            {dateCandidates.length > 0 && (
+              <div>
+                <div className="text-xs text-gray-500 mb-1">Link to a date touch (optional):</div>
+                <div className="space-y-1">
+                  {dateCandidates.map((t: any) => (
+                    <label key={t._id} className="flex items-center gap-2 text-xs cursor-pointer">
+                      <input
+                        type="radio"
+                        name="date-source"
+                        value={t._id}
+                        checked={dateMarkingId === t._id}
+                        onChange={() => setDateMarkingId(t._id)}
+                        className="accent-purple-500"
+                      />
+                      <span className="text-gray-300">{t.type} · {new Date(t.scheduled_for).toLocaleDateString()}</span>
+                    </label>
+                  ))}
+                  <label className="flex items-center gap-2 text-xs cursor-pointer">
+                    <input
+                      type="radio"
+                      name="date-source"
+                      value=""
+                      checked={dateMarkingId === null}
+                      onChange={() => setDateMarkingId(null)}
+                      className="accent-purple-500"
+                    />
+                    <span className="text-gray-400">No linked touch</span>
+                  </label>
+                </div>
+              </div>
+            )}
+            <div className="flex gap-2">
+              <button
+                onClick={() => handleMarkDateDone(dateMarkingId ?? undefined)}
+                disabled={markingBusy}
+                className="px-3 py-1.5 text-xs rounded bg-purple-700 hover:bg-purple-600 text-white font-semibold disabled:opacity-50"
+              >
+                {markingBusy ? "Scheduling…" : "Schedule +18h calibration touch"}
+              </button>
+              <button
+                onClick={() => { setShowDateDoneForm(false); setDateNotesText(""); setDateMarkingId(null) }}
+                className="px-3 py-1.5 text-xs rounded border border-gray-700 text-gray-400 hover:text-gray-200"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </Section>
+
       <Section title={`Upcoming (${upcoming.length})`}>
         {upcoming.length === 0 ? <Empty text="Nothing queued." /> : (
           <table className="w-full text-xs">

--- a/web/convex/crons.ts
+++ b/web/convex/crons.ts
@@ -124,4 +124,13 @@ crons.interval(
   internal.enrichment.sweepFatigueDetection,
 );
 
+// AI-9500 #6 — Post-date calibration auto-pick every 1 hour.
+// If a post_date_calibration touch has candidate_drafts set but operator hasn't
+// committed a choice within 6h, auto-picks "callback" (highest-converting) and fires.
+crons.interval(
+  "post-date-calibration-auto-pick",
+  { hours: 1 },
+  internal.touches.autoPick6hCron,
+);
+
 export default crons;

--- a/web/convex/touches.ts
+++ b/web/convex/touches.ts
@@ -9,13 +9,22 @@
  *   - scheduleOne     : insert + ctx.scheduler.runAt
  *   - cancelForPerson : when conversation state changes (e.g. she replied,
  *                       cancel pending nudge), cancel a person's pending touches
+ *   - markDateDone    : AI-9500 #6 — operator calls after a date completes.
+ *                       Schedules a post_date_calibration touch +18h out.
+ *   - commitPostDateChoice : AI-9500 #6 — operator picks one of 3 candidates.
+ *                            Copies body to draft_body and fires the standard pipeline.
  *
  * Internal:
  *   - fireOne   : runs at scheduled_for; checks active hours / safety brake;
  *                 enqueues an agent_jobs.send_imessage row (or sends inline);
- *                 records as fired/skipped
+ *                 records as fired/skipped.
+ *                 AI-9500 #6: when type=post_date_calibration, calls
+ *                 _draft3PostDateCandidates and parks row for operator choice.
  *   - drainDue  : safety net cron — finds any "scheduled" rows whose time has
  *                 passed and weren't fired (process crash, etc.)
+ *   - autoPick6hCron : AI-9500 #6 — 1h interval cron. If a post_date_calibration
+ *                      touch has candidate_drafts but operator hasn't chosen within 6h,
+ *                      auto-picks "callback" and fires.
  *
  * AI-9500 Wave 2.4D additions:
  *   - LAYER 1: Anti-loop collision detection via bodyShape (sha1-ish fingerprint
@@ -207,6 +216,117 @@ export const listPreviewsForPerson = query({
 });
 
 // ---------------------------------------------------------------------------
+// AI-9500 #6 — markDateDone
+//
+// Operator calls this from the dossier page once a date has completed.
+// Patches the originating touch (if given) with date_done_at / date_notes_text,
+// then schedules a post_date_calibration touch +18h out.
+//
+// The post_date_calibration touch starts in status="scheduled" and will NOT
+// auto-send: fireOne detects the type, calls _draft3PostDateCandidates, writes
+// candidate_drafts, and leaves the touch in scheduled status for the operator
+// to choose via commitPostDateChoice (or autoPick6hCron fires after 6h).
+// ---------------------------------------------------------------------------
+export const markDateDone = mutation({
+  args: {
+    user_id: v.string(),
+    person_id: v.id("people"),
+    conversation_id: v.optional(v.id("conversations")),
+    // Optionally patch the originating date_ask/date_dayof touch with notes.
+    source_touch_id: v.optional(v.id("scheduled_touches")),
+    date_done_at: v.number(),                  // unix ms — when the date ended
+    date_notes_text: v.optional(v.string()),   // operator notes about the date
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+
+    // Patch the source touch if given.
+    if (args.source_touch_id) {
+      const src = await ctx.db.get(args.source_touch_id);
+      if (src && src.person_id === args.person_id) {
+        await ctx.db.patch(args.source_touch_id, {
+          date_done_at: args.date_done_at,
+          date_notes_text: args.date_notes_text,
+          updated_at: now,
+        });
+      }
+    }
+
+    // Schedule the calibration touch +18h from date_done_at (or from now if date_done_at is in the past).
+    const fireAt = Math.max(args.date_done_at + 18 * 60 * 60 * 1000, now + 60 * 1000);
+    const calibrationTouchId = await ctx.db.insert("scheduled_touches", {
+      user_id: args.user_id,
+      person_id: args.person_id,
+      conversation_id: args.conversation_id,
+      type: "post_date_calibration",
+      scheduled_for: fireAt,
+      status: "scheduled",
+      generate_at_fire_time: true,              // fireOne generates candidates
+      date_done_at: args.date_done_at,
+      date_notes_text: args.date_notes_text,
+      created_at: now,
+      updated_at: now,
+    });
+
+    const delayMs = Math.max(0, fireAt - now);
+    await ctx.scheduler.runAfter(delayMs, internal.touches.fireOne, {
+      touch_id: calibrationTouchId,
+    });
+
+    return { scheduled: true, touch_id: calibrationTouchId, fire_at: fireAt };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// AI-9500 #6 — commitPostDateChoice
+//
+// Operator has reviewed the 3 candidate drafts and picked one.
+// Copies the chosen body to draft_body and runs the standard send pipeline.
+// ---------------------------------------------------------------------------
+export const commitPostDateChoice = mutation({
+  args: {
+    touch_id: v.id("scheduled_touches"),
+    chosen_kind: v.union(
+      v.literal("callback"),
+      v.literal("photo"),
+      v.literal("generic"),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const touch = await ctx.db.get(args.touch_id);
+    if (!touch) return { not_found: true };
+    if (touch.type !== "post_date_calibration") return { wrong_type: touch.type };
+    if (touch.status !== "scheduled") return { wrong_status: touch.status };
+    if (!touch.candidate_drafts?.length) return { no_candidates: true };
+
+    const chosen = touch.candidate_drafts.find((c) => c.kind === args.chosen_kind);
+    if (!chosen) {
+      // Fall back to first candidate if kind not found.
+      const first = touch.candidate_drafts[0];
+      await ctx.db.patch(args.touch_id, {
+        draft_body: first.body,
+        generate_at_fire_time: false,
+        updated_at: Date.now(),
+      });
+    } else {
+      await ctx.db.patch(args.touch_id, {
+        draft_body: chosen.body,
+        generate_at_fire_time: false,
+        updated_at: Date.now(),
+      });
+    }
+
+    // Schedule immediate fire through the standard pipeline.
+    const fireAt = Date.now() + 5 * 60 * 1000; // 5 min buffer for active-hours check
+    await ctx.db.patch(args.touch_id, { scheduled_for: fireAt, updated_at: Date.now() });
+    await ctx.scheduler.runAfter(5 * 60 * 1000, internal.touches.fireOne, {
+      touch_id: args.touch_id,
+    });
+    return { committed: true, chosen_kind: args.chosen_kind };
+  },
+});
+
+// ---------------------------------------------------------------------------
 // cancelForPerson — when she replies / state shifts, cancel pending touches
 // of certain types (we don't want to nudge her 5 minutes after she replied).
 // ---------------------------------------------------------------------------
@@ -379,6 +499,28 @@ export const fireOne = internalAction({
         touch_id: args.touch_id,
         body_shape: bodyShape,
       });
+    }
+
+    // -----------------------------------------------------------------------
+    // AI-9500 #6 — post_date_calibration special handling.
+    //
+    // Instead of immediately enqueueing a send job, we generate 3 candidate
+    // drafts and park the touch for operator review. The touch STAYS in
+    // "scheduled" status — it is NOT marked fired yet. The autoPick6hCron
+    // will auto-fire after 6h if the operator hasn't chosen.
+    // -----------------------------------------------------------------------
+    if (touch.type === "post_date_calibration") {
+      const candidates = await ctx.runAction(internal.touches._draft3PostDateCandidates, {
+        user_id: touch.user_id,
+        person_id: touch.person_id,
+        date_notes_text: touch.date_notes_text,
+      });
+      await ctx.runMutation(internal.touches._setPostDateCandidates, {
+        touch_id: args.touch_id,
+        candidates,
+      });
+      // Do NOT mark as fired — leave in "scheduled" so operator can pick.
+      return { parked_for_choice: true, type: touch.type, candidates };
     }
 
     // Enqueue an agent_jobs row for the Mac Mini daemon to actually send.
@@ -581,6 +723,218 @@ export const listForPerson = query({
       .order("desc")
       .take(Math.min(args.limit ?? 50, 200));
     return rows;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// AI-9500 #6 — _draft3PostDateCandidates (internalAction)
+//
+// Given person context and operator date notes, call the LLM to produce 3
+// candidate follow-up messages:
+//   "callback" — references a specific moment from date_notes_text (3x conversion)
+//   "photo"    — frame around sharing a photo from the date or the day
+//   "generic"  — warm, non-pressuring thanks / light callback
+//
+// Returns the 3 candidates as an array. fireOne writes them to candidate_drafts.
+// ---------------------------------------------------------------------------
+export const _draft3PostDateCandidates = internalAction({
+  args: {
+    user_id: v.string(),
+    person_id: v.id("people"),
+    date_notes_text: v.optional(v.string()),
+  },
+  handler: async (ctx, args): Promise<Array<{ kind: string; body: string; reasoning: string }>> => {
+    // Fetch person context for personalization.
+    const person = await ctx.runQuery(internal.touches._getPerson, { person_id: args.person_id });
+    const name = person?.display_name ?? "her";
+    const references = person?.references_to_callback ?? [];
+    const thingsSheLoves = person?.things_she_loves ?? [];
+    const notes = args.date_notes_text ?? "";
+
+    const systemPrompt = `You are a dating-coach AI helping a man craft the perfect post-date follow-up text.
+Your job is to generate 3 distinct candidate messages for after a first date.
+You MUST return ONLY valid JSON with no other text: an array of 3 objects each with keys "kind", "body", and "reasoning".
+
+Rules:
+- "body" is the actual text message to send (short, casual, no emojis overload, sounds like a real human)
+- Messages should be warm but not needy, specific but not overwhelming
+- The "callback" kind MUST reference a specific moment or detail from the date notes if available
+- The "photo" kind should naturally invite sharing a photo moment from the date/day
+- The "generic" kind is a warm, low-pressure message that works even with minimal notes
+- Keep all bodies under 120 characters — these are texts, not essays`;
+
+    const userPrompt = `Her name: ${name}
+Date notes from operator: ${notes || "No specific notes provided."}
+Known things she loves: ${thingsSheLoves.slice(0, 5).join(", ") || "unknown"}
+Past callback references we've used: ${references.slice(0, 3).join(", ") || "none"}
+
+Generate the 3 candidate follow-up texts now. Return JSON array only.
+Example format:
+[
+  {"kind":"callback","body":"Had to laugh thinking about the thing with the [specific moment]...","reasoning":"References the specific moment she animated about — 3x conversion vs generic"},
+  {"kind":"photo","body":"Still thinking about [location] — you should send me that photo you took","reasoning":"Creates a natural excuse for continued interaction via photo sharing"},
+  {"kind":"generic","body":"[Name] — tonight was actually really fun. Let's do it again soon","reasoning":"Safe fallback — warm without pressure, leaves ball in her court"}
+]`;
+
+    // Call the LLM via the same cascade used elsewhere in enrichment.ts
+    const gemKey = process.env.GEMINI_API_KEY;
+    const dsKey = process.env.DEEPSEEK_API_KEY;
+    const grokKey = process.env.XAI_API_KEY;
+
+    let result: any = null;
+
+    async function tryGeminiLocal(key: string): Promise<any> {
+      const model = process.env.CC_VIBE_MODEL_GEMINI ?? "gemini-2.0-flash";
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${key}`;
+      try {
+        const r = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            contents: [{ parts: [{ text: `${systemPrompt}\n\n${userPrompt}` }] }],
+            generationConfig: { responseMimeType: "application/json", temperature: 0.7, maxOutputTokens: 400 },
+          }),
+        });
+        if (!r.ok) return null;
+        const j: any = await r.json();
+        const text = j?.candidates?.[0]?.content?.parts?.[0]?.text;
+        if (!text) return null;
+        return JSON.parse(text);
+      } catch { return null; }
+    }
+
+    async function tryOpenAICompatLocal(url: string, key: string, model: string): Promise<any> {
+      try {
+        const r = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: `Bearer ${key}` },
+          body: JSON.stringify({
+            model,
+            messages: [
+              { role: "system", content: systemPrompt },
+              { role: "user", content: userPrompt },
+            ],
+            temperature: 0.7,
+            max_tokens: 400,
+          }),
+        });
+        if (!r.ok) return null;
+        const j: any = await r.json();
+        const text = j?.choices?.[0]?.message?.content;
+        if (!text) return null;
+        // Strip markdown code fences if present
+        const clean = text.replace(/```json\s*/gi, "").replace(/```\s*/g, "").trim();
+        return JSON.parse(clean);
+      } catch { return null; }
+    }
+
+    if (gemKey) result = await tryGeminiLocal(gemKey);
+    if (!result && dsKey) result = await tryOpenAICompatLocal("https://api.deepseek.com/chat/completions", dsKey, "deepseek-chat");
+    if (!result && grokKey) result = await tryOpenAICompatLocal("https://api.x.ai/v1/chat/completions", grokKey, "grok-2-latest");
+
+    // Validate: must be array of 3 objects with kind + body.
+    if (Array.isArray(result) && result.length >= 1 && result[0]?.kind && result[0]?.body) {
+      return result.slice(0, 3).map((c: any) => ({
+        kind: String(c.kind),
+        body: String(c.body).slice(0, 200),
+        reasoning: String(c.reasoning ?? "").slice(0, 300),
+      }));
+    }
+
+    // LLM failed — return safe fallbacks so the feature still works.
+    console.warn(`_draft3PostDateCandidates: LLM failed for person ${args.person_id}, using fallbacks`);
+    const fallbackName = name.split(" ")[0];
+    return [
+      {
+        kind: "callback",
+        body: notes
+          ? `Was just thinking about ${notes.slice(0, 40).split(".")[0].toLowerCase()}... good times`
+          : `${fallbackName} — I keep thinking about tonight. Really good time.`,
+        reasoning: "Fallback callback — references notes if available",
+      },
+      {
+        kind: "photo",
+        body: `Still smiling from tonight. You should send me that pic if you grabbed one`,
+        reasoning: "Fallback photo invite — natural excuse for continued contact",
+      },
+      {
+        kind: "generic",
+        body: `${fallbackName} — tonight was genuinely fun. Let's do this again`,
+        reasoning: "Fallback generic — warm, no pressure, open door",
+      },
+    ];
+  },
+});
+
+// ---------------------------------------------------------------------------
+// AI-9500 #6 — _setPostDateCandidates (internalMutation)
+// Writes the 3 candidate drafts to the touch row.
+// ---------------------------------------------------------------------------
+export const _setPostDateCandidates = internalMutation({
+  args: {
+    touch_id: v.id("scheduled_touches"),
+    candidates: v.array(v.object({
+      kind: v.string(),
+      body: v.string(),
+      reasoning: v.string(),
+    })),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.touch_id, {
+      candidate_drafts: args.candidates,
+      updated_at: Date.now(),
+    });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// AI-9500 #6 — autoPick6hCron (internalMutation)
+//
+// Called by a 1h-interval cron. Scans for post_date_calibration touches with
+// candidate_drafts set but no choice committed after 6h. Auto-picks "callback"
+// (the highest-converting kind) and fires via the standard pipeline.
+// ---------------------------------------------------------------------------
+export const autoPick6hCron = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const sixHoursAgo = now - 6 * 60 * 60 * 1000;
+
+    // Find post_date_calibration touches still in "scheduled" with candidates
+    // but updated (candidates generated) more than 6h ago.
+    const candidates = await ctx.db
+      .query("scheduled_touches")
+      .withIndex("by_due", (q) => q.eq("status", "scheduled").lte("scheduled_for", now + 18 * 60 * 60 * 1000))
+      .filter((q) => q.eq(q.field("type"), "post_date_calibration"))
+      .collect();
+
+    let autoPicked = 0;
+    for (const touch of candidates) {
+      if (!touch.candidate_drafts?.length) continue;
+      // Only auto-pick if touch was scheduled and candidates have been set for 6+ hours.
+      // We use updated_at as the proxy for when candidates were written.
+      if (touch.updated_at > sixHoursAgo) continue;
+      // Already has a draft_body = operator chose. Skip.
+      if (touch.draft_body) continue;
+
+      // Auto-pick "callback" — the highest-converting kind.
+      const callbackCandidate = touch.candidate_drafts.find((c) => c.kind === "callback");
+      const chosen = callbackCandidate ?? touch.candidate_drafts[0];
+
+      const fireAt = now + 5 * 60 * 1000;
+      await ctx.db.patch(touch._id, {
+        draft_body: chosen.body,
+        generate_at_fire_time: false,
+        scheduled_for: fireAt,
+        updated_at: now,
+      });
+      await ctx.scheduler.runAfter(5 * 60 * 1000, internal.touches.fireOne, {
+        touch_id: touch._id,
+      });
+      autoPicked++;
+    }
+
+    return { scanned: candidates.length, auto_picked: autoPicked };
   },
 });
 


### PR DESCRIPTION
## Summary
- After a date, operator calls `markDateDone` from the dossier **Schedule tab** (with optional `date_notes_text` capturing specific moments). This schedules a `post_date_calibration` touch +18h later.
- When `fireOne` runs at that time, it calls `_draft3PostDateCandidates` (Gemini → DeepSeek → Grok cascade) to generate 3 candidates: **callback** (references a specific moment — 3x 2nd-date conversion rate), **photo** (natural photo-share invite), **generic** (warm low-pressure fallback). Touch stays in `scheduled` status — not auto-fired.
- Dashboard shows all 3 as side-by-side cards with a "Use this" button. `commitPostDateChoice` copies the chosen body and fires through the standard pipeline (active-hours / anti-loop still apply).
- `autoPick6hCron` (1h interval) auto-picks "callback" if operator hasn't chosen within 6h.

## Schema fields used (already deployed in AI-9500-F)
`date_done_at`, `date_notes_text`, `candidate_drafts`, `post_date_calibration` (type union)

## Files changed
- `web/convex/touches.ts` — markDateDone, commitPostDateChoice, _draft3PostDateCandidates, _setPostDateCandidates, autoPick6hCron, fireOne branch for post_date_calibration
- `web/convex/crons.ts` — 1h interval cron
- `web/app/admin/clapcheeks-ops/people/[id]/page.tsx` — ScheduleTab with "Mark date done" form + 3-candidate picker

## Test plan
- [x] `npx convex deploy` passes TypeScript (clean deploy)
- [x] `markDateDone` creates a `post_date_calibration` touch ~18h out with `date_notes_text` attached
- [x] Touch appears in `listUpcoming` with status=scheduled
- [x] `cancelOne` cleanup confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)