### PR TITLE
feat(clapcheeks): AI-9500 W2 #H mobile dashboard + PWA

### DIFF
--- a/web/app/admin/clapcheeks-ops/coach/page.tsx
+++ b/web/app/admin/clapcheeks-ops/coach/page.tsx
@@ -468,10 +468,10 @@ export default function CoachPage() {
   const heatmap = useQuery(api.coach.getTimeOfDayHeatmap, { user_id: FLEET_USER_ID })
 
   return (
-    <div className="p-8 max-w-7xl">
+    <div className="p-4 sm:p-8 max-w-7xl">
       {/* Header */}
-      <div className="flex items-center justify-between mb-2">
-        <h1 className="text-3xl font-bold">Self-Coaching Dashboard</h1>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 mb-2">
+        <h1 className="text-2xl sm:text-3xl font-bold">Self-Coaching Dashboard</h1>
         <Link
           href="/admin/clapcheeks-ops"
           className="text-sm text-gray-400 hover:text-gray-200"
@@ -479,15 +479,15 @@ export default function CoachPage() {
           ← Ops overview
         </Link>
       </div>
-      <p className="text-gray-400 mb-8">
+      <p className="text-gray-400 text-sm mb-6 sm:mb-8">
         Your patterns across all active threads — last 30 days. Each card has one thing to do.
       </p>
 
       {/* KPI Summary */}
       <SummaryCard summary={summary} />
 
-      {/* 2-column grid for the cards */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Cards — 1 col on mobile, 2 col on lg+ */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
         <OverPursueCard data={overPursue} />
         <CutListCard data={cutList} />
         <StuckInStageCard data={stuckInStage} />

--- a/web/app/admin/clapcheeks-ops/network/page.tsx
+++ b/web/app/admin/clapcheeks-ops/network/page.tsx
@@ -109,21 +109,21 @@ export default function NetworkPage() {
   }
 
   return (
-    <div className="p-8 max-w-7xl">
-      <div className="flex justify-between items-start mb-2">
+    <div className="p-4 sm:p-8 max-w-7xl">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-3 mb-2">
         <div>
-          <h1 className="text-3xl font-bold">Network</h1>
-          <p className="text-gray-400">
+          <h1 className="text-2xl sm:text-3xl font-bold">Network</h1>
+          <p className="text-gray-400 text-sm">
             {filtered.length} of {people.length} people · ranked by hotness × recency
           </p>
         </div>
-        <div className="flex gap-3 items-center">
+        <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
           <input
             type="text"
             value={search}
             placeholder="search name…"
             onChange={(e) => setSearch(e.target.value)}
-            className="bg-gray-950 border border-gray-800 rounded px-3 py-1.5 text-sm w-48"
+            className="bg-gray-950 border border-gray-800 rounded px-3 py-1.5 text-sm w-full sm:w-48"
           />
           <label className="flex items-center gap-2 text-xs text-gray-400 cursor-pointer">
             <input type="checkbox" checked={showAll} onChange={(e) => setShowAll(e.target.checked)} />
@@ -185,9 +185,9 @@ function PersonRow({ p }: { p: any }) {
       href={`/admin/clapcheeks-ops/people/${p._id}`}
       className="block bg-gray-900 border border-gray-800 rounded-lg p-3 hover:border-purple-700 hover:bg-gray-800/60 transition-colors"
     >
-      <div className="flex justify-between items-start gap-4">
+      <div className="flex justify-between items-start gap-2 sm:gap-4">
         <div className="flex-1 min-w-0">
-          <div className="flex items-baseline gap-2 flex-wrap">
+          <div className="flex items-baseline gap-1.5 sm:gap-2 flex-wrap">
             <span className="font-medium">{p.display_name}</span>
             {p.age && <span className="text-gray-500 text-xs">· {p.age}</span>}
             {p.hotness_rating && (
@@ -209,30 +209,37 @@ function PersonRow({ p }: { p: any }) {
               </span>
             )}
             {platforms.length > 0 && (
-              <span className="text-xs text-gray-600">{platforms.join(" · ")}</span>
+              <span className="hidden sm:inline text-xs text-gray-600">{platforms.join(" · ")}</span>
             )}
           </div>
-          <div className="text-xs text-gray-500 mt-1">
+          {/* Secondary metrics — hidden on narrow screens */}
+          <div className="hidden sm:block text-xs text-gray-500 mt-1">
             inbound {lastInbound} · trust {trust} · ask {ttas} · emo {lastEmotion}
             {p.zodiac_sign && <span className="ml-2 capitalize">♈ {p.zodiac_sign}</span>}
           </div>
+          {/* Mobile-only compact metric row */}
+          <div className="sm:hidden text-xs text-gray-500 mt-0.5">
+            {lastInbound} · {lastEmotion}
+          </div>
           {p.next_best_move && (
-            <div className="text-sm text-purple-300 mt-2 line-clamp-1">💡 {p.next_best_move}</div>
+            <div className="text-sm text-purple-300 mt-1.5 line-clamp-1">💡 {p.next_best_move}</div>
           )}
           {p.curiosity_ledger && p.curiosity_ledger.filter((q: any) => q.status === "pending").length > 0 && (
-            <div className="text-xs text-gray-400 mt-1 line-clamp-1">
+            <div className="hidden sm:block text-xs text-gray-400 mt-1 line-clamp-1">
               Q: {p.curiosity_ledger.filter((q: any) => q.status === "pending")[0]?.question}
             </div>
           )}
         </div>
         <div className="text-right text-xs text-gray-500 flex-shrink-0">
-          <div>{p.cadence_profile}</div>
+          <div className="hidden sm:block">{p.cadence_profile}</div>
           <div className={p.whitelist_for_autoreply ? "text-green-400" : "text-gray-600"}>
-            {p.whitelist_for_autoreply ? "✓ whitelisted" : "○ manual"}
+            {p.whitelist_for_autoreply ? "✓" : "○"}
+            <span className="hidden sm:inline"> {p.whitelist_for_autoreply ? "whitelisted" : "manual"}</span>
           </div>
           {p.next_followup_at && (
             <div className="text-amber-400 mt-1">
-              follow-up {new Date(p.next_followup_at).toLocaleDateString()}
+              <span className="hidden sm:inline">follow-up </span>
+              {new Date(p.next_followup_at).toLocaleDateString()}
             </div>
           )}
         </div>

--- a/web/app/admin/clapcheeks-ops/page.tsx
+++ b/web/app/admin/clapcheeks-ops/page.tsx
@@ -26,9 +26,9 @@ export default function ClapcheeksOpsOverview() {
   const orphanStatus = useQuery(api.backfill.orphanStatus, { user_id: FLEET_USER_ID })
 
   return (
-    <div className="p-8 max-w-7xl">
-      <h1 className="text-3xl font-bold mb-2">Clapcheeks Ops</h1>
-      <p className="text-gray-400 mb-8">
+    <div className="p-4 sm:p-8 max-w-7xl">
+      <h1 className="text-2xl sm:text-3xl font-bold mb-2">Clapcheeks Ops</h1>
+      <p className="text-gray-400 text-sm mb-6 sm:mb-8">
         Your dating co-pilot — live state, ranked surfaces, one-tap controls.
       </p>
 
@@ -47,7 +47,7 @@ export default function ClapcheeksOpsOverview() {
         </div>
       </Link>
 
-      <div className="grid grid-cols-2 gap-4 mb-8">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-8">
         <Card title="Pending media for approval"
               value={pendingMedia?.length ?? "—"}
               href="/admin/clapcheeks-ops/media" />

--- a/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
+++ b/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
@@ -57,7 +57,7 @@ export default function PersonDossierPage() {
   const { person, messages, conversations, scheduled_touches, media_uses, media_assets, pending_links } = dossier as any
 
   return (
-    <div className="p-8 max-w-7xl">
+    <div className="p-4 sm:p-8 max-w-7xl">
       <div className="mb-4">
         <Link href="/admin/clapcheeks-ops/network" className="text-xs text-gray-500 hover:text-gray-300">
           ← back to network
@@ -68,12 +68,13 @@ export default function PersonDossierPage() {
 
       <OperatorPanel person={person} />
 
-      <div className="mt-6 flex gap-1 border-b border-gray-800">
+      {/* Tabs — scrollable on mobile so all tabs remain accessible */}
+      <div className="mt-6 flex gap-1 border-b border-gray-800 overflow-x-auto scrollbar-hide">
         {TABS.map((t) => (
           <button
             key={t}
             onClick={() => setTab(t)}
-            className={`px-4 py-2 text-sm rounded-t-md ${
+            className={`px-3 sm:px-4 py-2 text-xs sm:text-sm rounded-t-md whitespace-nowrap flex-shrink-0 ${
               tab === t
                 ? "bg-gray-900 text-white border border-gray-800 border-b-transparent"
                 : "text-gray-500 hover:text-gray-300"
@@ -84,7 +85,7 @@ export default function PersonDossierPage() {
         ))}
       </div>
 
-      <div className="bg-gray-900 border border-gray-800 border-t-0 rounded-b-md p-6 mb-8">
+      <div className="bg-gray-900 border border-gray-800 border-t-0 rounded-b-md p-4 sm:p-6 mb-8">
         {tab === "Timeline" && <TimelineTab messages={messages} conversations={conversations} />}
         {tab === "Memory" && <MemoryTab person={person} />}
         {tab === "Schedule" && <ScheduleTab person={person} touches={scheduled_touches} />}
@@ -113,11 +114,11 @@ function HeaderCard({ person }: { person: any }) {
   const lastEmotion = (person.emotional_state_recent ?? []).slice(-1)[0]?.state ?? "—"
 
   return (
-    <div className="bg-gradient-to-br from-purple-900/20 to-gray-900 border border-purple-800/40 rounded-lg p-6">
-      <div className="flex items-start justify-between">
-        <div>
-          <div className="flex items-center gap-3">
-            <h1 className="text-3xl font-bold">{person.display_name}</h1>
+    <div className="bg-gradient-to-br from-purple-900/20 to-gray-900 border border-purple-800/40 rounded-lg p-4 sm:p-6">
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 sm:gap-3 flex-wrap">
+            <h1 className="text-2xl sm:text-3xl font-bold">{person.display_name}</h1>
             {person.age && <span className="text-gray-500">· {person.age}</span>}
             <span className={`text-xs px-2 py-0.5 rounded ${
               person.whitelist_for_autoreply
@@ -130,26 +131,26 @@ function HeaderCard({ person }: { person: any }) {
             {person.location_observed || person.company || "—"}
             {person.occupation_observed ? ` · ${person.occupation_observed}` : ""}
           </div>
-          <div className="flex gap-4 mt-3 text-xs text-gray-400">
+          <div className="flex flex-wrap gap-2 sm:gap-4 mt-2 sm:mt-3 text-xs text-gray-400">
             <span>stage: <b className="text-purple-300">{person.courtship_stage ?? "early_chat"}</b></span>
             <span>cadence: {person.cadence_profile}</span>
-            <span>vibe: {person.conversation_temperature ?? "—"}</span>
-            <span>last emotion: {lastEmotion}</span>
+            <span className="hidden sm:inline">vibe: {person.conversation_temperature ?? "—"}</span>
+            <span>emo: {lastEmotion}</span>
           </div>
-          <div className="flex gap-4 mt-2 text-xs text-gray-500">
-            <span>inbound {lastInbound}</span>
-            <span>outbound {lastOutbound}</span>
-            <span>trust {trust}</span>
-            <span>ask-readiness {tta}</span>
-            <span>messages 30d {person.total_messages_30d ?? 0}</span>
+          <div className="flex flex-wrap gap-2 sm:gap-4 mt-1 sm:mt-2 text-xs text-gray-500">
+            <span>in {lastInbound}</span>
+            <span>out {lastOutbound}</span>
+            <span className="hidden sm:inline">trust {trust}</span>
+            <span className="hidden sm:inline">ask {tta}</span>
+            <span className="hidden sm:inline">msgs {person.total_messages_30d ?? 0}</span>
           </div>
         </div>
-        <div className="text-right text-xs text-gray-500 max-w-sm">
+        <div className="text-xs text-gray-500 sm:text-right sm:max-w-sm">
           {person.next_best_move && (
             <div className="text-purple-300 italic">💡 {person.next_best_move}</div>
           )}
           {person.zodiac_sign && (
-            <div className="mt-2 capitalize">♈ {person.zodiac_sign} · {person.disc_inference || "DISC ?"}</div>
+            <div className="mt-1 sm:mt-2 capitalize">♈ {person.zodiac_sign} · {person.disc_inference || "DISC ?"}</div>
           )}
         </div>
       </div>

--- a/web/app/admin/layout.tsx
+++ b/web/app/admin/layout.tsx
@@ -3,6 +3,13 @@ import { redirect } from "next/navigation"
 import { createClient } from "@/lib/supabase/server"
 import Link from "next/link"
 import { LayoutDashboard, Users, DollarSign, Radio, Shield, Rocket } from "lucide-react"
+import type { Viewport } from "next"
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: "#7C3AED",
+}
 
 const ADMIN_EMAILS = [
   "julian@clapcheeks.tech",
@@ -39,8 +46,8 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   return (
     <div className="min-h-screen bg-gray-950 text-gray-100 flex">
-      {/* Sidebar */}
-      <aside className="w-56 bg-gray-900 border-r border-gray-800 flex flex-col flex-shrink-0">
+      {/* Sidebar — hidden on mobile, visible md+ */}
+      <aside className="hidden md:flex w-56 bg-gray-900 border-r border-gray-800 flex-col flex-shrink-0">
         <div className="p-4 border-b border-gray-800">
           <div className="flex items-center gap-2">
             <Shield className="w-5 h-5 text-purple-400" />
@@ -70,8 +77,26 @@ export default async function AdminLayout({ children }: { children: React.ReactN
         </div>
       </aside>
 
-      {/* Main content */}
-      <main className="flex-1 overflow-auto">
+      {/* Mobile top nav bar */}
+      <div className="md:hidden fixed top-0 left-0 right-0 z-40 bg-gray-900/95 border-b border-gray-800 backdrop-blur-sm px-4 py-2 flex items-center gap-3 overflow-x-auto">
+        <div className="flex items-center gap-1.5 flex-shrink-0 mr-2">
+          <Shield className="w-4 h-4 text-purple-400" />
+          <span className="font-bold text-sm text-white">Admin</span>
+        </div>
+        {navItems.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="flex items-center gap-1.5 px-2 py-1.5 rounded text-xs text-gray-400 hover:text-white hover:bg-gray-800 transition-colors whitespace-nowrap flex-shrink-0"
+          >
+            <item.icon className="w-3.5 h-3.5" />
+            {item.label}
+          </Link>
+        ))}
+      </div>
+
+      {/* Main content — add top padding on mobile for the fixed nav bar */}
+      <main className="flex-1 overflow-auto md:mt-0 mt-12">
         {children}
       </main>
     </div>

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -65,10 +65,12 @@ export const metadata: Metadata = {
   },
   appleWebApp: {
     capable: true,
-    statusBarStyle: 'black',
+    title: 'Clapcheeks',
+    statusBarStyle: 'black-translucent',
   },
   other: {
-    'theme-color': '#000000',
+    'theme-color': '#7C3AED',
+    'mobile-web-app-capable': 'yes',
   },
   // Only allow indexing on production deploys. Vercel preview/dev stay noindex.
   robots:

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,3 +1,5 @@
+import withPWA from "@ducanh2912/next-pwa"
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   typescript: {
@@ -43,4 +45,51 @@ const nextConfig = {
   },
 }
 
-export default nextConfig
+// AI-9500 W7: Enable PWA via @ducanh2912/next-pwa so the service worker is
+// generated on every build with fresh content hashes. Offline-first for
+// navigation; network-first for everything else. Defensive — disables in dev.
+export default withPWA({
+  dest: "public",
+  disable: process.env.NODE_ENV === "development",
+  register: true,
+  skipWaiting: true,
+  reloadOnOnline: false,
+  fallbacks: {
+    // Serve the ops overview as offline fallback for admin nav requests
+    document: "/admin/clapcheeks-ops",
+  },
+  workboxOptions: {
+    // Don't precache Convex/Supabase API calls — always need fresh data
+    exclude: [/^https:\/\/.*\.convex\.cloud/, /^https:\/\/.*\.supabase\.co/],
+    runtimeCaching: [
+      {
+        // Navigation: network-first, cache as fallback
+        urlPattern: ({ request }) => request.mode === "navigate",
+        handler: "NetworkFirst",
+        options: {
+          cacheName: "cc-pages",
+          networkTimeoutSeconds: 5,
+          expiration: { maxEntries: 32, maxAgeSeconds: 86400 },
+        },
+      },
+      {
+        // Next.js static assets (content-addressed): cache-first forever
+        urlPattern: /\/_next\/static\/.+/,
+        handler: "CacheFirst",
+        options: {
+          cacheName: "cc-static",
+          expiration: { maxEntries: 256, maxAgeSeconds: 365 * 24 * 3600 },
+        },
+      },
+      {
+        // Icons, fonts, images
+        urlPattern: /\.(?:png|svg|ico|woff2?|jpg|jpeg|webp)$/i,
+        handler: "StaleWhileRevalidate",
+        options: {
+          cacheName: "cc-assets",
+          expiration: { maxEntries: 64, maxAgeSeconds: 7 * 24 * 3600 },
+        },
+      },
+    ],
+  },
+})(nextConfig)

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -2,12 +2,12 @@
   "name": "Clapcheeks — AI Dating Co-Pilot",
   "short_name": "Clapcheeks",
   "description": "Your AI dating co-pilot. Swipes, replies, and date bookings on autopilot.",
-  "start_url": "/dashboard",
+  "start_url": "/admin/clapcheeks-ops",
   "scope": "/",
   "display": "standalone",
   "display_override": ["window-controls-overlay", "standalone", "minimal-ui"],
-  "background_color": "#000000",
-  "theme_color": "#0A0A0A",
+  "background_color": "#030712",
+  "theme_color": "#7C3AED",
   "orientation": "any",
   "categories": ["lifestyle", "productivity", "social"],
   "icons": [
@@ -38,24 +38,24 @@
   ],
   "shortcuts": [
     {
-      "name": "Leads",
-      "short_name": "Leads",
-      "description": "Kanban of every match",
-      "url": "/leads",
+      "name": "Network",
+      "short_name": "Network",
+      "description": "Dating-relevant people ranked by priority",
+      "url": "/admin/clapcheeks-ops/network",
       "icons": [{ "src": "/icons/icon-192.png", "sizes": "192x192" }]
     },
     {
-      "name": "AI Settings",
-      "short_name": "AI",
-      "description": "Persona, drip rules, calendar",
-      "url": "/settings/ai",
+      "name": "Coach",
+      "short_name": "Coach",
+      "description": "Self-coaching dashboard — your patterns",
+      "url": "/admin/clapcheeks-ops/coach",
       "icons": [{ "src": "/icons/icon-192.png", "sizes": "192x192" }]
     },
     {
-      "name": "Dashboard",
-      "short_name": "Home",
-      "description": "Your stats and activity",
-      "url": "/dashboard",
+      "name": "Ops Overview",
+      "short_name": "Ops",
+      "description": "Clapcheeks ops control panel",
+      "url": "/admin/clapcheeks-ops",
       "icons": [{ "src": "/icons/icon-192.png", "sizes": "192x192" }]
     }
   ],


### PR DESCRIPTION
## Summary
- Enable `@ducanh2912/next-pwa` in `next.config.mjs`: generates a network-first Workbox service worker on every build with fresh content hashes; excludes Convex/Supabase API calls from caching; ops overview as offline navigation fallback
- `manifest.json`: `theme_color` → purple accent `#7C3AED`, `start_url` → `/admin/clapcheeks-ops`, shortcuts updated to Network / Coach / Ops (ops-relevant)
- `layout.tsx`: `appleWebApp.title`, `black-translucent` status bar style, `mobile-web-app-capable` meta for Android Chrome
- `admin/layout.tsx`: sidebar collapses on mobile (`hidden md:flex`); fixed scrollable top-nav bar for mobile (`md:hidden`, `overflow-x-auto`); main content adds `mt-12` on mobile for the nav bar; `Viewport` export with `themeColor`
- `admin/clapcheeks-ops/network/page.tsx`: responsive header stacks on mobile; search input full-width; person rows hide secondary stats (trust/ask/platforms/curiosity) on narrow screens; compact emo+inbound row on mobile
- `admin/clapcheeks-ops/coach/page.tsx`: responsive padding + header; cards already `1→2col at lg`
- `admin/clapcheeks-ops/people/[id]/page.tsx`: outer padding `p-4 sm:p-8`; tabs scrollable on mobile (`overflow-x-auto`, `whitespace-nowrap`, `flex-shrink-0`); header card stacks on mobile; secondary stats hidden on `sm`
- `admin/clapcheeks-ops/page.tsx`: responsive padding; stat cards `1-col → 2-col sm+`

## Test plan
- [ ] `npm run build` in `web/` passes (TS errors ignored; next-pwa generates `public/sw.js` + `public/workbox-*.js` as build artifacts)
- [ ] Open `/admin/clapcheeks-ops/network` at 390px viewport — header stacks, search full-width, person rows readable
- [ ] Open `/admin/clapcheeks-ops/coach` at 390px — cards stack vertically, header stacks
- [ ] Open `/admin/clapcheeks-ops/people/[id]` at 390px — tabs scroll horizontally without overflow, header stacks
- [ ] Mobile top-nav shows on screens < 768px; desktop sidebar visible md+
- [ ] Chrome DevTools → Application → Manifest shows Clapcheeks with purple theme
- [ ] Chrome DevTools → Application → Service Workers shows SW registered after build
- [ ] iOS Safari: "Add to Home Screen" works; shows Clapcheeks icon + title

🤖 Generated with [Claude Code](https://claude.com/claude-code)