### PR TITLE
feat(clapcheeks): AI-9500 W2 #D unified cross-platform thread

### DIFF
--- a/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
+++ b/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
@@ -6,6 +6,11 @@
  *
  * Wave 2.4 Task G — Compose panel ("Send a touch now"):
  *   pick template → click Preview → Mac Mini drafts → editable textarea → Send.
+ *
+ * AI-9500 W2 #D — Unified cross-platform thread (Timeline tab):
+ *   Interleaves iMessage + Hinge + IG + Telegram + email messages into one
+ *   chronological feed. Each message gets a platform pill. Toggle to single-
+ *   platform view. Powered by messages.unifiedThreadForPerson Convex query.
  */
 "use client"
 
@@ -85,7 +90,7 @@ export default function PersonDossierPage() {
       </div>
 
       <div className="bg-gray-900 border border-gray-800 border-t-0 rounded-b-md p-6 mb-8">
-        {tab === "Timeline" && <TimelineTab messages={messages} conversations={conversations} />}
+        {tab === "Timeline" && <TimelineTab messages={messages} conversations={conversations} personId={personId} />}
         {tab === "Memory" && <MemoryTab person={person} />}
         {tab === "Schedule" && <ScheduleTab person={person} touches={scheduled_touches} />}
         {tab === "Media" && <MediaTab uses={media_uses} assets={media_assets} />}
@@ -344,31 +349,125 @@ function Select({
 }
 
 // ---------------------------------------------------------------------------
-// Timeline tab — recent messages, ascending (oldest first within the slice)
+// Platform pill colors for the unified thread feed
 // ---------------------------------------------------------------------------
-function TimelineTab({ messages, conversations }: { messages: any[]; conversations: any[] }) {
-  const ordered = useMemo(() => [...messages].reverse(), [messages]) // newest at bottom
-  if (!ordered.length) {
+const PLATFORM_STYLES: Record<string, string> = {
+  hinge:     "bg-rose-900/60 text-rose-300 border-rose-700/50",
+  tinder:    "bg-orange-900/60 text-orange-300 border-orange-700/50",
+  bumble:    "bg-yellow-900/60 text-yellow-300 border-yellow-700/50",
+  imessage:  "bg-blue-900/60 text-blue-300 border-blue-700/50",
+  instagram: "bg-fuchsia-900/60 text-fuchsia-300 border-fuchsia-700/50",
+  telegram:  "bg-sky-900/60 text-sky-300 border-sky-700/50",
+  email:     "bg-emerald-900/60 text-emerald-300 border-emerald-700/50",
+  other:     "bg-gray-800 text-gray-400 border-gray-700",
+}
+function platformStyle(p: string) {
+  return PLATFORM_STYLES[p] ?? PLATFORM_STYLES.other
+}
+
+// ---------------------------------------------------------------------------
+// Timeline tab — AI-9500 W2 #D unified cross-platform thread
+//
+// Unified mode (default): fetches unifiedThreadForPerson from Convex — merges
+// all platforms (iMessage, Hinge, IG, Telegram, email…) into one chronological
+// feed. Each message gets a platform pill.
+// Per-platform mode: shows only the dossier messages (existing behavior).
+// Toggle hidden when only one platform is present (_handles_summary.length < 2).
+// ---------------------------------------------------------------------------
+function TimelineTab({ messages: dossierMessages, conversations, personId }: {
+  messages: any[];
+  conversations: any[];
+  personId: string;
+}) {
+  const [mode, setMode] = useState<"unified" | "platform">("unified")
+
+  // Unified thread query (always subscribed so switching is instant)
+  const unified = useQuery(api.messages.unifiedThreadForPerson, {
+    person_id: personId as Id<"people">,
+    limit: 200,
+  })
+
+  const handlesSummary: string[] = unified?._handles_summary ?? []
+  const multiPlatform = handlesSummary.length > 1
+
+  // Active message list — unified is oldest-first from the query;
+  // dossier list is newest-first so we reverse it for chronological display.
+  const activeMessages: any[] = mode === "unified"
+    ? (unified?.messages ?? [])
+    : [...dossierMessages].reverse()
+
+  const isLoading = mode === "unified" && unified === undefined
+
+  if (isLoading) {
+    return <div className="text-gray-500 text-sm">Loading unified thread…</div>
+  }
+  if (!activeMessages.length) {
     return <div className="text-gray-500 text-sm">No messages yet.</div>
   }
-  const platforms = Array.from(new Set(conversations.map((c) => c.platform)))
+
+  const platforms = Array.from(new Set(conversations.map((c: any) => c.platform)))
+
   return (
     <div>
-      <div className="text-xs text-gray-500 mb-3">
-        {ordered.length} messages across {conversations.length} conversation(s) · {platforms.join(", ")}
+      {/* Header bar */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-xs text-gray-500">
+          {activeMessages.length} message{activeMessages.length !== 1 ? "s" : ""}
+          {" · "}
+          {mode === "unified"
+            ? handlesSummary.join(", ") || platforms.join(", ")
+            : `${conversations.length} conversation(s) · ${platforms.join(", ")}`}
+        </div>
+
+        {/* Toggle — only shown when more than one platform exists */}
+        {multiPlatform && (
+          <div className="flex rounded border border-gray-700 overflow-hidden text-xs">
+            <button
+              onClick={() => setMode("unified")}
+              className={`px-3 py-1 transition-colors ${
+                mode === "unified"
+                  ? "bg-purple-700 text-white"
+                  : "bg-gray-900 text-gray-400 hover:text-gray-200"
+              }`}
+            >
+              unified
+            </button>
+            <button
+              onClick={() => setMode("platform")}
+              className={`px-3 py-1 transition-colors border-l border-gray-700 ${
+                mode === "platform"
+                  ? "bg-purple-700 text-white"
+                  : "bg-gray-900 text-gray-400 hover:text-gray-200"
+              }`}
+            >
+              this platform
+            </button>
+          </div>
+        )}
       </div>
+
+      {/* Message feed */}
       <div className="space-y-2 max-h-[60vh] overflow-y-auto pr-2">
-        {ordered.map((m: any) => {
+        {activeMessages.map((m: any, idx: number) => {
           const isOut = m.direction === "outbound"
           const ts = new Date(m.sent_at).toLocaleString()
+          const platform: string = m._platform ?? "imessage"
           return (
-            <div key={m._id} className={`flex ${isOut ? "justify-end" : "justify-start"}`}>
+            <div key={m._id ?? idx} className={`flex ${isOut ? "justify-end" : "justify-start"}`}>
               <div className={`max-w-[75%] rounded-lg px-3 py-2 ${
                 isOut ? "bg-purple-700/40 border border-purple-700/60" : "bg-gray-800 border border-gray-700"
               }`}>
                 <div className="text-sm whitespace-pre-wrap">{m.body}</div>
-                <div className="text-[10px] text-gray-500 mt-1">
-                  {ts} · {m.transport ?? m.source ?? "—"}
+                <div className="flex items-center gap-2 mt-1.5 flex-wrap">
+                  <span className="text-[10px] text-gray-500">{ts}</span>
+                  {mode === "unified" && (
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded border font-medium ${platformStyle(platform)}`}>
+                      {platform}
+                    </span>
+                  )}
+                  {(m.transport || m.source) && (
+                    <span className="text-[10px] text-gray-600">{m.transport ?? m.source}</span>
+                  )}
                 </div>
               </div>
             </div>

--- a/web/convex/messages.ts
+++ b/web/convex/messages.ts
@@ -536,3 +536,81 @@ export const listForProxy = query({
     return rows.slice(0, limit);
   },
 });
+
+// AI-9500 W2 #D — Unified cross-platform thread for the dossier Timeline tab.
+//
+// Interleaves messages from ALL conversations linked to a person (iMessage,
+// Hinge, Bumble, IG, Telegram, email…) into a single chronological feed.
+// Each message is annotated with a `_platform` tag derived from its source
+// conversation's `platform` field so the UI can render per-platform pills.
+//
+// Also returns `_handles_summary` — the distinct platforms present — so the
+// caller can hide the toggle when only one platform exists.
+//
+// Cap: 200 most-recent messages (configurable via `limit`, max 200).
+export const unifiedThreadForPerson = query({
+  args: {
+    person_id: v.id("people"),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = Math.min(args.limit ?? 200, 200);
+
+    // Step 1: find all conversations for this person.
+    const convs = await ctx.db
+      .query("conversations")
+      .withIndex("by_person", (q) => q.eq("person_id", args.person_id))
+      .collect();
+
+    // Build a lookup: conversation_id → platform.
+    const platformByConvId: Record<string, string> = {};
+    for (const c of convs) {
+      platformByConvId[c._id] = c.platform;
+    }
+
+    // Step 2: collect messages from each conversation.
+    // We over-fetch per conv so we don't miss messages after the final merge-sort.
+    const collected: Array<Record<string, unknown>> = [];
+
+    if (convs.length > 0) {
+      for (const c of convs) {
+        const msgs = await ctx.db
+          .query("messages")
+          .withIndex("by_conversation", (q) => q.eq("conversation_id", c._id))
+          .order("desc")
+          .take(limit);
+        for (const m of msgs) {
+          collected.push({ ...m, _platform: c.platform });
+        }
+      }
+    }
+
+    // Step 3: fallback — if no conv-linked messages, try messages by person_id directly.
+    // This covers older rows that have person_id but whose conversation lacks by_person index entry.
+    if (collected.length === 0) {
+      const directMsgs = await ctx.db
+        .query("messages")
+        .withIndex("by_person_recent", (q) => q.eq("person_id", args.person_id))
+        .order("desc")
+        .take(limit);
+      for (const m of directMsgs) {
+        const platform = platformByConvId[m.conversation_id as string] ?? "imessage";
+        collected.push({ ...m, _platform: platform });
+      }
+    }
+
+    // Step 4: sort by sent_at ascending (oldest first — UI can reverse if needed)
+    // and keep the 200 most-recent.
+    collected.sort((a, b) => ((a.sent_at as number) || 0) - ((b.sent_at as number) || 0));
+    const sliced = collected.slice(-limit);
+
+    // Step 5: derive handles_summary — distinct platforms present.
+    const platformsSet = new Set<string>();
+    for (const m of sliced) {
+      if (m._platform) platformsSet.add(m._platform as string);
+    }
+    const _handles_summary = Array.from(platformsSet);
+
+    return { messages: sliced, _handles_summary };
+  },
+});


### PR DESCRIPTION
## Summary
- New Convex query `messages.unifiedThreadForPerson` — merges messages from all conversations linked to a person (iMessage + Hinge + Bumble + IG + Telegram + email) into one chronological feed, each annotated with `_platform` and capped at 200
- Updated dossier Timeline tab to default to unified mode with color-coded platform pills per message bubble
- Added `[ unified ] / [ this platform ]` toggle (hidden when only 1 platform is present) and `_handles_summary` to power it
- Convex deploy verified + smoke-tested: `npx convex run messages:unifiedThreadForPerson` returns interleaved messages with `_platform` tags

## Test plan
- [ ] Open dossier for a person with messages on multiple platforms → Timeline tab shows unified feed with platform pills
- [ ] Toggle "this platform" → reverts to existing per-platform view
- [ ] Person with only iMessage → toggle is hidden (single platform)
- [ ] `npx convex run messages:unifiedThreadForPerson '{"person_id":"<id>","limit":50}'` returns `{ messages: [...], _handles_summary: [...] }`
- [ ] Did not touch enrichment.ts or touches.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)