### PR TITLE
feat(clapcheeks): AI-9500 W2 calls integration

### DIFF
--- a/clapcheeks-local/clapcheeks/convex_runner.py
+++ b/clapcheeks-local/clapcheeks/convex_runner.py
@@ -258,3 +258,198 @@ def _draft_with_template(
 
     # Hardcoded fallback — always safe to send.
     return ["figured I'd just say hey"]
+
+
+# ---------------------------------------------------------------------------
+# AI-9500 W2 E13 — call sync handler
+#
+# Reads call records from chat.db (the message table has item_type=2 for
+# audio/video calls and a non-null audio_files / was_data_detected column on
+# FaceTime calls).  We use the following columns:
+#
+#   message.item_type        — 2 = attachment/call event (audio call)
+#   message.is_from_me       — 1 = outbound, 0 = inbound
+#   message.date             — Apple CoreData timestamp (ns since 2001-01-01)
+#   message.date_delivered   — non-zero for connected calls
+#   message.was_delivered_quietly — sometimes set for missed
+#   handle.id                — phone / iMessage handle
+#   message.service          — "iMessage" or "SMS" (FaceTime shows as iMessage)
+#   message.text             — may contain "FaceTime" for FaceTime audio/video
+#
+# Simpler approach used here:  messages whose `text` IS NULL and `item_type`
+# IN (2, 3) or whose text matches FaceTime-style system text.  We also capture
+# plain audio calls via `message.service` = 'iMessage' and text NULL.
+#
+# We look for:
+#   - "FaceTime Audio" or "FaceTime Video" in the text or cache_has_attachments > 0
+#     with item_type in (2, 3) → platform = "facetime"
+#   - item_type = 2, service = "iMessage", text IS NULL → platform = "imessage_native"
+#
+# Duration: chat.db does NOT store call duration for iMessage/FaceTime natively
+# (it is not surfaced in the SQLite schema the way WhatsApp does it).  We
+# store None and allow a future patch via the upsertCall mutation if Twilio
+# or another source provides it.
+#
+# This handler is registered in agent_jobs as job_type = "sync_calls".
+# The cron at /clapcheeks-local/clapcheeks/agent_jobs.py enqueues it every
+# 15 minutes.
+# ---------------------------------------------------------------------------
+
+import datetime
+import sqlite3
+from pathlib import Path
+from typing import Optional, Any
+
+CHAT_DB_PATH = Path.home() / "Library" / "Messages" / "chat.db"
+
+# Apple's reference epoch: 2001-01-01 00:00:00 UTC
+_APPLE_EPOCH_TS = datetime.datetime(2001, 1, 1, tzinfo=datetime.timezone.utc).timestamp()
+
+# How far back to look on each poll (avoids re-scanning the full DB forever)
+_CALL_LOOKBACK_DAYS = 30
+
+
+def _apple_ns_to_epoch_ms(ns_ts: Optional[int]) -> Optional[int]:
+    """Convert an Apple CoreData nanosecond timestamp to Unix milliseconds."""
+    if ns_ts is None or ns_ts == 0:
+        return None
+    seconds = ns_ts / 1_000_000_000.0
+    return int((_APPLE_EPOCH_TS + seconds) * 1_000)
+
+
+def _handle_sync_calls(
+    convex_client: Any,
+    user_id: str,
+    *,
+    lookback_days: int = _CALL_LOOKBACK_DAYS,
+) -> dict[str, int]:
+    """Poll chat.db for call records and upsert them to Convex.
+
+    Args:
+        convex_client: A convex Python client instance with a ``mutation`` method.
+        user_id: The Convex user_id (typically "fleet-julian").
+        lookback_days: How many days back to scan (default 30).
+
+    Returns:
+        Dict with keys ``scanned``, ``upserted``, ``skipped``.
+    """
+    if not CHAT_DB_PATH.exists():
+        logger.warning("[sync_calls] chat.db not found at %s — skipping", CHAT_DB_PATH)
+        return {"scanned": 0, "upserted": 0, "skipped": 0}
+
+    # Open read-only via URI
+    try:
+        conn = sqlite3.connect(
+            f"file:{CHAT_DB_PATH}?mode=ro",
+            uri=True,
+            timeout=10,
+        )
+        conn.row_factory = sqlite3.Row
+    except sqlite3.OperationalError as exc:
+        logger.warning("[sync_calls] Cannot open chat.db: %s", exc)
+        return {"scanned": 0, "upserted": 0, "skipped": 0}
+
+    # Compute the Apple timestamp for our lookback window
+    now_unix = datetime.datetime.now(datetime.timezone.utc).timestamp()
+    lookback_unix = now_unix - lookback_days * 86400
+    # Convert back to Apple nanoseconds
+    lookback_apple_ns = int((lookback_unix - _APPLE_EPOCH_TS) * 1_000_000_000)
+
+    # Detect calls:
+    # item_type = 2 or 3 in the message table often marks call events.
+    # We also include messages where `text` IS NULL and `service` = 'iMessage'
+    # with an associated audio/video attachment (cache_has_attachments = 1).
+    # Broadest safe filter: item_type IN (2, 3) OR text LIKE '%FaceTime%'
+    CALL_SQL = """
+        SELECT
+            m.ROWID         AS msg_id,
+            m.date          AS apple_date,
+            m.is_from_me    AS is_from_me,
+            m.service       AS service,
+            m.text          AS msg_text,
+            m.item_type     AS item_type,
+            m.was_delivered_quietly AS was_quiet,
+            h.id            AS handle_value
+        FROM message m
+        LEFT JOIN handle h ON h.ROWID = m.handle_id
+        WHERE m.date > ?
+          AND (
+              m.item_type IN (2, 3)
+              OR (m.text IS NOT NULL AND m.text LIKE '%FaceTime%')
+          )
+        ORDER BY m.date ASC
+        LIMIT 2000
+    """
+
+    scanned = 0
+    upserted = 0
+    skipped = 0
+
+    try:
+        cursor = conn.execute(CALL_SQL, (lookback_apple_ns,))
+        rows = cursor.fetchall()
+    except sqlite3.OperationalError as exc:
+        logger.warning("[sync_calls] Query failed: %s", exc)
+        conn.close()
+        return {"scanned": 0, "upserted": 0, "skipped": 0}
+    finally:
+        conn.close()
+
+    for row in rows:
+        scanned += 1
+        started_at_ms = _apple_ns_to_epoch_ms(row["apple_date"])
+        if started_at_ms is None:
+            skipped += 1
+            continue
+
+        # Determine platform
+        msg_text = row["msg_text"] or ""
+        service = row["service"] or ""
+        if "FaceTime" in msg_text:
+            platform = "facetime"
+        elif service.lower() in ("imessage", "iMessage"):
+            platform = "imessage_native"
+        else:
+            platform = "phone_native"
+
+        # Direction: is_from_me=1 → outbound.
+        # "Missed" detection: was_delivered_quietly=1 is sometimes set for missed;
+        # more reliably, item_type=3 often marks a missed FaceTime.
+        is_from_me = bool(row["is_from_me"])
+        was_quiet = bool(row["was_quiet"])
+        item_type = row["item_type"]
+
+        if is_from_me:
+            direction = "outbound"
+        elif item_type == 3 or was_quiet:
+            direction = "missed"
+        else:
+            direction = "inbound"
+
+        handle_value = row["handle_value"] or None
+
+        try:
+            convex_client.mutation(
+                "calls:upsertCall",
+                {
+                    "user_id": user_id,
+                    "direction": direction,
+                    "started_at_ms": started_at_ms,
+                    "handle_value": handle_value,
+                    "platform": platform,
+                },
+            )
+            upserted += 1
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[sync_calls] upsertCall failed for row %s: %s",
+                row["msg_id"],
+                exc,
+            )
+            skipped += 1
+
+    logger.info(
+        "[sync_calls] done — scanned=%d upserted=%d skipped=%d",
+        scanned, upserted, skipped,
+    )
+    return {"scanned": scanned, "upserted": upserted, "skipped": skipped}

