### PR TITLE
fix(clapcheeks): AI-9526 dating-only roster KPIs + real Elite Feature copy

### DIFF
--- a/web/app/(main)/dashboard/page.tsx
+++ b/web/app/(main)/dashboard/page.tsx
@@ -463,7 +463,8 @@ export default async function Dashboard() {
           </div>
         )}
 
-        {/* Elite Features */}
+        {/* Elite Features — AI-9526: copy now reflects whether your agent
+            is reporting data, not promotional fluff */}
         <div className="space-y-4 mb-8">
           <h2 className="font-display text-2xl text-white uppercase tracking-wide gold-text">
             Elite Features
@@ -473,27 +474,47 @@ export default async function Dashboard() {
               <div className="bg-white/5 border border-white/10 rounded-xl p-5">
                 <div className="flex items-center justify-between mb-2">
                   <h3 className="text-white font-semibold text-sm">Autopilot</h3>
-                  <div className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+                  <div className={`w-2 h-2 rounded-full ${
+                    hasAgent && totals.swipes_right > 0 ? "bg-green-400 animate-pulse" : "bg-gray-600"
+                  }`} />
                 </div>
-                <p className="text-white/40 text-xs">Auto-swiping is active across all platforms.</p>
+                <p className="text-white/40 text-xs">
+                  {hasAgent && totals.swipes_right > 0
+                    ? `Active — ${totals.swipes_right} right-swipes in last 30 days.`
+                    : hasAgent
+                    ? "Agent connected, but no swipes yet. Run `clapcheeks swipe` to start."
+                    : "Install the Mac agent to enable auto-swiping."}
+                </p>
               </div>
             </EliteOnly>
             <EliteOnly isElite={userIsElite} featureName="Match Intel">
               <div className="bg-white/5 border border-white/10 rounded-xl p-5">
                 <h3 className="text-white font-semibold text-sm mb-2">Match Intel</h3>
-                <p className="text-white/40 text-xs">Deep profile analysis on your latest matches.</p>
+                <p className="text-white/40 text-xs">
+                  {realMatchCount > 0
+                    ? `${realMatchCount} matches analyzed. Open Matches to see profile insights.`
+                    : "No matches yet — connect a dating app to start collecting profiles."}
+                </p>
               </div>
             </EliteOnly>
             <EliteOnly isElite={userIsElite} featureName="Ghost Hunter">
               <div className="bg-white/5 border border-white/10 rounded-xl p-5">
                 <h3 className="text-white font-semibold text-sm mb-2">Ghost Hunter</h3>
-                <p className="text-white/40 text-xs">Detect and re-engage inactive matches.</p>
+                <p className="text-white/40 text-xs">
+                  {convoTotals.conversations_started > 0
+                    ? `Tracking ${convoTotals.conversations_started} conversations for re-engagement opportunities.`
+                    : "No conversations yet — start chatting to enable ghost detection."}
+                </p>
               </div>
             </EliteOnly>
             <EliteOnly isElite={userIsElite} featureName="Date Closer">
               <div className="bg-white/5 border border-white/10 rounded-xl p-5">
                 <h3 className="text-white font-semibold text-sm mb-2">Date Closer</h3>
-                <p className="text-white/40 text-xs">AI-assisted date scheduling and booking.</p>
+                <p className="text-white/40 text-xs">
+                  {totals.dates > 0
+                    ? `${totals.dates} dates booked in last 30 days. Keep the streak going.`
+                    : "No dates booked yet — your AI proposes options when she's ready."}
+                </p>
               </div>
             </EliteOnly>
           </div>

--- a/web/app/admin/clapcheeks-ops/coach/page.tsx
+++ b/web/app/admin/clapcheeks-ops/coach/page.tsx
@@ -143,8 +143,15 @@ function SummaryCard({ summary, callStats }: { summary: any; callStats: any }) {
 
   const callsTotal = callStats?.total_30d ?? "—"
 
+  // AI-9526 — show dating-active separately from total active so the operator
+  // can see at-a-glance that ~half the active threads are professional/platonic.
+  const datingActive = summary.active_dating_threads
+  const datingLabel =
+    typeof datingActive === "number" && datingActive !== summary.active_threads
+      ? `${datingActive} (of ${summary.active_threads} total)`
+      : summary.active_threads
   const kpis = [
-    { label: "Active threads", value: summary.active_threads },
+    { label: "Dating threads", value: datingLabel },
     { label: "Dates this week", value: summary.dates_this_week },
     {
       label: "Ghost rate (30d)",

--- a/web/convex/coach.ts
+++ b/web/convex/coach.ts
@@ -537,8 +537,18 @@ export const getDashboardSummary = query({
             (replyRates.reduce((a, b) => a + b, 0) / replyRates.length) * 100
           ) / 100;
 
+    // AI-9526 — also report dating-only count so the roster card doesn't
+    // overstate by counting Sean Gelt (Hafnia, vibe=professional) and the
+    // other 60+ professional/platonic active threads.
+    const datingActive = activePeople.filter(
+      (p: any) =>
+        p.vibe_classification !== "professional" &&
+        p.vibe_classification !== "platonic"
+    );
+
     return {
       active_threads: activePeople.length,
+      active_dating_threads: datingActive.length,
       dates_this_week: datesThisWeek.length,
       ghost_rate_this_month: ghostRate,
       kissed_this_month: kissedCount,
@@ -584,7 +594,15 @@ export const getRosterKPIs = query({
       .collect();
 
     const active = all.filter((p) =>
-      isDatingRelevant(p, now) && (p.status === "active" || p.status === "dating")
+      isDatingRelevant(p, now) &&
+      (p.status === "active" || p.status === "dating") &&
+      // AI-9526 — exclude vibe=professional/platonic from roster KPIs so the
+      // capacity reading + cooling threats reflect actual dating threads, not
+      // Sean Gelt (Hafnia client, vibe=professional) or Anagha (Script.IQ
+      // co-founder, vibe=professional). Vibe=undefined still counts so
+      // unenriched people surface for operator review.
+      p.vibe_classification !== "professional" &&
+      p.vibe_classification !== "platonic"
     );
     const capacity = target - active.length;
 


### PR DESCRIPTION
## Summary

Round 3 of AI-9526. Live verification surfaced two more "fake-looking real data" issues:

1. **Coach roster KPIs showed 260 active threads** but ~half are work contacts (Sean Gelt vibe=professional, Anagha vibe=professional). Cooling threats included Sean Gelt for the same reason. Filter by vibe so capacity reflects actual dating workload.
2. **Public dashboard Elite Features cards had hardcoded promotional copy** ("Auto-swiping is active across all platforms") that showed even when the agent was sending zero data — making the dashboard look fake.

## Changes

- `coach:getDashboardSummary` returns `active_dating_threads` alongside `active_threads`.
- `coach:getRosterKPIs` filters active set by vibe — capacity + cooling threats now reflect dating only.
- Coach SummaryCard: "Active threads" → "Dating threads" with "N (of M total)" format.
- Public /dashboard Elite Features (Autopilot, Match Intel, Ghost Hunter, Date Closer) now show real copy based on `hasAgent + totals + matches`.

## Test plan

- [x] Convex deployed
- [ ] Live verify after Vercel deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)