### PR TITLE
fix(clapcheeks): AI-9526 better empty states + over-pursue dating filter

### DIFF
--- a/web/app/admin/clapcheeks-ops/coach/page.tsx
+++ b/web/app/admin/clapcheeks-ops/coach/page.tsx
@@ -682,11 +682,6 @@ export default function CoachPage() {
         <RosterCard kpis={rosterKpis} />
       </div>
 
-      {/* Roster KPIs — full width */}
-      <div className="mb-4 sm:mb-6">
-        <RosterCard kpis={rosterKpis} />
-      </div>
-
       {/* Cards — 1 col on mobile, 2 col on lg+ */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6">
         <OverPursueCard data={overPursue} />

--- a/web/app/admin/clapcheeks-ops/network/page.tsx
+++ b/web/app/admin/clapcheeks-ops/network/page.tsx
@@ -278,8 +278,12 @@ function PersonRow({ p, showArchiveInfo }: { p: any; showArchiveInfo?: boolean }
           <div className="sm:hidden text-xs text-gray-500 mt-0.5">
             {lastInbound} · {lastEmotion}
           </div>
-          {p.next_best_move && (
+          {p.next_best_move ? (
             <div className="text-sm text-purple-300 mt-1.5 line-clamp-1">💡 {p.next_best_move}</div>
+          ) : (
+            <div className="text-xs text-gray-600 mt-1.5 italic line-clamp-1">
+              💡 Awaiting enrichment — sweep populates next-move every 6h
+            </div>
           )}
           {p.curiosity_ledger && p.curiosity_ledger.filter((q: any) => q.status === "pending").length > 0 && (
             <div className="hidden sm:block text-xs text-gray-400 mt-1 line-clamp-1">

--- a/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
+++ b/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
@@ -452,8 +452,25 @@ function OperatorPanel({ person }: { person: any }) {
     await save("boundaries_stated", next)
   }
 
+  // AI-9526 — enrichment status banner
+  const lastEnriched = person.courtship_last_analyzed
+  const lastVibed = person.vibe_classified_at
+  const enrichmentAge = lastEnriched ? Math.floor((Date.now() - lastEnriched) / (24 * 3600 * 1000)) : null
+  const enrichmentLabel = !lastEnriched
+    ? { color: "amber", text: "⚠ Never enriched — run /admin/clapcheeks-ops kick-sweep", title: "courtship + next_best_move + curiosity not populated yet" }
+    : enrichmentAge !== null && enrichmentAge >= 7
+    ? { color: "amber", text: `⚠ Enrichment is ${enrichmentAge}d stale — sweep due`, title: "" }
+    : { color: "green", text: `✓ Enriched ${enrichmentAge === 0 ? "today" : `${enrichmentAge}d ago`}${lastVibed ? ` · vibe: ${person.vibe_classification ?? "unclear"}` : ""}`, title: "" }
+
   return (
     <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3">
+      <div className={`md:col-span-2 text-xs px-3 py-1.5 rounded border ${
+        enrichmentLabel.color === "amber"
+          ? "bg-amber-950/40 border-amber-800/50 text-amber-200"
+          : "bg-emerald-950/40 border-emerald-800/50 text-emerald-300"
+      }`} title={enrichmentLabel.title}>
+        {enrichmentLabel.text}
+      </div>
       {/* Ratings */}
       <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
         <div className="text-xs uppercase tracking-wider text-gray-500 mb-3">Ratings</div>

--- a/web/convex/coach.ts
+++ b/web/convex/coach.ts
@@ -42,9 +42,17 @@ export const getOverPursueList = query({
       last_inbound_at: number | undefined;
     }> = [];
 
+    // AI-9526 — exclude people whose vibe was classified as professional or
+    // platonic so the "you're over-investing" list doesn't suggest cooling
+    // off on Anagha (Script.IQ co-founder) or Colin White (work contact).
+    // We still include vibe=dating, vibe=unclear, or vibe=undefined (sweep
+    // hasn't run yet) — operator judgment kicks in.
+    const datingFilter = (p: any) =>
+      p.vibe_classification !== "professional" &&
+      p.vibe_classification !== "platonic";
     // Limit to first 100 active people to stay within Convex read limits.
     // (260 active people × N messages each can exceed 16MB; 100 is safe.)
-    const peopleSample = people.slice(0, 100);
+    const peopleSample = people.filter(datingFilter).slice(0, 100);
 
     for (const person of peopleSample) {
       // Use by_person_recent index (person_id, sent_at) — properly indexed per person.


### PR DESCRIPTION
## Summary

Round 2 of AI-9526. After the listForUser cap bump shipped in #130, more rows became visible — surfacing more "—" cells and more cases where the over-pursue list was including non-dating people.

## Changes

- **Network row** — when `next_best_move` is missing, show "Awaiting enrichment — sweep populates next-move every 6h" instead of nothing. Operator now sees the field is real, just unpopulated yet.
- **Dossier OperatorPanel** — enrichment-status banner at the top: "✓ Enriched today" / "⚠ N days stale" / "⚠ Never enriched — kick sweep". Operator instantly sees whether the rich fields have data behind them.
- **Coach overview** — removed accidental duplicate `RosterCard` render.
- **`coach:getOverPursueList`** — filter out vibe=professional and vibe=platonic. Was suggesting Anagha Deshmukh (Script.IQ co-founder, 936 outbound 0 inbound — work, not dating) and Colin White (work contact). Vibe=dating, vibe=unclear, or vibe=undefined still surface.

## Test plan

- [x] Convex deployed
- [x] Sweep kicked (eligible: 386, scheduled: 30)
- [x] Enrichment counts rising (vibe 14→42, courtship 9→34)
- [ ] Live verify on production after Vercel deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)