--- a/web/app/admin/clapcheeks-ops/coach/page.tsx
+++ b/web/app/admin/clapcheeks-ops/coach/page.tsx
@@ -40,8 +40,10 @@ function daysAgo(ms: number | undefined): string {
 // ---------------------------------------------------------------------------
 // Top summary KPI bar
 // ---------------------------------------------------------------------------
-function SummaryCard({ summary }: { summary: any }) {
+function SummaryCard({ summary, callStats }: { summary: any; callStats: any }) {
   if (!summary) return <div className="text-sm text-gray-500">Loading summary…</div>
+
+  const callsTotal = callStats?.total_30d ?? "—"
 
   const kpis = [
     { label: "Active threads", value: summary.active_threads },
@@ -58,15 +60,17 @@ function SummaryCard({ summary }: { summary: any }) {
     },
     { label: "Kissed (notes)", value: summary.kissed_this_month },
     { label: "Closed (notes)", value: summary.slept_with_this_month },
+    // AI-9500 W2 E13 — call stat
+    { label: "📞 Calls (30d)", value: callsTotal },
   ]
 
   return (
-    <div className="grid grid-cols-3 md:grid-cols-6 gap-3 mb-8">
+    <div className="grid grid-cols-3 md:grid-cols-7 gap-3 mb-8">
       {kpis.map((kpi) => (
         <div
           key={kpi.label}
           className={`bg-gray-900 border rounded-lg p-4 text-center ${
-            kpi.warn ? "border-amber-700" : "border-gray-800"
+            (kpi as any).warn ? "border-amber-700" : "border-gray-800"
           }`}
         >
           <div className="text-2xl font-bold">{kpi.value ?? "—"}</div>
@@ -74,6 +78,60 @@ function SummaryCard({ summary }: { summary: any }) {
         </div>
       ))}
     </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// CallsCard — 30-day call breakdown for /coach
+// AI-9500 W2 E13
+// ---------------------------------------------------------------------------
+function CallsCard({ data }: { data: any }) {
+  if (!data) return <CardShell title="Calls (30d)" loading />
+
+  const { total_30d, by_direction, avg_duration_seconds } = data
+
+  if (total_30d === 0) {
+    return (
+      <CardShell title="📞 Calls (30d)" action="No calls logged this month — consider voice-based check-ins.">
+        <p className="text-sm text-gray-500">Connect a call source or log manually.</p>
+      </CardShell>
+    )
+  }
+
+  const durationLabel = avg_duration_seconds
+    ? (() => {
+        const m = Math.floor(avg_duration_seconds / 60)
+        const s = avg_duration_seconds % 60
+        return m > 0 ? `${m}m${s > 0 ? `${s}s` : ""}` : `${s}s`
+      })()
+    : null
+
+  const action = `${total_30d} calls in 30d — ${by_direction.missed} missed${durationLabel ? `, avg ${durationLabel}` : ""}.`
+
+  return (
+    <CardShell title="📞 Calls (30d)" action={action}>
+      <div className="grid grid-cols-3 gap-3 text-center text-sm">
+        <div>
+          <div className="text-xl font-bold text-blue-400">{by_direction.outbound}</div>
+          <div className="text-xs text-gray-500">outbound</div>
+        </div>
+        <div>
+          <div className="text-xl font-bold text-green-400">{by_direction.inbound}</div>
+          <div className="text-xs text-gray-500">inbound</div>
+        </div>
+        <div>
+          <div className={`text-xl font-bold ${by_direction.missed > 0 ? "text-red-400" : "text-gray-500"}`}>
+            {by_direction.missed}
+          </div>
+          <div className="text-xs text-gray-500">missed</div>
+        </div>
+      </div>
+      {durationLabel && (
+        <div className="mt-3 text-xs text-gray-400 text-center">
+          avg duration: {durationLabel}
+        </div>
+      )}
+    </CardShell>
   )
 }
 
@@ -466,6 +524,8 @@ export default function CoachPage() {
   const cutList = useQuery(api.coach.getCutListCandidates, { user_id: FLEET_USER_ID })
   const stuckInStage = useQuery(api.coach.getStuckInStage, { user_id: FLEET_USER_ID })
   const heatmap = useQuery(api.coach.getTimeOfDayHeatmap, { user_id: FLEET_USER_ID })
+  // AI-9500 W2 E13 — call stats for /coach KPI bar + breakdown card
+  const callStats = useQuery(api.calls.recentForCoach, { user_id: FLEET_USER_ID })
 
   return (
     <div className="p-8 max-w-7xl">
@@ -483,8 +543,8 @@ export default function CoachPage() {
         Your patterns across all active threads — last 30 days. Each card has one thing to do.
       </p>
 
-      {/* KPI Summary */}
-      <SummaryCard summary={summary} />
+      {/* KPI Summary — includes calls (30d) stat */}
+      <SummaryCard summary={summary} callStats={callStats} />
 
       {/* 2-column grid for the cards */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -494,6 +554,8 @@ export default function CoachPage() {
         <OpenerOveruseCard data={openerOveruse} />
         <LateNightCard data={lateNight} />
         <HeatmapCard data={heatmap} />
+        {/* AI-9500 W2 E13 — calls breakdown card */}
+        <CallsCard data={callStats} />
       </div>
     </div>
   )

--- a/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
+++ b/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
@@ -38,6 +38,8 @@ export default function PersonDossierPage() {
   const params = useParams<{ id: string }>()
   const personId = params.id as Id<"people">
   const dossier = useQuery(api.people.getDossier, { person_id: personId })
+  // AI-9500 W2 E13 — call history for this person
+  const calls = useQuery(api.calls.listForPerson, { person_id: personId, limit: 100 })
   const [tab, setTab] = useState<TabName>("Timeline")
 
   if (dossier === undefined) {
@@ -85,7 +87,7 @@ export default function PersonDossierPage() {
       </div>
 
       <div className="bg-gray-900 border border-gray-800 border-t-0 rounded-b-md p-6 mb-8">
-        {tab === "Timeline" && <TimelineTab messages={messages} conversations={conversations} />}
+        {tab === "Timeline" && <TimelineTab messages={messages} conversations={conversations} calls={calls ?? []} />}
         {tab === "Memory" && <MemoryTab person={person} />}
         {tab === "Schedule" && <ScheduleTab person={person} touches={scheduled_touches} />}
         {tab === "Media" && <MediaTab uses={media_uses} assets={media_assets} />}
@@ -346,19 +348,104 @@ function Select({
 // ---------------------------------------------------------------------------
 // Timeline tab — recent messages, ascending (oldest first within the slice)
 // ---------------------------------------------------------------------------
-function TimelineTab({ messages, conversations }: { messages: any[]; conversations: any[] }) {
-  const ordered = useMemo(() => [...messages].reverse(), [messages]) // newest at bottom
-  if (!ordered.length) {
-    return <div className="text-gray-500 text-sm">No messages yet.</div>
+// ---------------------------------------------------------------------------
+// CallBubble — single call entry in the timeline
+// ---------------------------------------------------------------------------
+function CallBubble({ call }: { call: any }) {
+  const isMissed = call.direction === "missed"
+  const isOut = call.direction === "outbound"
+
+  const icon = isMissed ? "📵" : "📞"
+  const label = isMissed
+    ? "missed call"
+    : isOut
+    ? "outbound call"
+    : "inbound call"
+
+  const durationLabel = (() => {
+    if (call.duration_seconds === undefined || call.duration_seconds === null) return ""
+    const m = Math.floor(call.duration_seconds / 60)
+    const s = call.duration_seconds % 60
+    if (m === 0) return ` · ${s}s`
+    return ` · ${m}m${s > 0 ? `${s}s` : ""}`
+  })()
+
+  const platformLabel = call.platform
+    ? ` · ${call.platform.replace("_", " ")}`
+    : ""
+
+  const ts = new Date(call.started_at_ms).toLocaleString()
+
+  return (
+    <div className={`flex ${isOut ? "justify-end" : "justify-start"}`}>
+      <div className={`rounded-lg px-3 py-2 border text-sm ${
+        isMissed
+          ? "bg-red-900/20 border-red-700/40 text-red-300"
+          : isOut
+          ? "bg-blue-900/20 border-blue-700/40 text-blue-200"
+          : "bg-gray-800 border-gray-700 text-gray-200"
+      }`}>
+        <span className="mr-1">{icon}</span>
+        <span className="font-medium">{label}</span>
+        {durationLabel && <span className="text-xs opacity-70">{durationLabel}</span>}
+        {call.notes && (
+          <div className="text-xs opacity-60 mt-0.5 italic">{call.notes}</div>
+        )}
+        <div className="text-[10px] text-gray-500 mt-1">
+          {ts}{platformLabel}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// TimelineTab — messages + calls interleaved by timestamp
+// ---------------------------------------------------------------------------
+function TimelineTab({
+  messages,
+  conversations,
+  calls,
+}: {
+  messages: any[]
+  conversations: any[]
+  calls: any[]
+}) {
+  // Build a unified event list sorted by timestamp (oldest at top, newest at bottom)
+  const unified = useMemo(() => {
+    const msgEvents = messages.map((m: any) => ({
+      kind: "message" as const,
+      ts: m.sent_at,
+      data: m,
+    }))
+    const callEvents = calls.map((c: any) => ({
+      kind: "call" as const,
+      ts: c.started_at_ms,
+      data: c,
+    }))
+    return [...msgEvents, ...callEvents].sort((a, b) => a.ts - b.ts)
+  }, [messages, calls])
+
+  if (!unified.length) {
+    return <div className="text-gray-500 text-sm">No messages or calls yet.</div>
   }
-  const platforms = Array.from(new Set(conversations.map((c) => c.platform)))
+
+  const platforms = Array.from(new Set(conversations.map((c: any) => c.platform)))
+  const callCount = calls.length
+
   return (
     <div>
       <div className="text-xs text-gray-500 mb-3">
-        {ordered.length} messages across {conversations.length} conversation(s) · {platforms.join(", ")}
+        {messages.length} messages across {conversations.length} conversation(s) ·{" "}
+        {callCount > 0 ? `${callCount} call(s) · ` : ""}
+        {platforms.join(", ")}
       </div>
       <div className="space-y-2 max-h-[60vh] overflow-y-auto pr-2">
-        {ordered.map((m: any) => {
+        {unified.map((event) => {
+          if (event.kind === "call") {
+            return <CallBubble key={`call-${event.data._id}`} call={event.data} />
+          }
+          const m = event.data
           const isOut = m.direction === "outbound"
           const ts = new Date(m.sent_at).toLocaleString()
           return (

--- a/web/convex/agent_jobs.ts
+++ b/web/convex/agent_jobs.ts
@@ -214,3 +214,61 @@ export const reapStuck = internalMutation({
 
 // (Duplicate enqueueHingeSync from main was removed during integration→main merge.
 // The canonical version above accepts an optional user_id arg.)
+
+// ---------------------------------------------------------------------------
+// AI-9500 W2 E13 — enqueueCallsSync
+//
+// Enqueues a sync_calls job for the Mac Mini daemon every 15 minutes.
+// The daemon reads chat.db via _handle_sync_calls in convex_runner.py and
+// upserts records via calls:upsertCall.
+// Dedup guard: skips if a queued or running job already exists.
+// ---------------------------------------------------------------------------
+export const enqueueCallsSync = internalMutation({
+  args: {
+    user_id: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const userId = args.user_id ?? "fleet-julian";
+    const now = Date.now();
+
+    // Skip if one is already queued
+    const existingQueued = await ctx.db
+      .query("agent_jobs")
+      .withIndex("by_user_status", (q) =>
+        q.eq("user_id", userId).eq("status", "queued"),
+      )
+      .filter((q) => q.eq(q.field("job_type"), "sync_calls"))
+      .first();
+
+    if (existingQueued) {
+      return { enqueued: false, reason: "already_queued", job_id: existingQueued._id };
+    }
+
+    // Skip if one is actively running
+    const existingRunning = await ctx.db
+      .query("agent_jobs")
+      .withIndex("by_user_status", (q) =>
+        q.eq("user_id", userId).eq("status", "running"),
+      )
+      .filter((q) => q.eq(q.field("job_type"), "sync_calls"))
+      .first();
+
+    if (existingRunning) {
+      return { enqueued: false, reason: "already_running", job_id: existingRunning._id };
+    }
+
+    const id = await ctx.db.insert("agent_jobs", {
+      user_id: userId,
+      job_type: "sync_calls",
+      payload: { lookback_days: 30 },
+      status: "queued",
+      priority: 0,
+      attempts: 0,
+      max_attempts: 3,
+      created_at: now,
+      updated_at: now,
+    });
+
+    return { enqueued: true, reason: null, job_id: id };
+  },
+});

--- a/web/convex/calls.ts
+++ b/web/convex/calls.ts
@@ -1,0 +1,291 @@
+/**
+ * calls.ts — Convex backend for call tracking.
+ *
+ * AI-9500 W2 E13 — surfaces call timestamps in the unified person
+ * dossier Timeline tab and on /coach as a 30-day stat.
+ *
+ * Schema table `calls` was deployed in AI-9500-F.  This file adds:
+ *   upsertCall     — mutation: webhook ingest + manual entry (idempotent)
+ *   listForPerson  — query: all calls for a specific person
+ *   listForUser    — query: all calls for a user (newest first)
+ *   recentForCoach — query: last-30d call count + per-day breakdown for /coach
+ */
+
+import { mutation, query, internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// upsertCall
+//
+// Idempotent ingest from the Mac Mini daemon or manual entry.  Dedup key:
+//   (user_id, handle_value, started_at_ms, platform) — two calls within the
+//   same second on the same handle are treated as the same event.
+//
+// If no matching row exists, inserts a new one.
+// If a row exists but duration_seconds was missing and we now have it, patches.
+// ---------------------------------------------------------------------------
+export const upsertCall = mutation({
+  args: {
+    user_id: v.string(),
+    person_id: v.optional(v.id("people")),
+    direction: v.union(
+      v.literal("inbound"),
+      v.literal("outbound"),
+      v.literal("missed"),
+    ),
+    started_at_ms: v.number(),
+    duration_seconds: v.optional(v.number()),
+    handle_value: v.optional(v.string()),
+    platform: v.optional(
+      v.union(
+        v.literal("imessage_native"),
+        v.literal("facetime"),
+        v.literal("twilio"),
+        v.literal("phone_native"),
+      ),
+    ),
+    notes: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    // Dedup: look for an existing record within 5 seconds on the same handle+platform
+    const windowStart = args.started_at_ms - 5_000;
+    const windowEnd = args.started_at_ms + 5_000;
+
+    const existing = await ctx.db
+      .query("calls")
+      .withIndex("by_user_started", (q) =>
+        q
+          .eq("user_id", args.user_id)
+          .gt("started_at_ms", windowStart)
+      )
+      .filter((q) =>
+        q.and(
+          q.lt(q.field("started_at_ms"), windowEnd),
+          args.handle_value
+            ? q.eq(q.field("handle_value"), args.handle_value)
+            : q.eq(q.field("handle_value"), undefined),
+          args.platform
+            ? q.eq(q.field("platform"), args.platform)
+            : q.eq(q.field("platform"), undefined),
+        ),
+      )
+      .first();
+
+    if (existing) {
+      // Patch duration if we now have it and didn't before
+      if (
+        args.duration_seconds !== undefined &&
+        existing.duration_seconds === undefined
+      ) {
+        await ctx.db.patch(existing._id, {
+          duration_seconds: args.duration_seconds,
+          notes: args.notes ?? existing.notes,
+          person_id: args.person_id ?? existing.person_id,
+        });
+      }
+      return existing._id;
+    }
+
+    return await ctx.db.insert("calls", {
+      user_id: args.user_id,
+      person_id: args.person_id,
+      direction: args.direction,
+      started_at_ms: args.started_at_ms,
+      duration_seconds: args.duration_seconds,
+      handle_value: args.handle_value,
+      platform: args.platform,
+      notes: args.notes,
+      created_at: Date.now(),
+    });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// listForPerson
+//
+// All calls linked to a specific person, newest first, capped at `limit`.
+// Used by the dossier Timeline tab.
+// ---------------------------------------------------------------------------
+export const listForPerson = query({
+  args: {
+    person_id: v.id("people"),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, { person_id, limit = 50 }) => {
+    return await ctx.db
+      .query("calls")
+      .withIndex("by_person", (q) => q.eq("person_id", person_id))
+      .order("desc")
+      .take(limit);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// listForUser
+//
+// All calls for a user, newest first, capped at `limit`.
+// Useful for a global activity log.
+// ---------------------------------------------------------------------------
+export const listForUser = query({
+  args: {
+    user_id: v.string(),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, { user_id, limit = 100 }) => {
+    return await ctx.db
+      .query("calls")
+      .withIndex("by_user", (q) => q.eq("user_id", user_id))
+      .order("desc")
+      .take(limit);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// recentForCoach
+//
+// Aggregates calls for /coach: last-30d total count + per-day breakdown.
+//
+// Returns:
+//   total_30d          — total call count last 30 days
+//   by_day             — array of { date_iso: string; count: number }
+//                        ordered ascending, only days with calls included
+//   by_direction       — { inbound, outbound, missed } totals
+//   avg_duration_seconds — mean duration of non-missed calls, or null
+// ---------------------------------------------------------------------------
+export const recentForCoach = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, { user_id }) => {
+    const cutoff = Date.now() - THIRTY_DAYS_MS;
+
+    const recent = await ctx.db
+      .query("calls")
+      .withIndex("by_user_started", (q) =>
+        q.eq("user_id", user_id).gt("started_at_ms", cutoff),
+      )
+      .order("asc")
+      .collect();
+
+    // Aggregate by day (ISO date string, UTC)
+    const dayMap = new Map<string, number>();
+    let inbound = 0;
+    let outbound = 0;
+    let missed = 0;
+    let durationSum = 0;
+    let durationCount = 0;
+
+    for (const call of recent) {
+      const d = new Date(call.started_at_ms);
+      const iso = d.toISOString().slice(0, 10); // "YYYY-MM-DD"
+      dayMap.set(iso, (dayMap.get(iso) ?? 0) + 1);
+
+      if (call.direction === "inbound") inbound++;
+      else if (call.direction === "outbound") outbound++;
+      else missed++;
+
+      if (call.duration_seconds !== undefined) {
+        durationSum += call.duration_seconds;
+        durationCount++;
+      }
+    }
+
+    const by_day = Array.from(dayMap.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date_iso, count]) => ({ date_iso, count }));
+
+    return {
+      total_30d: recent.length,
+      by_day,
+      by_direction: { inbound, outbound, missed },
+      avg_duration_seconds:
+        durationCount > 0
+          ? Math.round(durationSum / durationCount)
+          : null,
+    };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// internalUpsertCall
+//
+// Internal variant for server-side use (e.g., http.ts webhook handler).
+// Same logic as upsertCall but callable without a client auth token.
+// ---------------------------------------------------------------------------
+export const internalUpsertCall = internalMutation({
+  args: {
+    user_id: v.string(),
+    person_id: v.optional(v.id("people")),
+    direction: v.union(
+      v.literal("inbound"),
+      v.literal("outbound"),
+      v.literal("missed"),
+    ),
+    started_at_ms: v.number(),
+    duration_seconds: v.optional(v.number()),
+    handle_value: v.optional(v.string()),
+    platform: v.optional(
+      v.union(
+        v.literal("imessage_native"),
+        v.literal("facetime"),
+        v.literal("twilio"),
+        v.literal("phone_native"),
+      ),
+    ),
+    notes: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const windowStart = args.started_at_ms - 5_000;
+    const windowEnd = args.started_at_ms + 5_000;
+
+    const existing = await ctx.db
+      .query("calls")
+      .withIndex("by_user_started", (q) =>
+        q
+          .eq("user_id", args.user_id)
+          .gt("started_at_ms", windowStart),
+      )
+      .filter((q) =>
+        q.and(
+          q.lt(q.field("started_at_ms"), windowEnd),
+          args.handle_value
+            ? q.eq(q.field("handle_value"), args.handle_value)
+            : q.eq(q.field("handle_value"), undefined),
+          args.platform
+            ? q.eq(q.field("platform"), args.platform)
+            : q.eq(q.field("platform"), undefined),
+        ),
+      )
+      .first();
+
+    if (existing) {
+      if (
+        args.duration_seconds !== undefined &&
+        existing.duration_seconds === undefined
+      ) {
+        await ctx.db.patch(existing._id, {
+          duration_seconds: args.duration_seconds,
+          notes: args.notes ?? existing.notes,
+          person_id: args.person_id ?? existing.person_id,
+        });
+      }
+      return existing._id;
+    }
+
+    return await ctx.db.insert("calls", {
+      user_id: args.user_id,
+      person_id: args.person_id,
+      direction: args.direction,
+      started_at_ms: args.started_at_ms,
+      duration_seconds: args.duration_seconds,
+      handle_value: args.handle_value,
+      platform: args.platform,
+      notes: args.notes,
+      created_at: Date.now(),
+    });
+  },
+});

--- a/web/convex/crons.ts
+++ b/web/convex/crons.ts
@@ -92,6 +92,15 @@ crons.interval(
   { user_id: "fleet-julian" },
 );
 
+// AI-9500 W2 E13 — Enqueue a call sync job every 15 minutes.
+// The Mac Mini daemon picks up sync_calls jobs and polls chat.db for
+// iMessage / FaceTime call events, upserting via calls:upsertCall.
+crons.interval(
+  "enqueue-calls-sync",
+  { minutes: 15 },
+  internal.agent_jobs.enqueueCallsSync,
+);
+
 // AI-9500-C: Enqueue a Hinge message sync job every 5 minutes.
 // The local Mac Mini agent (convex_runner.py) claims and executes the job
 // via hinge_poller.poll_hinge(). Dedup guard inside enqueueHingeSync prevents


### PR DESCRIPTION
## Summary

- **New `web/convex/calls.ts`** — 4 public functions: `upsertCall` (idempotent dedup on handle+timestamp window), `listForPerson`, `listForUser`, `recentForCoach` (30d aggregation by day/direction/avg duration). Plus `internalUpsertCall` for server-side webhook use.
- **Dossier Timeline tab** (`people/[id]/page.tsx`) — interleaves 📞 outbound / 📵 missed / inbound call bubbles chronologically with messages. New `CallBubble` component shows platform, duration, direction, timestamp.
- **`/coach` page** — new `CallsCard` with inbound/outbound/missed breakdown + avg duration. `SummaryCard` KPI bar gains a `📞 Calls (30d)` stat tile (7-column grid, was 6).
- **`agent_jobs.ts`** — `enqueueCallsSync` internalMutation with dedup guard (skips if queued/running).
- **`crons.ts`** — `enqueue-calls-sync` every 15 minutes.
- **`clapcheeks-local/clapcheeks/convex_runner.py`** — `_handle_sync_calls` polls `chat.db` for iMessage/FaceTime call records (`item_type IN (2,3)`, `text LIKE '%FaceTime%'`), maps direction (outbound/missed/inbound), upserts via `calls:upsertCall`.

## Test plan
- [x] `upsertCall` mutation inserts a row (smoke-tested against valiant-oriole-651, returned ID)
- [x] `recentForCoach` query returns correct 30d aggregation with avg_duration_seconds
- [x] Dossier page compiles with new `calls` prop on `TimelineTab`
- [x] Coach page compiles with `CallsCard` + updated `SummaryCard`
- [x] Convex deploy succeeded without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)