### PR TITLE
fix(clapcheeks): AI-9500 W2 dedupe voiceBusy useState — fixes prod build

### DIFF
--- a/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
+++ b/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
@@ -950,8 +950,6 @@ function ScheduleTab({ person, touches }: { person: any; touches: any[] }) {
   // AI-9500 W2 #G — voice memo state
   const [voiceBusy, setVoiceBusy] = useState<string | null>(null)   // touch_id being marked
 
-  const [voiceBusy, setVoiceBusy] = useState<string | null>(null)
-
   const upcoming = touches.filter((t) => t.status === "scheduled" && !t.is_preview)
   const fired = touches.filter((t) => t.status === "fired").slice(0, 10)
   const skipped = touches.filter((t) => t.status === "skipped").slice(0, 10)


### PR DESCRIPTION
Vercel build failing on main with: Module parse failed: Identifier voiceBusy has already been declared (1321:11). Wave2 #G voice-memo agent + another agent both inserted the same useState. Removes the duplicate. 2-line surgical fix.