### PR TITLE
feat(clapcheeks): AI-9500 #7 self-coaching dashboard

### DIFF
--- a/web/app/admin/clapcheeks-ops/coach/page.tsx
+++ b/web/app/admin/clapcheeks-ops/coach/page.tsx
@@ -1,0 +1,500 @@
+/**
+ * AI-9500 #7 — Self-coaching dashboard.
+ *
+ * Shows Julian his own patterns across 60+ active threads:
+ *   - Dashboard summary (KPIs)
+ *   - Over-pursue list (who he's out-investing)
+ *   - Late-night conversion (sends after 11pm vs daytime)
+ *   - Same-opener overuse (repetitive first messages)
+ *   - Cut-list candidates (high effort, low return)
+ *   - Stuck-in-stage warnings (>14d in matched/early_chat)
+ *   - Time-of-day heatmap (7×24 grid)
+ *
+ * Each card has 1 actionable sentence.
+ */
+"use client"
+
+import { useQuery } from "convex/react"
+import { api } from "@/convex/_generated/api"
+import Link from "next/link"
+
+const FLEET_USER_ID = "fleet-julian"
+
+const DOW_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+function formatHour(h: number): string {
+  if (h === 0) return "12am"
+  if (h < 12) return `${h}am`
+  if (h === 12) return "12pm"
+  return `${h - 12}pm`
+}
+
+function daysAgo(ms: number | undefined): string {
+  if (!ms) return "never"
+  const d = Math.floor((Date.now() - ms) / (24 * 60 * 60 * 1000))
+  if (d === 0) return "today"
+  if (d === 1) return "yesterday"
+  return `${d}d ago`
+}
+
+// ---------------------------------------------------------------------------
+// Top summary KPI bar
+// ---------------------------------------------------------------------------
+function SummaryCard({ summary }: { summary: any }) {
+  if (!summary) return <div className="text-sm text-gray-500">Loading summary…</div>
+
+  const kpis = [
+    { label: "Active threads", value: summary.active_threads },
+    { label: "Dates this week", value: summary.dates_this_week },
+    {
+      label: "Ghost rate (30d)",
+      value: `${Math.round(summary.ghost_rate_this_month * 100)}%`,
+      warn: summary.ghost_rate_this_month > 0.25,
+    },
+    {
+      label: "Avg reply rate",
+      value: `${Math.round(summary.avg_reply_rate * 100)}%`,
+      warn: summary.avg_reply_rate < 0.3,
+    },
+    { label: "Kissed (notes)", value: summary.kissed_this_month },
+    { label: "Closed (notes)", value: summary.slept_with_this_month },
+  ]
+
+  return (
+    <div className="grid grid-cols-3 md:grid-cols-6 gap-3 mb-8">
+      {kpis.map((kpi) => (
+        <div
+          key={kpi.label}
+          className={`bg-gray-900 border rounded-lg p-4 text-center ${
+            kpi.warn ? "border-amber-700" : "border-gray-800"
+          }`}
+        >
+          <div className="text-2xl font-bold">{kpi.value ?? "—"}</div>
+          <div className="text-xs text-gray-400 mt-1">{kpi.label}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Over-pursue card
+// ---------------------------------------------------------------------------
+function OverPursueCard({ data }: { data: any[] | undefined }) {
+  if (!data) return <CardShell title="Over-pursue list" loading />
+  if (data.length === 0)
+    return (
+      <CardShell title="Over-pursue list" action="No over-pursuing detected this month — nice.">
+        <p className="text-sm text-gray-500">All active threads are balanced.</p>
+      </CardShell>
+    )
+
+  const top = data[0]
+  return (
+    <CardShell
+      title="Over-pursue list"
+      action={`Pull back on ${top.display_name} — you're sending ${top.ratio}x her word volume.`}
+    >
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-gray-500 border-b border-gray-800">
+            <th className="pb-2">Name</th>
+            <th className="pb-2 text-right">Your words</th>
+            <th className="pb-2 text-right">Her words</th>
+            <th className="pb-2 text-right">Ratio</th>
+            <th className="pb-2 text-right">Her last msg</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-800">
+          {data.map((p: any) => (
+            <tr key={p.person_id}>
+              <td className="py-2">
+                <Link
+                  href={`/admin/clapcheeks-ops/people/${p.person_id}`}
+                  className="text-blue-400 hover:underline"
+                >
+                  {p.display_name}
+                </Link>
+              </td>
+              <td className="py-2 text-right">{p.outbound_words}</td>
+              <td className="py-2 text-right">{p.inbound_words}</td>
+              <td className={`py-2 text-right font-bold ${p.ratio > 5 ? "text-red-400" : "text-amber-400"}`}>
+                {p.ratio}×
+              </td>
+              <td className="py-2 text-right text-gray-500">{daysAgo(p.last_inbound_at)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </CardShell>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Late-night conversion card
+// ---------------------------------------------------------------------------
+function LateNightCard({ data }: { data: any[] | undefined }) {
+  if (!data) return <CardShell title="Late-night conversion" loading />
+
+  // Find late-night (11pm–2am) vs prime-time (6pm–10pm) conversion
+  const lateNight = data.filter((d: any) => d.hour >= 23 || d.hour <= 2)
+  const primeTime = data.filter((d: any) => d.hour >= 18 && d.hour <= 22)
+
+  const avgLate =
+    lateNight.length === 0
+      ? 0
+      : lateNight.reduce((acc: number, d: any) => acc + d.conversion_rate, 0) /
+        lateNight.length
+  const avgPrime =
+    primeTime.length === 0
+      ? 0
+      : primeTime.reduce((acc: number, d: any) => acc + d.conversion_rate, 0) /
+        primeTime.length
+
+  const diff = avgLate - avgPrime
+  const action =
+    lateNight.reduce((acc: number, d: any) => acc + d.sends, 0) === 0
+      ? "No late-night sends this month."
+      : diff < -0.1
+      ? `Your late-night sends convert ${Math.round(Math.abs(diff) * 100)}% worse than evening — stop sending after 11pm.`
+      : diff > 0.05
+      ? `Late-night sends actually convert ${Math.round(diff * 100)}% better — unusual, keep it.`
+      : "Late-night conversion is similar to evening — timing isn't your issue."
+
+  // Show top 6 by sends
+  const sorted = [...data].sort((a: any, b: any) => b.sends - a.sends).slice(0, 12)
+  const maxSends = Math.max(...sorted.map((d: any) => d.sends), 1)
+
+  return (
+    <CardShell title="Late-night conversion" action={action}>
+      <div className="mt-3 space-y-1">
+        {sorted.map((d: any) => (
+          <div key={d.hour} className="flex items-center gap-2 text-sm">
+            <span className="w-10 text-gray-400 text-right">{formatHour(d.hour)}</span>
+            <div className="flex-1 bg-gray-800 rounded-full h-2 relative">
+              <div
+                className={`absolute inset-y-0 left-0 rounded-full ${
+                  d.hour >= 23 || d.hour <= 2 ? "bg-red-500" : "bg-blue-500"
+                }`}
+                style={{ width: `${(d.sends / maxSends) * 100}%` }}
+              />
+              <div
+                className="absolute inset-y-0 left-0 rounded-full bg-green-500 opacity-60"
+                style={{ width: `${(d.replies / maxSends) * 100}%` }}
+              />
+            </div>
+            <span className="w-8 text-gray-400 text-right">{d.sends}</span>
+            <span className="w-12 text-right text-xs text-gray-500">
+              {Math.round(d.conversion_rate * 100)}%
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-4 mt-3 text-xs text-gray-500">
+        <span><span className="inline-block w-3 h-3 rounded-full bg-blue-500 mr-1" />Prime sends</span>
+        <span><span className="inline-block w-3 h-3 rounded-full bg-red-500 mr-1" />Late-night sends</span>
+        <span><span className="inline-block w-3 h-3 rounded-full bg-green-500 opacity-60 mr-1" />Replies</span>
+      </div>
+    </CardShell>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Same-opener overuse card
+// ---------------------------------------------------------------------------
+function OpenerOveruseCard({ data }: { data: any[] | undefined }) {
+  if (!data) return <CardShell title="Opener overuse" loading />
+  if (data.length === 0)
+    return (
+      <CardShell title="Opener overuse" action="Good variety — no opener is overused (3+ uses).">
+        <p className="text-sm text-gray-500">No repeated openers detected this month.</p>
+      </CardShell>
+    )
+
+  const top = data[0]
+  const action = `"${top.preview}…" used ${top.count}× with ${Math.round(top.reply_rate * 100)}% reply rate — rotate your opener.`
+
+  return (
+    <CardShell title="Opener overuse" action={action}>
+      <table className="w-full text-sm mt-2">
+        <thead>
+          <tr className="text-left text-gray-500 border-b border-gray-800">
+            <th className="pb-2">Opener (first 50 chars)</th>
+            <th className="pb-2 text-right">Uses</th>
+            <th className="pb-2 text-right">Reply rate</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-800">
+          {data.map((g: any, i: number) => (
+            <tr key={i}>
+              <td className="py-2 text-gray-300 truncate max-w-xs">
+                {g.preview}…
+              </td>
+              <td className="py-2 text-right">{g.count}</td>
+              <td className={`py-2 text-right ${g.reply_rate < 0.3 ? "text-red-400" : "text-green-400"}`}>
+                {Math.round(g.reply_rate * 100)}%
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </CardShell>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Cut-list candidates card
+// ---------------------------------------------------------------------------
+function CutListCard({ data }: { data: any[] | undefined }) {
+  if (!data) return <CardShell title="Cut list" loading />
+  if (data.length === 0)
+    return (
+      <CardShell title="Cut list" action="No obvious cut candidates — ROI looks balanced.">
+        <p className="text-sm text-gray-500">No one meets the cut criteria (high effort, low hotness, low reciprocity).</p>
+      </CardShell>
+    )
+
+  const top = data[0]
+  const action = `Stop putting energy into ${top.display_name} — effort=${top.effort_rating}/5, hotness=${top.hotness_rating ?? "?"}/10, she's at ${Math.round(top.her_word_ratio * 100)}% reciprocity.`
+
+  return (
+    <CardShell title="Cut list" action={action}>
+      <table className="w-full text-sm mt-2">
+        <thead>
+          <tr className="text-left text-gray-500 border-b border-gray-800">
+            <th className="pb-2">Name</th>
+            <th className="pb-2 text-right">Effort</th>
+            <th className="pb-2 text-right">Hotness</th>
+            <th className="pb-2 text-right">Her reciprocity</th>
+            <th className="pb-2 text-right">Last heard</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-800">
+          {data.map((p: any) => (
+            <tr key={p.person_id}>
+              <td className="py-2">
+                <Link
+                  href={`/admin/clapcheeks-ops/people/${p.person_id}`}
+                  className="text-blue-400 hover:underline"
+                >
+                  {p.display_name}
+                </Link>
+              </td>
+              <td className="py-2 text-right text-amber-400">{p.effort_rating}/5</td>
+              <td className="py-2 text-right">{p.hotness_rating ?? "—"}/10</td>
+              <td className="py-2 text-right text-red-400">{Math.round(p.her_word_ratio * 100)}%</td>
+              <td className="py-2 text-right text-gray-500">{daysAgo(p.last_inbound_at)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </CardShell>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Stuck-in-stage card
+// ---------------------------------------------------------------------------
+function StuckInStageCard({ data }: { data: any[] | undefined }) {
+  if (!data) return <CardShell title="Stuck in stage" loading />
+  if (data.length === 0)
+    return (
+      <CardShell title="Stuck in stage" action="No one stuck for 14+ days — momentum looks good.">
+        <p className="text-sm text-gray-500">No matched/early_chat threads older than 14 days.</p>
+      </CardShell>
+    )
+
+  const top = data[0]
+  const action = `${top.display_name} has been in "${top.courtship_stage}" for ${top.days_in_stage} days — move forward or move on.`
+
+  return (
+    <CardShell title="Stuck in stage" action={action}>
+      <table className="w-full text-sm mt-2">
+        <thead>
+          <tr className="text-left text-gray-500 border-b border-gray-800">
+            <th className="pb-2">Name</th>
+            <th className="pb-2">Stage</th>
+            <th className="pb-2 text-right">Days stuck</th>
+            <th className="pb-2 text-right">Last heard</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-800">
+          {data.map((p: any) => (
+            <tr key={p.person_id}>
+              <td className="py-2">
+                <Link
+                  href={`/admin/clapcheeks-ops/people/${p.person_id}`}
+                  className="text-blue-400 hover:underline"
+                >
+                  {p.display_name}
+                </Link>
+              </td>
+              <td className="py-2 text-gray-400">{p.courtship_stage}</td>
+              <td className={`py-2 text-right font-bold ${p.days_in_stage > 30 ? "text-red-400" : "text-amber-400"}`}>
+                {p.days_in_stage}d
+              </td>
+              <td className="py-2 text-right text-gray-500">{daysAgo(p.last_inbound_at)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </CardShell>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Time-of-day heatmap card
+// ---------------------------------------------------------------------------
+function HeatmapCard({ data }: { data: any[] | undefined }) {
+  if (!data) return <CardShell title="Send heatmap" loading />
+
+  // Build 7×24 grid
+  const grid: Record<string, { sends: number; replies: number; conversion_rate: number }> = {}
+  for (const cell of data) {
+    grid[`${cell.dow}:${cell.hour}`] = cell
+  }
+
+  const maxSends = Math.max(...data.map((d: any) => d.sends), 1)
+
+  // Find best and worst hours
+  const withSends = data.filter((d: any) => d.sends >= 3)
+  const best = withSends.sort((a: any, b: any) => b.conversion_rate - a.conversion_rate)[0]
+  const worst = withSends.sort((a: any, b: any) => a.conversion_rate - b.conversion_rate)[0]
+
+  const action =
+    best
+      ? `Best send window: ${DOW_LABELS[best.dow]} ${formatHour(best.hour)} (${Math.round(best.conversion_rate * 100)}% reply rate). Worst: ${worst ? DOW_LABELS[worst.dow] + " " + formatHour(worst.hour) : "—"}.`
+      : "Not enough data yet — need 3+ sends per slot."
+
+  // Show hours 7am-2am (7-26) for readability
+  const SHOW_HOURS = Array.from({ length: 20 }, (_, i) => (i + 7) % 24)
+
+  return (
+    <CardShell title="Send heatmap (7d × 24h)" action={action}>
+      <div className="mt-3 overflow-x-auto">
+        <table className="text-xs border-collapse">
+          <thead>
+            <tr>
+              <th className="w-8" />
+              {DOW_LABELS.map((d) => (
+                <th key={d} className="px-1 text-gray-500 font-normal pb-1">
+                  {d}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {SHOW_HOURS.map((hour) => (
+              <tr key={hour}>
+                <td className="text-gray-500 pr-2 text-right w-10">
+                  {formatHour(hour)}
+                </td>
+                {Array.from({ length: 7 }, (_, dow) => {
+                  const cell = grid[`${dow}:${hour}`]
+                  const intensity = cell ? cell.sends / maxSends : 0
+                  const rate = cell ? cell.conversion_rate : 0
+                  const bg =
+                    !cell
+                      ? "bg-gray-900"
+                      : rate > 0.5
+                      ? "bg-green-700"
+                      : rate > 0.25
+                      ? "bg-blue-700"
+                      : "bg-gray-700"
+                  return (
+                    <td key={dow} className="px-0.5 py-0.5">
+                      <div
+                        title={cell ? `${cell.sends} sends, ${Math.round(rate * 100)}% replied` : "no sends"}
+                        className={`w-7 h-5 rounded-sm ${bg} flex items-center justify-center text-gray-300`}
+                        style={{ opacity: cell ? 0.3 + intensity * 0.7 : 0.2 }}
+                      >
+                        {cell ? cell.sends : ""}
+                      </div>
+                    </td>
+                  )
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="flex gap-4 mt-2 text-xs text-gray-500">
+          <span><span className="inline-block w-3 h-3 rounded-sm bg-green-700 mr-1" />&gt;50% reply</span>
+          <span><span className="inline-block w-3 h-3 rounded-sm bg-blue-700 mr-1" />25–50%</span>
+          <span><span className="inline-block w-3 h-3 rounded-sm bg-gray-700 mr-1" />&lt;25%</span>
+        </div>
+      </div>
+    </CardShell>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Shell component for all cards
+// ---------------------------------------------------------------------------
+function CardShell({
+  title,
+  action,
+  loading,
+  children,
+}: {
+  title: string
+  action?: string
+  loading?: boolean
+  children?: React.ReactNode
+}) {
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl p-5">
+      <h2 className="text-lg font-semibold mb-1">{title}</h2>
+      {loading && <div className="text-sm text-gray-500">Loading…</div>}
+      {action && (
+        <p className="text-sm text-amber-400 bg-amber-950 border border-amber-800 rounded-lg px-3 py-2 mb-4">
+          {action}
+        </p>
+      )}
+      {children}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+export default function CoachPage() {
+  const summary = useQuery(api.coach.getDashboardSummary, { user_id: FLEET_USER_ID })
+  const overPursue = useQuery(api.coach.getOverPursueList, { user_id: FLEET_USER_ID })
+  const lateNight = useQuery(api.coach.getLateNightConversion, { user_id: FLEET_USER_ID })
+  const openerOveruse = useQuery(api.coach.getSameOpenerOveruse, { user_id: FLEET_USER_ID })
+  const cutList = useQuery(api.coach.getCutListCandidates, { user_id: FLEET_USER_ID })
+  const stuckInStage = useQuery(api.coach.getStuckInStage, { user_id: FLEET_USER_ID })
+  const heatmap = useQuery(api.coach.getTimeOfDayHeatmap, { user_id: FLEET_USER_ID })
+
+  return (
+    <div className="p-8 max-w-7xl">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-2">
+        <h1 className="text-3xl font-bold">Self-Coaching Dashboard</h1>
+        <Link
+          href="/admin/clapcheeks-ops"
+          className="text-sm text-gray-400 hover:text-gray-200"
+        >
+          ← Ops overview
+        </Link>
+      </div>
+      <p className="text-gray-400 mb-8">
+        Your patterns across all active threads — last 30 days. Each card has one thing to do.
+      </p>
+
+      {/* KPI Summary */}
+      <SummaryCard summary={summary} />
+
+      {/* 2-column grid for the cards */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <OverPursueCard data={overPursue} />
+        <CutListCard data={cutList} />
+        <StuckInStageCard data={stuckInStage} />
+        <OpenerOveruseCard data={openerOveruse} />
+        <LateNightCard data={lateNight} />
+        <HeatmapCard data={heatmap} />
+      </div>
+    </div>
+  )
+}

--- a/web/app/admin/clapcheeks-ops/page.tsx
+++ b/web/app/admin/clapcheeks-ops/page.tsx
@@ -32,6 +32,21 @@ export default function ClapcheeksOpsOverview() {
         Your dating co-pilot — live state, ranked surfaces, one-tap controls.
       </p>
 
+      {/* AI-9500 #7 — Self-coaching nav card */}
+      <Link href="/admin/clapcheeks-ops/coach"
+            className="block mb-6 bg-gradient-to-r from-purple-950 to-gray-900 border border-purple-800 rounded-xl p-5 hover:border-purple-600 transition">
+        <div className="flex items-center gap-3">
+          <span className="text-2xl">🧠</span>
+          <div>
+            <div className="font-bold text-lg text-white">Self-coaching dashboard</div>
+            <div className="text-sm text-purple-300">
+              See your patterns — over-pursue, late-night sends, opener overuse, cut list, stuck threads, heatmap
+            </div>
+          </div>
+          <span className="ml-auto text-purple-400 text-xl">→</span>
+        </div>
+      </Link>
+
       <div className="grid grid-cols-2 gap-4 mb-8">
         <Card title="Pending media for approval"
               value={pendingMedia?.length ?? "—"}

--- a/web/convex/_generated/api.d.ts
+++ b/web/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as agent_jobs from "../agent_jobs.js";
 import type * as backfill from "../backfill.js";
 import type * as calendar from "../calendar.js";
+import type * as coach from "../coach.js";
 import type * as conversations from "../conversations.js";
 import type * as crons from "../crons.js";
 import type * as digest from "../digest.js";
@@ -35,6 +36,7 @@ declare const fullApi: ApiFromModules<{
   agent_jobs: typeof agent_jobs;
   backfill: typeof backfill;
   calendar: typeof calendar;
+  coach: typeof coach;
   conversations: typeof conversations;
   crons: typeof crons;
   digest: typeof digest;

--- a/web/convex/coach.ts
+++ b/web/convex/coach.ts
@@ -1,0 +1,542 @@
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+// AI-9500 #7 — Self-coaching dashboard.
+//
+// All queries are read-only aggregations over messages + people + scheduled_touches.
+// Designed for /admin/clapcheeks-ops/coach which shows Julian his own patterns
+// and one actionable sentence per card.
+//
+// Every query takes user_id and operates over the last 30 days unless noted.
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+const FOURTEEN_DAYS_MS = 14 * 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// getOverPursueList
+//
+// For each active person with messages in the last 30d, compute:
+//   outbound_words / inbound_words ratio (proxy for "over-investment").
+// Returns top 10 where ratio > 2.5, sorted descending.
+//
+// Logic: pull all messages by conversation → count words per direction.
+// ---------------------------------------------------------------------------
+export const getOverPursueList = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, { user_id }) => {
+    const cutoff = Date.now() - THIRTY_DAYS_MS;
+
+    // Get all active/paused/dating people for this user
+    const people = await ctx.db
+      .query("people")
+      .withIndex("by_user_status", (q) => q.eq("user_id", user_id).eq("status", "active"))
+      .collect();
+
+    const results: Array<{
+      person_id: string;
+      display_name: string;
+      courtship_stage: string | undefined;
+      outbound_words: number;
+      inbound_words: number;
+      ratio: number;
+      last_inbound_at: number | undefined;
+    }> = [];
+
+    // Limit to first 100 active people to stay within Convex read limits.
+    // (260 active people × N messages each can exceed 16MB; 100 is safe.)
+    const peopleSample = people.slice(0, 100);
+
+    for (const person of peopleSample) {
+      // Use by_person_recent index (person_id, sent_at) — properly indexed per person.
+      const personMessages = await ctx.db
+        .query("messages")
+        .withIndex("by_person_recent", (q) =>
+          q.eq("person_id", person._id).gt("sent_at", cutoff)
+        )
+        .take(200); // cap per person
+
+      const outboundMessages = personMessages.filter((m) => m.direction === "outbound");
+      const inboundMessages = personMessages.filter((m) => m.direction === "inbound");
+
+      if (outboundMessages.length === 0 && inboundMessages.length === 0) continue;
+
+      const outboundWords = outboundMessages.reduce(
+        (acc, m) => acc + (m.body?.split(/\s+/).filter(Boolean).length ?? 0),
+        0
+      );
+      const inboundWords = inboundMessages.reduce(
+        (acc, m) => acc + (m.body?.split(/\s+/).filter(Boolean).length ?? 0),
+        0
+      );
+
+      // Skip if no outbound activity
+      if (outboundWords === 0) continue;
+
+      // Avoid div/0: if she has sent nothing, ratio = outboundWords (effectively infinite)
+      const ratio = inboundWords === 0 ? outboundWords : outboundWords / inboundWords;
+
+      if (ratio > 2.5) {
+        results.push({
+          person_id: person._id,
+          display_name: person.display_name,
+          courtship_stage: person.courtship_stage,
+          outbound_words: outboundWords,
+          inbound_words: inboundWords,
+          ratio: Math.round(ratio * 10) / 10,
+          last_inbound_at: person.last_inbound_at,
+        });
+      }
+    }
+
+    return results
+      .sort((a, b) => b.ratio - a.ratio)
+      .slice(0, 10);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// getLateNightConversion
+//
+// Your outbound sends bucketed by hour-of-day (0-23, local UTC-7 approximation).
+// For each hour: total sends + how many got a reply within 24h.
+// Returns array of { hour, sends, replies, conversion_rate }.
+// Limited to 2000 outbound + 2000 inbound messages (30-day window, most recent first).
+// ---------------------------------------------------------------------------
+export const getLateNightConversion = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, { user_id }) => {
+    const cutoff = Date.now() - THIRTY_DAYS_MS;
+    const MSG_LIMIT = 2000;
+
+    const outboundMessages = await ctx.db
+      .query("messages")
+      .withIndex("by_user_recent", (q) =>
+        q.eq("user_id", user_id).gt("sent_at", cutoff)
+      )
+      .filter((q) => q.eq(q.field("direction"), "outbound"))
+      .order("desc")
+      .take(MSG_LIMIT);
+
+    // Build map of conversation_id -> sorted inbound sent_at timestamps
+    const convInboundTimes: Record<string, number[]> = {};
+    const inboundMessages = await ctx.db
+      .query("messages")
+      .withIndex("by_user_recent", (q) =>
+        q.eq("user_id", user_id).gt("sent_at", cutoff)
+      )
+      .filter((q) => q.eq(q.field("direction"), "inbound"))
+      .order("desc")
+      .take(MSG_LIMIT);
+
+    for (const msg of inboundMessages) {
+      const cid = msg.conversation_id;
+      if (!convInboundTimes[cid]) convInboundTimes[cid] = [];
+      convInboundTimes[cid].push(msg.sent_at);
+    }
+
+    // Hour buckets (adjust for Pacific time UTC-7 heuristic)
+    const UTC_OFFSET_HOURS = -7;
+    const buckets = Array.from({ length: 24 }, (_, h) => ({
+      hour: h,
+      sends: 0,
+      replies: 0,
+    }));
+
+    const TWENTY_FOUR_H_MS = 24 * 60 * 60 * 1000;
+
+    for (const msg of outboundMessages) {
+      // Convert UTC ms to local hour
+      const localHour = ((new Date(msg.sent_at).getUTCHours() + UTC_OFFSET_HOURS + 24) % 24);
+      buckets[localHour].sends++;
+
+      // Check if any inbound came within 24h on the same conversation
+      const inbounds = convInboundTimes[msg.conversation_id] ?? [];
+      const gotReply = inbounds.some(
+        (t) => t > msg.sent_at && t <= msg.sent_at + TWENTY_FOUR_H_MS
+      );
+      if (gotReply) buckets[localHour].replies++;
+    }
+
+    return buckets.map((b) => ({
+      ...b,
+      conversion_rate:
+        b.sends === 0 ? 0 : Math.round((b.replies / b.sends) * 100) / 100,
+    }));
+  },
+});
+
+// ---------------------------------------------------------------------------
+// getSameOpenerOveruse
+//
+// Group your outbound messages (first message in each conversation) by the
+// first 50 chars. Return groups where count >= 3, with reply-rate per group.
+//
+// "First message" = lowest sent_at outbound per conversation.
+// ---------------------------------------------------------------------------
+export const getSameOpenerOveruse = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, { user_id }) => {
+    const cutoff = Date.now() - THIRTY_DAYS_MS;
+
+    // Get all conversations for user
+    // Cap at 300 most-recent conversations (by last_message_at desc) to stay within read limits.
+    const allConversations = await ctx.db
+      .query("conversations")
+      .withIndex("by_last_message", (q) => q.eq("user_id", user_id).gt("last_message_at", cutoff))
+      .order("desc")
+      .take(300);
+    const conversations = allConversations;
+
+    // For each conversation, find the first outbound message
+    const openerMap: Record<
+      string,
+      { preview: string; count: number; replied_count: number; conv_ids: string[] }
+    > = {};
+
+    for (const conv of conversations) {
+      // Find earliest outbound
+      const firstOutbound = await ctx.db
+        .query("messages")
+        .withIndex("by_conversation", (q) =>
+          q.eq("conversation_id", conv._id).gt("sent_at", 0)
+        )
+        .filter((q) => q.eq(q.field("direction"), "outbound"))
+        .first(); // index is ordered by sent_at ascending
+
+      if (!firstOutbound) continue;
+      if (firstOutbound.sent_at < cutoff) continue; // only openers from last 30d
+
+      const preview = (firstOutbound.body ?? "").slice(0, 50).trim();
+      if (!preview) continue;
+
+      // Normalize: lowercase + strip punctuation for grouping
+      const key = preview.toLowerCase().replace(/[^a-z0-9\s]/g, "").trim();
+      if (!openerMap[key]) {
+        openerMap[key] = { preview, count: 0, replied_count: 0, conv_ids: [] };
+      }
+      openerMap[key].count++;
+      openerMap[key].conv_ids.push(conv._id as string);
+
+      // Did this conversation get a reply after the opener?
+      const firstReply = await ctx.db
+        .query("messages")
+        .withIndex("by_conversation", (q) =>
+          q.eq("conversation_id", conv._id).gt("sent_at", firstOutbound.sent_at)
+        )
+        .filter((q) => q.eq(q.field("direction"), "inbound"))
+        .first();
+
+      if (firstReply) openerMap[key].replied_count++;
+    }
+
+    return Object.values(openerMap)
+      .filter((g) => g.count >= 3)
+      .map((g) => ({
+        preview: g.preview,
+        count: g.count,
+        reply_rate: Math.round((g.replied_count / g.count) * 100) / 100,
+      }))
+      .sort((a, b) => b.count - a.count);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// getCutListCandidates
+//
+// People where:
+//   effort_rating >= 3 (medium-high effort) AND
+//   hotness_rating <= 4 (low operator interest) AND
+//   her_words / your_words < 0.3 in last 30d (she's barely engaging)
+// Returns top 10, sorted by effort_rating desc.
+// ---------------------------------------------------------------------------
+export const getCutListCandidates = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, { user_id }) => {
+    const cutoff = Date.now() - THIRTY_DAYS_MS;
+
+    const people = await ctx.db
+      .query("people")
+      .withIndex("by_user", (q) => q.eq("user_id", user_id))
+      .filter((q) =>
+        q.and(
+          q.gte(q.field("effort_rating"), 3),
+          q.lte(q.field("hotness_rating"), 4)
+        )
+      )
+      .collect();
+
+    const results: Array<{
+      person_id: string;
+      display_name: string;
+      effort_rating: number;
+      hotness_rating: number | undefined;
+      courtship_stage: string | undefined;
+      her_word_ratio: number;
+      last_inbound_at: number | undefined;
+    }> = [];
+
+    for (const person of people) {
+      // Use by_person_recent index — properly indexed per person
+      const personMessages = await ctx.db
+        .query("messages")
+        .withIndex("by_person_recent", (q) =>
+          q.eq("person_id", person._id).gt("sent_at", cutoff)
+        )
+        .take(200); // cap per person
+
+      const outboundMessages = personMessages.filter((m) => m.direction === "outbound");
+      const inboundMessages = personMessages.filter((m) => m.direction === "inbound");
+
+      const outboundWords = outboundMessages.reduce(
+        (acc, m) => acc + (m.body?.split(/\s+/).filter(Boolean).length ?? 0),
+        0
+      );
+      const inboundWords = inboundMessages.reduce(
+        (acc, m) => acc + (m.body?.split(/\s+/).filter(Boolean).length ?? 0),
+        0
+      );
+
+      // Skip if no activity at all
+      if (outboundWords === 0) continue;
+
+      const ratio = outboundWords === 0 ? 0 : inboundWords / outboundWords;
+
+      if (ratio < 0.3) {
+        results.push({
+          person_id: person._id,
+          display_name: person.display_name,
+          effort_rating: person.effort_rating ?? 0,
+          hotness_rating: person.hotness_rating,
+          courtship_stage: person.courtship_stage,
+          her_word_ratio: Math.round(ratio * 100) / 100,
+          last_inbound_at: person.last_inbound_at,
+        });
+      }
+    }
+
+    return results
+      .sort((a, b) => b.effort_rating - a.effort_rating)
+      .slice(0, 10);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// getStuckInStage
+//
+// People in courtship_stage "matched" or "early_chat" for > 14 days.
+// Days-in-stage approximated from (now - last_inbound_at) when courtship_stage
+// was set. We use updated_at as a proxy if courtship_last_analyzed is absent.
+// Returns list with days_in_stage, sorted descending.
+// ---------------------------------------------------------------------------
+export const getStuckInStage = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, { user_id }) => {
+    const now = Date.now();
+
+    const people = await ctx.db
+      .query("people")
+      .withIndex("by_user", (q) => q.eq("user_id", user_id))
+      .filter((q) =>
+        q.or(
+          q.eq(q.field("courtship_stage"), "matched"),
+          q.eq(q.field("courtship_stage"), "early_chat")
+        )
+      )
+      .collect();
+
+    return people
+      .map((p) => {
+        // Use courtship_last_analyzed as "when we last confirmed stage" or created_at as fallback
+        const stageSetAt = p.courtship_last_analyzed ?? p.created_at;
+        const daysInStage = Math.floor((now - stageSetAt) / (24 * 60 * 60 * 1000));
+        return {
+          person_id: p._id,
+          display_name: p.display_name,
+          courtship_stage: p.courtship_stage,
+          days_in_stage: daysInStage,
+          last_inbound_at: p.last_inbound_at,
+          hotness_rating: p.hotness_rating,
+        };
+      })
+      .filter((p) => p.days_in_stage >= 14)
+      .sort((a, b) => b.days_in_stage - a.days_in_stage);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// getTimeOfDayHeatmap
+//
+// 7×24 grid: for each (day_of_week 0=Sun…6=Sat, hour 0-23 local):
+//   sends: your outbound count
+//   replies: inbound messages that arrived in same hour×day window
+//   conversion_rate: replies / sends (0-1)
+//
+// Returns flat array of { dow, hour, sends, replies, conversion_rate }.
+// Only includes cells with at least 1 send.
+// ---------------------------------------------------------------------------
+export const getTimeOfDayHeatmap = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, { user_id }) => {
+    const cutoff = Date.now() - THIRTY_DAYS_MS;
+    const UTC_OFFSET_HOURS = -7; // Pacific heuristic
+    const MSG_LIMIT = 2000;
+
+    const outboundMessages = await ctx.db
+      .query("messages")
+      .withIndex("by_user_recent", (q) =>
+        q.eq("user_id", user_id).gt("sent_at", cutoff)
+      )
+      .filter((q) => q.eq(q.field("direction"), "outbound"))
+      .order("desc")
+      .take(MSG_LIMIT);
+
+    const inboundMessages = await ctx.db
+      .query("messages")
+      .withIndex("by_user_recent", (q) =>
+        q.eq("user_id", user_id).gt("sent_at", cutoff)
+      )
+      .filter((q) => q.eq(q.field("direction"), "inbound"))
+      .order("desc")
+      .take(MSG_LIMIT);
+
+    // Build inbound bucket: key = "dow:hour" -> count
+    const inboundBuckets: Record<string, number> = {};
+    for (const msg of inboundMessages) {
+      const d = new Date(msg.sent_at);
+      const localHour = ((d.getUTCHours() + UTC_OFFSET_HOURS + 24) % 24);
+      const localDow = d.getUTCDay(); // good enough approximation
+      const key = `${localDow}:${localHour}`;
+      inboundBuckets[key] = (inboundBuckets[key] ?? 0) + 1;
+    }
+
+    // Build outbound bucket
+    const outboundBuckets: Record<string, number> = {};
+    for (const msg of outboundMessages) {
+      const d = new Date(msg.sent_at);
+      const localHour = ((d.getUTCHours() + UTC_OFFSET_HOURS + 24) % 24);
+      const localDow = d.getUTCDay();
+      const key = `${localDow}:${localHour}`;
+      outboundBuckets[key] = (outboundBuckets[key] ?? 0) + 1;
+    }
+
+    const cells: Array<{
+      dow: number;
+      hour: number;
+      sends: number;
+      replies: number;
+      conversion_rate: number;
+    }> = [];
+
+    for (let dow = 0; dow < 7; dow++) {
+      for (let hour = 0; hour < 24; hour++) {
+        const key = `${dow}:${hour}`;
+        const sends = outboundBuckets[key] ?? 0;
+        if (sends === 0) continue;
+        const replies = inboundBuckets[key] ?? 0;
+        cells.push({
+          dow,
+          hour,
+          sends,
+          replies,
+          conversion_rate: Math.round((replies / sends) * 100) / 100,
+        });
+      }
+    }
+
+    return cells;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// getDashboardSummary
+//
+// Single-call rollup for the top KPI bar:
+//   active_threads: count of people with status=active
+//   dates_this_week: count of scheduled_touches type=date_confirm_24h fired this week
+//   ghost_rate_this_month: (people who went ghosted in last 30d) / (all active+ghosted)
+//   kissed_this_month: count of people whose operator_notes contains kiss/kissed/making out (regex)
+//   slept_with_this_month: count of people whose operator_notes contains slept with/sex/hooked up (regex)
+//   avg_reply_rate: mean of response_rate across active people (from enrichment)
+// ---------------------------------------------------------------------------
+export const getDashboardSummary = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, { user_id }) => {
+    const now = Date.now();
+    const cutoff = now - THIRTY_DAYS_MS;
+    const weekCutoff = now - 7 * 24 * 60 * 60 * 1000;
+
+    // Active people count
+    const activePeople = await ctx.db
+      .query("people")
+      .withIndex("by_user_status", (q) => q.eq("user_id", user_id).eq("status", "active"))
+      .collect();
+
+    // Ghosted in last 30 days (status=ghosted AND updated_at > cutoff)
+    const recentlyGhosted = await ctx.db
+      .query("people")
+      .withIndex("by_user_status", (q) => q.eq("user_id", user_id).eq("status", "ghosted"))
+      .filter((q) => q.gt(q.field("updated_at"), cutoff))
+      .collect();
+
+    const ghostRate =
+      activePeople.length + recentlyGhosted.length === 0
+        ? 0
+        : Math.round(
+            (recentlyGhosted.length / (activePeople.length + recentlyGhosted.length)) * 100
+          ) / 100;
+
+    // Dates this week: date_confirm_24h touches fired in last 7 days
+    const datesThisWeek = await ctx.db
+      .query("scheduled_touches")
+      .withIndex("by_user_fired_at", (q) =>
+        q.eq("user_id", user_id).gt("fired_at", weekCutoff)
+      )
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("type"), "date_confirm_24h"),
+          q.eq(q.field("status"), "fired")
+        )
+      )
+      .collect();
+
+    // Kissed / slept-with: scan operator_notes for keywords (best-effort regex)
+    const KISS_RE = /\b(kiss(ed|ing)?|making out|makeout|made out)\b/i;
+    const SLEEP_RE = /\b(slept with|had sex|hooked up|sex with|sleeping with|fucked)\b/i;
+
+    let kissedCount = 0;
+    let sleptWithCount = 0;
+
+    // Scan all people (not just active — notes persist across status changes)
+    const allPeople = await ctx.db
+      .query("people")
+      .withIndex("by_user", (q) => q.eq("user_id", user_id))
+      .collect();
+
+    for (const person of allPeople) {
+      if (!person.operator_notes) continue;
+      if (KISS_RE.test(person.operator_notes)) kissedCount++;
+      if (SLEEP_RE.test(person.operator_notes)) sleptWithCount++;
+    }
+
+    // Average reply rate from enrichment data
+    const replyRates = activePeople
+      .map((p) => p.response_rate)
+      .filter((r): r is number => typeof r === "number");
+    const avgReplyRate =
+      replyRates.length === 0
+        ? 0
+        : Math.round(
+            (replyRates.reduce((a, b) => a + b, 0) / replyRates.length) * 100
+          ) / 100;
+
+    return {
+      active_threads: activePeople.length,
+      dates_this_week: datesThisWeek.length,
+      ghost_rate_this_month: ghostRate,
+      kissed_this_month: kissedCount,
+      slept_with_this_month: sleptWithCount,
+      avg_reply_rate: avgReplyRate,
+      total_people: allPeople.length,
+    };
+  },
+});


### PR DESCRIPTION
## Summary
- New Convex module `web/convex/coach.ts` with 6 read-only queries aggregating Julian's 30-day messaging patterns across 260+ active threads
- New route `web/app/admin/clapcheeks-ops/coach/page.tsx` with dashboard summary KPIs + 6 pattern cards
- Nav entry added to clapcheeks-ops overview page linking to /coach

## Cards shipped
| Card | What it shows | Actionable sentence |
|---|---|---|
| Dashboard summary | Active threads, dates this week, ghost rate, avg reply rate, kissed/closed (from operator_notes) | Top-line KPIs |
| Over-pursue list | outbound_words/inbound_words ratio > 2.5×, top 10 | "Pull back on X — you're sending Nx her word volume" |
| Late-night conversion | Hourly bar chart: send volume vs reply rate | "Your late-night sends convert N% worse" |
| Same-opener overuse | Groups first messages by first-50-chars, flags 3+ repeats | "hey used 8× at 63% reply rate — rotate your opener" |
| Cut list | effort>=3 AND hotness<=4 AND her reciprocity<30% | "Stop putting energy into X" |
| Stuck in stage | >14d in matched/early_chat | "X has been in early_chat for 22d — move forward or move on" |
| Send heatmap | 7×24 grid color-coded green/blue/gray by conversion rate | "Best window: Fri 7pm (97% reply rate)" |

## Convex queries
All queries are read-only. Used `by_person_recent` index (person_id, sent_at) for per-person message lookups — avoids full-table scans that hit the 16MB budget. Capped at `.take(2000)` on global message queries and `.take(200)` per person. Smoke-tested against live `fleet-julian` data.

## Test plan
- [x] All 6 Convex queries return data without errors (smoke-tested via `npx convex run`)
- [x] TypeScript: zero errors in coach.ts or coach/page.tsx
- [x] getDashboardSummary: 260 active threads, 1033 people returned correctly
- [x] getLateNightConversion: hourly data with conversion rates returned
- [x] getSameOpenerOveruse: "hey" flagged 8× with 63% reply rate
- [x] getOverPursueList: over-pursuit detected across active threads
- [ ] Visual review at /admin/clapcheeks-ops/coach after Vercel deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)