### PR TITLE
feat(clapcheeks): AI-9500 W2 #E cut workflow

### DIFF
--- a/web/app/admin/clapcheeks-ops/coach/page.tsx
+++ b/web/app/admin/clapcheeks-ops/coach/page.tsx
@@ -14,9 +14,10 @@
  */
 "use client"
 
-import { useQuery } from "convex/react"
+import { useQuery, useMutation } from "convex/react"
 import { api } from "@/convex/_generated/api"
 import Link from "next/link"
+import { useState } from "react"
 
 const FLEET_USER_ID = "fleet-julian"
 
@@ -243,9 +244,13 @@ function OpenerOveruseCard({ data }: { data: any[] | undefined }) {
 }
 
 // ---------------------------------------------------------------------------
-// Cut-list candidates card
+// Cut-list candidates card — with one-click Archive button per row
 // ---------------------------------------------------------------------------
 function CutListCard({ data }: { data: any[] | undefined }) {
+  const archivePerson = useMutation(api.people.archivePerson)
+  const [archiving, setArchiving] = useState<Record<string, boolean>>({})
+  const [archived, setArchived] = useState<Record<string, boolean>>({})
+
   if (!data) return <CardShell title="Cut list" loading />
   if (data.length === 0)
     return (
@@ -254,8 +259,21 @@ function CutListCard({ data }: { data: any[] | undefined }) {
       </CardShell>
     )
 
-  const top = data[0]
-  const action = `Stop putting energy into ${top.display_name} — effort=${top.effort_rating}/5, hotness=${top.hotness_rating ?? "?"}/10, she's at ${Math.round(top.her_word_ratio * 100)}% reciprocity.`
+  const visible = data.filter((p: any) => !archived[p.person_id])
+  const top = visible[0]
+  const action = top
+    ? `Stop putting energy into ${top.display_name} — effort=${top.effort_rating}/5, hotness=${top.hotness_rating ?? "?"}/10, she's at ${Math.round(top.her_word_ratio * 100)}% reciprocity.`
+    : "All cut candidates archived — nice cleanup."
+
+  async function handleArchive(personId: string) {
+    setArchiving((prev) => ({ ...prev, [personId]: true }))
+    try {
+      await archivePerson({ person_id: personId as any, reason: "manual_cut" })
+      setArchived((prev) => ({ ...prev, [personId]: true }))
+    } finally {
+      setArchiving((prev) => ({ ...prev, [personId]: false }))
+    }
+  }
 
   return (
     <CardShell title="Cut list" action={action}>
@@ -265,12 +283,13 @@ function CutListCard({ data }: { data: any[] | undefined }) {
             <th className="pb-2">Name</th>
             <th className="pb-2 text-right">Effort</th>
             <th className="pb-2 text-right">Hotness</th>
-            <th className="pb-2 text-right">Her reciprocity</th>
+            <th className="pb-2 text-right">Reciprocity</th>
             <th className="pb-2 text-right">Last heard</th>
+            <th className="pb-2 text-right">Action</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-800">
-          {data.map((p: any) => (
+          {visible.map((p: any) => (
             <tr key={p.person_id}>
               <td className="py-2">
                 <Link
@@ -284,10 +303,24 @@ function CutListCard({ data }: { data: any[] | undefined }) {
               <td className="py-2 text-right">{p.hotness_rating ?? "—"}/10</td>
               <td className="py-2 text-right text-red-400">{Math.round(p.her_word_ratio * 100)}%</td>
               <td className="py-2 text-right text-gray-500">{daysAgo(p.last_inbound_at)}</td>
+              <td className="py-2 text-right">
+                <button
+                  onClick={() => handleArchive(p.person_id)}
+                  disabled={archiving[p.person_id]}
+                  className="text-xs px-2 py-1 rounded bg-red-900/40 text-red-300 border border-red-700/50 hover:bg-red-800/60 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {archiving[p.person_id] ? "…" : "Archive"}
+                </button>
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
+      {Object.keys(archived).length > 0 && (
+        <p className="text-xs text-gray-500 mt-3">
+          {Object.keys(archived).length} archived this session — check <Link href="/admin/clapcheeks-ops/network" className="text-blue-400 hover:underline">Network</Link> to review.
+        </p>
+      )}
     </CardShell>
   )
 }

--- a/web/app/admin/clapcheeks-ops/network/page.tsx
+++ b/web/app/admin/clapcheeks-ops/network/page.tsx
@@ -52,19 +52,28 @@ function priorityScore(p: any): number {
 
 export default function NetworkPage() {
   const [showAll, setShowAll] = useState(false)
+  const [showArchived, setShowArchived] = useState(false)
   const [search, setSearch] = useState("")
   const people = useQuery(api.people.listForUser, {
     user_id: FLEET_USER_ID, limit: 500, only_cc_tech: false,
   })
+  const archivedPeople = useQuery(api.people.listArchived, {
+    user_id: FLEET_USER_ID,
+  })
 
   if (people === undefined) return <div className="p-8 text-gray-500">Loading…</div>
 
-  const filtered = people.filter((p: any) => {
+  // Separate active vs archived pools.
+  const activePeople = (people as any[]).filter((p: any) => !p.archived_at)
+  const archivedCount = archivedPeople?.length ?? 0
+
+  const filtered = (showArchived ? (archivedPeople ?? []) : activePeople).filter((p: any) => {
     if (search) {
       const q = search.toLowerCase()
       if (!p.display_name?.toLowerCase().includes(q) &&
           !p.context_notes?.toLowerCase().includes(q)) return false
     }
+    if (showArchived) return true
     return showAll ? true : isDatingRelevant(p)
   })
 
@@ -114,10 +123,13 @@ export default function NetworkPage() {
         <div>
           <h1 className="text-3xl font-bold">Network</h1>
           <p className="text-gray-400">
-            {filtered.length} of {people.length} people · ranked by hotness × recency
+            {showArchived
+              ? `${filtered.length} archived · ${activePeople.length} active`
+              : `${filtered.length} of ${activePeople.length} active · ${archivedCount} archived`
+            } · ranked by hotness × recency
           </p>
         </div>
-        <div className="flex gap-3 items-center">
+        <div className="flex gap-3 items-center flex-wrap justify-end">
           <input
             type="text"
             value={search}
@@ -125,46 +137,76 @@ export default function NetworkPage() {
             onChange={(e) => setSearch(e.target.value)}
             className="bg-gray-950 border border-gray-800 rounded px-3 py-1.5 text-sm w-48"
           />
-          <label className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer">
-            <input type="checkbox" checked={showAll} onChange={(e) => setShowAll(e.target.checked)} />
-            show all (incl. non-dating)
-          </label>
+          {!showArchived && (
+            <label className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer">
+              <input type="checkbox" checked={showAll} onChange={(e) => setShowAll(e.target.checked)} />
+              show all (incl. non-dating)
+            </label>
+          )}
+          <button
+            onClick={() => { setShowArchived((v) => !v); setSearch("") }}
+            className={`text-xs px-3 py-1.5 rounded border transition-colors ${
+              showArchived
+                ? "bg-red-900/40 text-red-300 border-red-700/50 hover:bg-red-800/60"
+                : "bg-gray-900 text-gray-400 border-gray-700 hover:border-gray-500"
+            }`}
+          >
+            {showArchived ? "← Active" : `🗂 Archived (${archivedCount})`}
+          </button>
         </div>
       </div>
 
       <div className="text-xs text-gray-600 mb-4">
-        Default view: lead/active/dating/paused with dating-channel handle, recent inbound, operator rating, or dating vibe.
+        {showArchived
+          ? "Archived people — auto-cut after 30d silence or manually cut from the cut list."
+          : "Default view: lead/active/dating/paused with dating-channel handle, recent inbound, operator rating, or dating vibe."
+        }
       </div>
 
-      <PulseCard needsResponse={needsResponse} cooling={cooling} followupDue={followupDue} />
+      {!showArchived && (
+        <PulseCard needsResponse={needsResponse} cooling={cooling} followupDue={followupDue} />
+      )}
 
       {filtered.length === 0 && (
         <div className="text-center py-12 text-gray-500">
-          {search ? "No matches." : "No dating-relevant people yet — toggle 'show all' to see everyone."}
+          {search
+            ? "No matches."
+            : showArchived
+            ? "No archived people yet — archive candidates from the Coach Cut list."
+            : "No dating-relevant people yet — toggle 'show all' to see everyone."}
         </div>
       )}
 
-      {STAGE_ORDER.map((stage) => {
-        const ppl = (byStage[stage] || []).sort((a, b) => priorityScore(b) - priorityScore(a))
-        if (ppl.length === 0) return null
-        return (
-          <section key={stage} className="mb-8">
-            <h2 className="text-xl font-semibold mb-2 capitalize">
-              {stage.replace(/_/g, " ")} ({ppl.length})
-            </h2>
-            <div className="space-y-2">
-              {ppl.map((p) => (
-                <PersonRow key={p._id} p={p} />
-              ))}
-            </div>
-          </section>
-        )
-      })}
+      {showArchived ? (
+        // Flat list for archived view, sorted by archived_at desc (already sorted by query)
+        <div className="space-y-2">
+          {filtered.map((p: any) => (
+            <PersonRow key={p._id} p={p} showArchiveInfo />
+          ))}
+        </div>
+      ) : (
+        STAGE_ORDER.map((stage) => {
+          const ppl = (byStage[stage] || []).sort((a: any, b: any) => priorityScore(b) - priorityScore(a))
+          if (ppl.length === 0) return null
+          return (
+            <section key={stage} className="mb-8">
+              <h2 className="text-xl font-semibold mb-2 capitalize">
+                {stage.replace(/_/g, " ")} ({ppl.length})
+              </h2>
+              <div className="space-y-2">
+                {ppl.map((p: any) => (
+                  <PersonRow key={p._id} p={p} />
+                ))}
+              </div>
+            </section>
+          )
+        })
+      )}
     </div>
   )
 }
 
-function PersonRow({ p }: { p: any }) {
+function PersonRow({ p, showArchiveInfo }: { p: any; showArchiveInfo?: boolean }) {
   const now = Date.now()
   const lastInbound = p.last_inbound_at
     ? `${Math.round((now - p.last_inbound_at) / 3600000)}h ago`
@@ -173,6 +215,9 @@ function PersonRow({ p }: { p: any }) {
   const ttas = p.time_to_ask_score?.toFixed(2) ?? "—"
   const lastEmotion = (p.emotional_state_recent ?? []).slice(-1)[0]?.state ?? "—"
   const platforms = Array.from(new Set((p.handles ?? []).map((h: any) => h.channel)))
+  const archivedDaysAgo = p.archived_at
+    ? Math.floor((now - p.archived_at) / (24 * 60 * 60 * 1000))
+    : null
 
   // AI-9500 #1 — quiet thread badge
   const questionRatio: number | null = p.her_question_ratio_7d ?? null
@@ -183,13 +228,24 @@ function PersonRow({ p }: { p: any }) {
   return (
     <Link
       href={`/admin/clapcheeks-ops/people/${p._id}`}
-      className="block bg-gray-900 border border-gray-800 rounded-lg p-3 hover:border-purple-700 hover:bg-gray-800/60 transition-colors"
+      className={`block bg-gray-900 border rounded-lg p-3 hover:bg-gray-800/60 transition-colors ${
+        showArchiveInfo
+          ? "border-gray-700 hover:border-gray-500"
+          : "border-gray-800 hover:border-purple-700"
+      }`}
     >
       <div className="flex justify-between items-start gap-4">
         <div className="flex-1 min-w-0">
           <div className="flex items-baseline gap-2 flex-wrap">
             <span className="font-medium">{p.display_name}</span>
             {p.age && <span className="text-gray-500 text-xs">· {p.age}</span>}
+            {/* AI-9500 W2 #E — archive badge */}
+            {showArchiveInfo && archivedDaysAgo !== null && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-gray-800 text-gray-400 border border-gray-700">
+                archived {archivedDaysAgo === 0 ? "today" : `${archivedDaysAgo}d ago`}
+                {p.archive_reason ? ` · ${p.archive_reason}` : ""}
+              </span>
+            )}
             {p.hotness_rating && (
               <span className="text-pink-300 text-xs font-mono">🔥 {p.hotness_rating}/10</span>
             )}

--- a/web/convex/crons.ts
+++ b/web/convex/crons.ts
@@ -142,4 +142,14 @@ crons.interval(
   internal.enrichment.sweepDateAskGhostOuts,
 );
 
+// AI-9500 Wave 2 #E — Auto-archive 30d-silence threads daily at 4am Pacific
+// (12:00 UTC). Scans all people; anyone with both last_inbound AND last_outbound
+// older than 30 days (and not already archived/ghosted) gets archived with
+// reason="auto_30d_silence" and whitelist_for_autoreply flipped to false.
+crons.cron(
+  "auto-archive-ghosted-30d",
+  "0 12 * * *",
+  internal.people.autoArchiveGhosted30d,
+);
+
 export default crons;

--- a/web/convex/people.ts
+++ b/web/convex/people.ts
@@ -1,4 +1,4 @@
-import { mutation, query } from "./_generated/server";
+import { mutation, query, internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 
 // AI-9449 — Unified person record across iMessage / dating apps / email / Telegram.
@@ -1167,5 +1167,113 @@ export const updateLiveState = mutation({
     if (args.next_followup_at !== undefined) patch.next_followup_at = args.next_followup_at;
     if (args.style_profile !== undefined) patch.style_profile = args.style_profile;
     await ctx.db.patch(args.person_id, patch);
+  },
+});
+
+// ----------------------------------------------------------------------------
+// AI-9500 Wave 2 #E — Cut workflow: archivePerson / unarchivePerson / listArchived
+// ----------------------------------------------------------------------------
+
+// archivePerson — operator-initiated archive. Flips whitelist_for_autoreply to
+// false so the daemon stops sending. reason is optional; defaults to "manual".
+export const archivePerson = mutation({
+  args: {
+    person_id: v.id("people"),
+    reason: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const person = await ctx.db.get(args.person_id);
+    if (!person) return { ok: false, error: "not_found" };
+    if (person.archived_at) return { ok: false, error: "already_archived" };
+    await ctx.db.patch(args.person_id, {
+      archived_at: now,
+      archive_reason: args.reason ?? "manual",
+      whitelist_for_autoreply: false,
+      updated_at: now,
+    });
+    return { ok: true, person_id: args.person_id };
+  },
+});
+
+// unarchivePerson — operator restores an archived person. Clears archive_at /
+// archive_reason. Does NOT auto-re-whitelist (operator does that manually).
+export const unarchivePerson = mutation({
+  args: { person_id: v.id("people") },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const person = await ctx.db.get(args.person_id);
+    if (!person) return { ok: false, error: "not_found" };
+    if (!person.archived_at) return { ok: false, error: "not_archived" };
+    await ctx.db.patch(args.person_id, {
+      archived_at: undefined,
+      archive_reason: undefined,
+      updated_at: now,
+    });
+    return { ok: true, person_id: args.person_id };
+  },
+});
+
+// listArchived — dashboard reader. Returns all archived people for the user,
+// sorted by archived_at desc (most recently cut first).
+export const listArchived = query({
+  args: {
+    user_id: v.string(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = Math.min(args.limit ?? 200, 500);
+    const all = await ctx.db
+      .query("people")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .collect();
+    const archived = all
+      .filter((p) => p.archived_at !== undefined)
+      .sort((a, b) => (b.archived_at ?? 0) - (a.archived_at ?? 0));
+    return archived.slice(0, limit);
+  },
+});
+
+// autoArchiveGhosted30d — internal cron handler.
+// Finds people who have been silent (both inbound AND outbound) for 30+ days,
+// are not already archived, and whose status is not "ghosted" — then marks
+// them archived with reason="auto_30d_silence". Ghosted people are already
+// tracked; this catches threads that just quietly stopped without a status
+// update. Scoped to all users (sweeps the whole people table).
+export const autoArchiveGhosted30d = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+    const cutoff = now - THIRTY_DAYS_MS;
+
+    // Collect ALL people (no per-user restriction — cron owns the sweep).
+    // At human scale this is fine; add pagination if the table ever exceeds 50k.
+    const all = await ctx.db.query("people").collect();
+
+    let archived = 0;
+    for (const person of all) {
+      // Already archived — skip.
+      if (person.archived_at !== undefined) continue;
+      // Explicitly ghosted — status already says so — skip.
+      if (person.status === "ghosted") continue;
+      // If no inbound/outbound timestamps at all — skip (never had a message).
+      if (!person.last_inbound_at && !person.last_outbound_at) continue;
+      // Check 30-day silence on both sides.
+      const lastInboundOld =
+        !person.last_inbound_at || person.last_inbound_at < cutoff;
+      const lastOutboundOld =
+        !person.last_outbound_at || person.last_outbound_at < cutoff;
+      if (!lastInboundOld || !lastOutboundOld) continue;
+
+      await ctx.db.patch(person._id, {
+        archived_at: now,
+        archive_reason: "auto_30d_silence",
+        whitelist_for_autoreply: false,
+        updated_at: now,
+      });
+      archived++;
+    }
+    return { archived, scanned: all.length };
   },
 });


### PR DESCRIPTION
## Summary

- **`people.ts`**: `archivePerson` mutation (sets `archived_at`, `archive_reason`, flips `whitelist_for_autoreply=false`), `unarchivePerson` mutation (clears both fields), `listArchived` query (returns all archived for a user sorted by `archived_at` desc), and `autoArchiveGhosted30d` internal mutation (sweeps all people for 30d two-sided silence).
- **`crons.ts`**: new `auto-archive-ghosted-30d` cron fires daily at 04:00 Pacific (12:00 UTC) calling `internal.people.autoArchiveGhosted30d`.
- **`/coach` page**: `CutListCard` gets a per-row **Archive** button. One-click calls `archivePerson` with `reason="manual_cut"`, optimistically hides the row, and shows a session counter with a link to Network.
- **`/network` page**: archived people are hidden from the default active view. A new **"Archived (N)"** toggle button switches to the archived pool (flat sorted list). `PersonRow` shows an archive badge (days ago + reason) when in archived view.

## Test plan

- [ ] `archivePerson` patches `archived_at`, `archive_reason`, `whitelist_for_autoreply=false` on a test person
- [ ] `listArchived` returns that person; it disappears from active `listForUser` view
- [ ] `unarchivePerson` clears both fields (person re-appears in active view)
- [ ] `autoArchiveGhosted30d` dry-run: manually call with test data — confirms only 30d-silent non-ghosted non-archived rows are touched
- [ ] `/coach` cut list: Archive button appears, click archives and hides the row
- [ ] `/network` archived toggle shows archived pool; badge shows reason + days ago

🤖 Generated with [Claude Code](https://claude.com/claude-code)