### PR TITLE
feat(clapcheeks): AI-9537 migrate billing + misc tables from Supabase to Convex

### DIFF
--- a/clapcheeks-local/scripts/backfill_misc_supabase_to_convex.py
+++ b/clapcheeks-local/scripts/backfill_misc_supabase_to_convex.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""AI-9537 — Idempotent backfill: copy billing + miscellaneous Supabase tables
+into Convex.
+
+Tables migrated:
+  - clapcheeks_subscriptions       -> subscriptions
+  - dunning_events                 -> dunning_events
+  - clapcheeks_voice_profiles      -> voice_profiles
+  - user_voice_context             -> voice_context
+  - clapcheeks_notification_prefs  -> notification_prefs
+  - clapcheeks_outbound_notifications -> outbound_notifications
+  - clapcheeks_push_queue          -> push_queue
+  - clapcheeks_report_preferences  -> report_preferences
+  - clapcheeks_coaching_sessions   -> coaching_sessions
+  - clapcheeks_tip_feedback        -> tip_feedback
+  - clapcheeks_memos               -> memos
+  - clapcheeks_referrals           -> referrals
+  - notifications                  -> notifications
+  - devices                        -> devices
+  - google_calendar_tokens         -> google_calendar_tokens
+                                       (refresh_token + access_token are
+                                        encrypted client-side via the token
+                                        vault before write — never plaintext
+                                        at rest in Convex)
+
+Run from any host with Supabase service-role + Convex deploy access.
+Safe to re-run: every write is an idempotent upsert on the natural key.
+
+Usage:
+  CONVEX_URL=...  \\
+  CONVEX_DEPLOY_KEY=...  \\
+  CONVEX_RUNNER_SHARED_SECRET=...  \\
+  SUPABASE_URL=... SUPABASE_SERVICE_KEY=... \\
+  CLAPCHEEKS_TOKEN_MASTER_KEY=...  # required for google_calendar_tokens
+  python3 scripts/backfill_misc_supabase_to_convex.py [--dry-run] [--only TABLE,...]
+
+Optional flags:
+  --dry-run    : count rows but write nothing
+  --only       : comma-separated table list to limit scope
+                 (e.g. --only google_calendar_tokens,memos)
+  --limit N    : per-table cap (smoke-test friendly)
+
+Output: a JSON summary {table: {read, written, skipped, errors}}.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from datetime import datetime
+from typing import Any, Iterable
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("backfill_misc")
+
+
+def _to_ms(value: Any) -> int | None:
+    """Convert Supabase timestamp/text -> unix ms."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        # Heuristic: < 10^12 means seconds, else already ms.
+        return int(value) if value > 1e11 else int(value * 1000)
+    if isinstance(value, str):
+        try:
+            # Postgres timestamptz: 2026-04-27T18:00:00.000Z
+            iso = value.replace("Z", "+00:00")
+            return int(datetime.fromisoformat(iso).timestamp() * 1000)
+        except Exception:
+            return None
+    return None
+
+
+def _iter_pages(client, table: str, page_size: int = 500, columns: str = "*"):
+    offset = 0
+    while True:
+        resp = (
+            client.table(table)
+            .select(columns)
+            .range(offset, offset + page_size - 1)
+            .execute()
+        )
+        rows = resp.data or []
+        if not rows:
+            return
+        for r in rows:
+            yield r
+        if len(rows) < page_size:
+            return
+        offset += page_size
+
+
+# ---------------------------------------------------------------------------
+# Table-specific backfillers
+# ---------------------------------------------------------------------------
+
+
+def backfill_subscriptions(supabase, convex, *, dry_run: bool, limit: int | None):
+    stats = {"read": 0, "written": 0, "skipped": 0, "errors": 0}
+    plan_allow = {"starter", "pro", "elite"}
+    for row in _iter_pages(supabase, "clapcheeks_subscriptions"):
+        stats["read"] += 1
+        if limit and stats["read"] > limit:
+            break
+        plan = row.get("plan")
+        if plan not in plan_allow:
+            stats["skipped"] += 1
+            continue
+        payload = {
+            "user_id": row["user_id"],
+            "stripe_subscription_id": row.get("stripe_subscription_id"),
+            "plan": plan,
+            "status": row.get("status") or "active",
+            "current_period_start": _to_ms(row.get("current_period_start")),
+            "current_period_end": _to_ms(row.get("current_period_end")),
+        }
+        if dry_run:
+            stats["written"] += 1
+            continue
+        try:
+            convex.mutation("billing:upsertSubscription", payload)
+            stats["written"] += 1
+        except Exception as exc:
+            log.warning("subscriptions row %s failed: %s", row.get("id"), exc)
+            stats["errors"] += 1
+    return stats
+
+
+def backfill_dunning_events(supabase, convex, *, dry_run: bool, limit: int | None):
+    stats = {"read": 0, "written": 0, "skipped": 0, "errors": 0}
+    valid_types = {
+        "payment_failed",
+        "payment_recovered",
+        "grace_period_expired",
+        "manual_retry",
+        "subscription_canceled",
+    }
+    for row in _iter_pages(supabase, "dunning_events"):
+        stats["read"] += 1
+        if limit and stats["read"] > limit:
+            break
+        et = row.get("event_type")
+        if et not in valid_types:
+            stats["skipped"] += 1
+            continue
+        payload = {
+            "user_id": row.get("user_id"),
+            "stripe_customer_id": row.get("stripe_customer_id"),
+            "stripe_invoice_id": row.get("stripe_invoice_id"),
+            "event_type": et,
+            "attempt_number": row.get("attempt_number"),
+            "grace_period_end": _to_ms(row.get("grace_period_end")),
+            "metadata": row.get("metadata") or {},
+        }
+        if dry_run:
+            stats["written"] += 1
+            continue
+        try:
+            convex.mutation("billing:insertDunningEvent", payload)
+            stats["written"] += 1
+        except Exception as exc:
+            log.warning("dunning_events row %s failed: %s", row.get("id"), exc)
+            stats["errors"] += 1
+    return stats
+
+
+def backfill_voice_profiles(supabase, convex, *, dry_run: bool, limit: int | None):
+    stats = {"read": 0, "written": 0, "skipped": 0, "errors": 0}
+    for row in _iter_pages(supabase, "clapcheeks_voice_profiles"):
+        stats["read"] += 1
+        if limit and stats["read"] > limit:
+            break
+        payload = {
+            "user_id": row["user_id"],
+            "style_summary": row.get("style_summary"),
+            "sample_phrases": row.get("sample_phrases") or [],
+            "tone": row.get("tone"),
+            "profile_data": row.get("profile_data") or {},
+            "messages_analyzed": row.get("messages_analyzed"),
+        }
+        if dry_run:
+            stats["written"] += 1
+            continue
+        try:
+            convex.mutation("voice:upsertProfile", payload)
+            digest_payload = {
+                "user_id": row["user_id"],
+                "digest": row.get("digest"),
+                "boosted_samples": row.get("boosted_samples"),
+                "last_scan_at": _to_ms(row.get("last_scan_at")),
+            }
+            convex.mutation("voice:upsertProfileDigest", digest_payload)
+            stats["written"] += 1
+        except Exception as exc:
+            log.warning("voice_profiles row %s failed: %s", row.get("user_id"), exc)
+            stats["errors"] += 1
+    return stats
+
+
+def backfill_voice_context(supabase, convex, *, dry_run: bool, limit: int | None):
+    stats = {"read": 0, "written": 0, "skipped": 0, "errors": 0}
+    for row in _iter_pages(supabase, "user_voice_context"):
+        stats["read"] += 1
+        if limit and stats["read"] > limit:
+            break
+        payload = {
+            "user_id": row["user_id"],
+            "answers": row.get("answers") or {},
+            "summary": row.get("summary"),
+            "persona_blob": row.get("persona_blob"),
+            "completed_at": _to_ms(row.get("completed_at")),
+        }
+        if dry_run:
+            stats["written"] += 1
+            continue
+        try:
+            convex.mutation("voice:upsertContext", payload)
+            stats["written"] += 1
+        except Exception as exc:
+            log.warning("voice_context row %s failed: %s", row.get("user_id"), exc)
+            stats["errors"] += 1
+    return stats
+
+
+def backfill_notification_prefs(supabase, convex, *, dry_run: bool, limit: int | None):
+    stats = {"read": 0, "written": 0, "skipped": 0, "errors": 0}
+    for row in _iter_pages(supabase, "clapcheeks_notification_prefs"):
+        stats["read"] += 1
+        if limit and stats["read"] > limit:
+            break
+        payload = {
+            "user_id": row["user_id"],
+            "email": row.get("email"),
+            "phone_e164": row.get("phone_e164"),
+            "channels_per_event": row.get("channels_per_event") or {},
+            "quiet_hours_start": int(row.get("quiet_hours_start") or 21),
+            "quiet_hours_end": int(row.get("quiet_hours_end") or 8),
+        }
+        if dry_run:
+            stats["written"] += 1
+            continue
+        try:
+            convex.mutation("notifications:upsertPrefs", payload)
+            stats["written"] += 1
+        except Exception as exc:
+            log.warning("notification_prefs row %s failed: %s", row.get("user_id"), exc)
+            stats["errors"] += 1
+    return stats
+
+
+def backfill_report_preferences(supabase, convex, *, dry_run: bool, limit: int | None):
+    stats = {"read": 0, "written": 0, "skipped": 0, "errors": 0}
+    for row in _iter_pages(supabase, "clapcheeks_report_preferences"):
+        stats["read"] += 1
+        if limit and stats["read"] > limit:
+            break
+        payload = {
+            "user_id": row["user_id"],
+            "email_enabled": bool(row.get("email_enabled", True)),
+            "send_day": row.get("send_day") or "sunday",
+            "send_hour": int(row.get("send_hour", 8)),
+        }
+        if dry_run:
+            stats["written"] += 1
+            continue
+        try:
+            convex.mutation("reportPreferences:upsertForUser", payload)
+            stats["written"] += 1
+        except Exception as exc:
+            log.warning("report_preferences row %s failed: %s", row.get("user_id"), exc)
+            stats["errors"] += 1
+    return stats
+
+
+def backfill_coaching_sessions(supabase, convex, *, dry_run: bool, limit: int | None):
+    stats = {"read": 0, "written": 0, "skipped": 0, "errors": 0}
+    for row in _iter_pages(supabase, "clapcheeks_coaching_sessions"):
+        stats["read"] += 1
+        if limit and stats["read"] > limit:
+            break
+        payload = {
+            "user_id": row["user_id"],
+            "week_start": str(row.get("week_start") or "")[:10],
+            "generated_at": _to_ms(row.get("generated_at")),
+            "tips": row.get("tips") or [],
+            "stats_snapshot": row.get("stats_snapshot"),
+            "feedback_score": row.get("feedback_score"),
+            "model_used": row.get("model_used"),
+        }
+        if dry_run:
+            stats["written"] += 1
+            continue
+        try:
+            convex.mutation("coaching:upsertSession", payload)
+            stats["written"] += 1
+        except Exception as exc:
+            log.warning("coaching_sessions row %s failed: %s", row.get("id"), exc)
+            stats["errors"] += 1
+    return stats
+
+
+def backfill_memos(supabase, convex, *, dry_run: bool, limit: int | None):
+    stats = {"read": 0, "written": 0, "skipped": 0, "errors": 0}
+    for row in _iter_pages(supabase, "clapcheeks_memos"):
+        stats["read"] += 1
+        if limit and stats["read"] > limit:
+            break
+        payload = {
+            "user_id": row["user_id"],
+            "contact_handle": row["contact_handle"],
+            "content": row.get("content") or "",
+        }
+        if dry_run:
+            stats["written"] += 1
+            continue
+        try:
+            convex.mutation("memos:upsertMemo", payload)
+            stats["written"] += 1
+        except Exception as exc:
+            log.warning("memos row %s failed: %s", row.get("id"), exc)
+            stats["errors"] += 1
+    return stats
+
+
+def backfill_referrals(supabase, convex, *, dry_run: bool, limit: int | None):
+    stats = {"read": 0, "written": 0, "skipped": 0, "errors": 0}
+    for row in _iter_pages(supabase, "clapcheeks_referrals"):
+        stats["read"] += 1
+        if limit and stats["read"] > limit:
+            break
+        payload = {
+            "referrer_id": row["referrer_id"],
+            "referred_id": row.get("referred_id"),
+            "referral_code": row["referral_code"],
+            "status": row.get("status") or "pending",
+        }
+        if dry_run:
+            stats["written"] += 1
+            continue
+        try:
+            convex.mutation("referrals:insertReferral", payload)
+            stats["written"] += 1
+        except Exception as exc:
+            log.warning("referrals row %s failed: %s", row.get("id"), exc)
+            stats["errors"] += 1
+    return stats
+
+
+def backfill_notifications(supabase, convex, *, dry_run: bool, limit: int | None):
+    stats = {"read": 0, "written": 0, "skipped": 0, "errors": 0}
+    for row in _iter_pages(supabase, "notifications"):
+        stats["read"] += 1
+        if limit and stats["read"] > limit:
+            break
+        payload = {
+            "user_id": row["user_id"],
+            "title": row.get("title") or "",
+            "message": row.get("message"),
+            "type": row.get("type"),
+            "action_url": row.get("action_url"),
+        }
+        if dry_run:
+            stats["written"] += 1
+            continue
+        try:
+            convex.mutation("notifications:insertNotification", payload)
+            stats["written"] += 1
+        except Exception as exc:
+            log.warning("notifications row %s failed: %s", row.get("id"), exc)
+            stats["errors"] += 1
+    return stats
+
+
+def backfill_devices(supabase, convex, *, dry_run: bool, limit: int | None):
+    stats = {"read": 0, "written": 0, "skipped": 0, "errors": 0}
+    for row in _iter_pages(supabase, "devices"):
+        stats["read"] += 1
+        if limit and stats["read"] > limit:
+            break
+        payload = {
+            "user_id": row["user_id"],
+            "device_name": row.get("device_name") or "unknown",
+            "platform": row.get("platform") or "other",
+            "agent_version": row.get("agent_version"),
+        }
+        if dry_run:
+            stats["written"] += 1
+            continue
+        try:
+            convex.mutation("devices:upsertDevice", payload)
+            stats["written"] += 1
+        except Exception as exc:
+            log.warning("devices row %s failed: %s", row.get("id"), exc)
+            stats["errors"] += 1
+    return stats
+
+
+def backfill_google_calendar_tokens(supabase, convex, *, dry_run: bool, limit: int | None):
+    """Encrypt refresh_token + access_token client-side, then write ciphertext."""
+    stats = {"read": 0, "written": 0, "skipped": 0, "errors": 0}
+
+    # Lazy-import to avoid a hard dependency unless this table is requested.
+    try:
+        from clapcheeks.auth.token_vault import encrypt_token  # type: ignore
+    except Exception as exc:
+        log.error(
+            "google_calendar_tokens requires clapcheeks.auth.token_vault.encrypt_token: %s",
+            exc,
+        )
+        stats["errors"] = 1
+        return stats
+
+    for row in _iter_pages(supabase, "google_calendar_tokens"):
+        stats["read"] += 1
+        if limit and stats["read"] > limit:
+            break
+        user_id = row["user_id"]
+        access = row.get("access_token") or ""
+        refresh = row.get("refresh_token") or ""
+        if not refresh:
+            stats["skipped"] += 1
+            continue
+        try:
+            access_ct = bytes(encrypt_token(access, user_id))
+            refresh_ct = bytes(encrypt_token(refresh, user_id))
+        except Exception as exc:
+            log.warning(
+                "encrypt failure for user %s on google_calendar_tokens: %s",
+                user_id, exc,
+            )
+            stats["errors"] += 1
+            continue
+        payload = {
+            "user_id": user_id,
+            "google_email": row.get("google_email") or "",
+            "google_sub": row.get("google_sub"),
+            "access_token_encrypted": access_ct,
+            "refresh_token_encrypted": refresh_ct,
+            "enc_version": 1,
+            "expires_at": _to_ms(row.get("expires_at")) or 0,
+            "scopes": row.get("scopes") or [],
+            "calendar_id": row.get("calendar_id") or "primary",
+        }
+        if dry_run:
+            stats["written"] += 1
+            continue
+        try:
+            convex.mutation("calendarTokens:upsertEncrypted", payload)
+            stats["written"] += 1
+        except Exception as exc:
+            log.warning(
+                "google_calendar_tokens row %s failed: %s", user_id, exc,
+            )
+            stats["errors"] += 1
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+TABLE_RUNNERS = {
+    "subscriptions": backfill_subscriptions,
+    "dunning_events": backfill_dunning_events,
+    "voice_profiles": backfill_voice_profiles,
+    "voice_context": backfill_voice_context,
+    "notification_prefs": backfill_notification_prefs,
+    "report_preferences": backfill_report_preferences,
+    "coaching_sessions": backfill_coaching_sessions,
+    "memos": backfill_memos,
+    "referrals": backfill_referrals,
+    "notifications": backfill_notifications,
+    "devices": backfill_devices,
+    "google_calendar_tokens": backfill_google_calendar_tokens,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--only", default="", help="comma-separated table list")
+    parser.add_argument("--limit", type=int, default=0)
+    args = parser.parse_args()
+
+    supabase_url = os.environ.get("SUPABASE_URL")
+    supabase_key = os.environ.get("SUPABASE_SERVICE_KEY")
+    convex_url = os.environ.get("CONVEX_URL")
+    if not (supabase_url and supabase_key and convex_url):
+        log.error(
+            "SUPABASE_URL, SUPABASE_SERVICE_KEY, and CONVEX_URL are required",
+        )
+        return 1
+
+    try:
+        from supabase import create_client  # type: ignore
+        from convex import ConvexClient  # type: ignore
+    except ImportError as exc:
+        log.error("missing dependency: %s", exc)
+        log.error("install with: pip install supabase convex")
+        return 1
+
+    supabase = create_client(supabase_url, supabase_key)
+    convex = ConvexClient(convex_url)
+    deploy_key = os.environ.get("CONVEX_DEPLOY_KEY")
+    if deploy_key:
+        convex.set_admin_auth(deploy_key)
+
+    only = {t.strip() for t in args.only.split(",") if t.strip()}
+    limit = args.limit or None
+
+    summary: dict[str, dict[str, int]] = {}
+    for table, runner in TABLE_RUNNERS.items():
+        if only and table not in only:
+            continue
+        log.info("backfilling %s (dry_run=%s)", table, args.dry_run)
+        try:
+            stats = runner(supabase, convex, dry_run=args.dry_run, limit=limit)
+        except Exception as exc:
+            log.exception("table %s failed: %s", table, exc)
+            stats = {"read": 0, "written": 0, "skipped": 0, "errors": 1}
+        summary[table] = stats
+        log.info("%s -> %s", table, json.dumps(stats))
+
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/web/app/(main)/dashboard/page.tsx
+++ b/web/app/(main)/dashboard/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from 'next'
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: subscriptions + devices on Convex.
 import ManageBillingButton from '@/components/manage-billing-button'
 import PlanBadge from '@/components/plan-badge'
 import EliteOnly from '@/components/elite-only'
@@ -73,7 +77,8 @@ export default async function Dashboard() {
   const fourteenDaysAgo = new Date()
   fourteenDaysAgo.setDate(fourteenDaysAgo.getDate() - 14)
 
-  const [analyticsRes, convoRes, spendRes, deviceRes, subRes, profileRes, heartbeatRes, matchCountRes] = await Promise.all([
+  const convex = getConvexServerClient()
+  const [analyticsRes, convoRes, spendRes, deviceListRes, subRes, profileRes, heartbeatRes, matchCountRes] = await Promise.all([
     supabase
       .from('clapcheeks_analytics_daily')
       .select('app, swipes_right, swipes_left, matches, conversations_started, dates_booked, money_spent, date')
@@ -91,18 +96,8 @@ export default async function Dashboard() {
       .select('amount, category, date')
       .eq('user_id', user.id)
       .gte('date', sinceStr),
-    supabase
-      .from('devices')
-      .select('last_seen_at, is_active')
-      .eq('user_id', user.id)
-      .order('last_seen_at', { ascending: false })
-      .limit(1),
-    supabase
-      .from('clapcheeks_subscriptions')
-      .select('status')
-      .eq('user_id', user.id)
-      .limit(1)
-      .single(),
+    convex.query(api.devices.listForUser, { user_id: user.id }),
+    convex.query(api.billing.getByUser, { user_id: user.id }),
     supabase
       .from('profiles')
       .select('subscription_tier, subscription_status')
@@ -127,7 +122,7 @@ export default async function Dashboard() {
   // Fetch coaching session
   const coachingSession = await getLatestCoaching(supabase, user.id)
 
-  const isSubscribed = subRes.data?.status === 'active'
+  const isSubscribed = subRes?.status === 'active'
   const userPlan = (profileRes.data?.subscription_tier || 'base') as 'base' | 'elite'
   const userSubStatus = profileRes.data?.subscription_status || 'inactive'
   const userIsElite = userPlan === 'elite' && userSubStatus === 'active'
@@ -136,11 +131,14 @@ export default async function Dashboard() {
   const convos: ConvoRow[] = convoRes.data || []
   const spending = spendRes.data || []
 
-  // AI-8926: pick the freshest of (devices.last_seen_at, clapcheeks_device_heartbeats.last_heartbeat_at).
-  const oldDevice = deviceRes.data?.[0] || null
+  // AI-8926/AI-9537: pick the freshest of (Convex devices.last_seen_at, clapcheeks_device_heartbeats.last_heartbeat_at).
+  const deviceList = (deviceListRes ?? []) as Array<{ last_seen_at: number; is_active: boolean }>
+  const oldDevice = deviceList.length
+    ? deviceList.reduce((best, d) => (d.last_seen_at > best.last_seen_at ? d : best))
+    : null
   const heartbeatTs = (heartbeatRes.data as { last_heartbeat_at: string | null } | null)?.last_heartbeat_at ?? null
   const candidates: { last_seen_at: string; is_active: boolean }[] = []
-  if (oldDevice?.last_seen_at) candidates.push({ last_seen_at: oldDevice.last_seen_at, is_active: oldDevice.is_active })
+  if (oldDevice) candidates.push({ last_seen_at: new Date(oldDevice.last_seen_at).toISOString(), is_active: oldDevice.is_active })
   if (heartbeatTs) candidates.push({ last_seen_at: heartbeatTs, is_active: true })
   const device: DeviceRow | null = candidates.length
     ? candidates.reduce((best, c) =>

--- a/web/app/(main)/dogfood/page.tsx
+++ b/web/app/(main)/dogfood/page.tsx
@@ -2,6 +2,10 @@ import type { Metadata } from 'next'
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import DogfoodDashboard from './dogfood-dashboard'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: subscriptions on Convex.
 
 export const metadata: Metadata = {
   title: 'Dogfooding — Clapcheeks',
@@ -17,6 +21,7 @@ export default async function DogfoodPage() {
   const since = new Date()
   since.setDate(since.getDate() - 14)
 
+  const convex = getConvexServerClient()
   const [healthRes, frictionRes, reportsRes, subscriptionRes] = await Promise.all([
     supabase
       .from('clapcheeks_dogfood_health')
@@ -36,18 +41,15 @@ export default async function DogfoodPage() {
       .eq('user_id', user.id)
       .order('week_start', { ascending: false })
       .limit(4),
-    supabase
-      .from('clapcheeks_subscriptions')
-      .select('status, plan_id')
-      .eq('user_id', user.id)
-      .limit(1)
-      .single(),
+    convex.query(api.billing.getByUser, { user_id: user.id }),
   ])
 
   const health = healthRes.data || []
   const friction = frictionRes.data || []
   const reports = reportsRes.data || []
-  const subscription = subscriptionRes.data
+  const subscription = subscriptionRes
+    ? { status: subscriptionRes.status, plan_id: subscriptionRes.plan }
+    : null
 
   // Calculate current streak from health data
   const latestHealth = health[0]

--- a/web/app/(main)/matches/[id]/page.tsx
+++ b/web/app/(main)/matches/[id]/page.tsx
@@ -4,6 +4,10 @@ import { redirect, notFound } from 'next/navigation'
 import MatchProfileView from './match-profile-view'
 import { getMatchConversationUnified } from '@/lib/matches/conversation'
 import type { ChatMessage } from './conversation-thread'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: memos on Convex.
 
 export const metadata: Metadata = {
   title: 'Match Profile - Clapcheeks',
@@ -98,16 +102,17 @@ export default async function MatchDetailPage({
   let memoInitial: { content: string; updated_at: string | null } | null = null
   if (memoHandle) {
     try {
-      const { data: memoRow } = await (supabase as any)
-        .from('clapcheeks_memos')
-        .select('content, updated_at')
-        .eq('user_id', user.id)
-        .eq('contact_handle', memoHandle)
-        .maybeSingle()
+      const convex = getConvexServerClient()
+      const memoRow = await convex.query(api.memos.getForContact, {
+        user_id: user.id,
+        contact_handle: memoHandle,
+      })
       memoInitial = memoRow
         ? {
-            content: (memoRow.content as string) ?? '',
-            updated_at: (memoRow.updated_at as string | null) ?? null,
+            content: memoRow.content ?? '',
+            updated_at: memoRow.updated_at
+              ? new Date(memoRow.updated_at).toISOString()
+              : null,
           }
         : { content: '', updated_at: null }
     } catch {

--- a/web/app/(main)/referrals/page.tsx
+++ b/web/app/(main)/referrals/page.tsx
@@ -59,14 +59,15 @@ export default function ReferralsPage() {
 
       setMonthsEarned(profile?.free_months_earned || 0)
 
-      // Get referrals — swallow errors so the page still renders
+      // Get referrals (AI-9537: now via Convex-backed API route).
       try {
-        const { data: refs } = await supabase
-          .from('clapcheeks_referrals')
-          .select('id, referred_id, status, converted_at, rewarded_at, created_at')
-          .eq('referrer_id', user.id)
-          .order('created_at', { ascending: false })
-        setReferrals(refs || [])
+        const r = await fetch('/api/referral/list', { credentials: 'include' })
+        if (r.ok) {
+          const j = await r.json()
+          setReferrals(j.referrals || [])
+        } else {
+          setReferrals([])
+        }
       } catch {
         setReferrals([])
       }

--- a/web/app/(main)/reports/page.tsx
+++ b/web/app/(main)/reports/page.tsx
@@ -3,6 +3,10 @@ import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import ReportsList from './reports-list'
 import ReportPreferences from './report-preferences'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: report_preferences on Convex.
 
 export const metadata: Metadata = {
   title: 'Reports — Clapcheeks',
@@ -15,6 +19,7 @@ export default async function ReportsPage() {
 
   if (!user) redirect('/auth/login')
 
+  const convex = getConvexServerClient()
   const [reportsRes, prefsRes] = await Promise.all([
     supabase
       .from('clapcheeks_weekly_reports')
@@ -22,15 +27,17 @@ export default async function ReportsPage() {
       .eq('user_id', user.id)
       .order('week_start', { ascending: false })
       .limit(12),
-    supabase
-      .from('clapcheeks_report_preferences')
-      .select('*')
-      .eq('user_id', user.id)
-      .single(),
+    convex.query(api.reportPreferences.getForUser, { user_id: user.id }),
   ])
 
   const reports = reportsRes.data || []
-  const preferences = prefsRes.data || { email_enabled: true, send_day: 'sunday', send_hour: 8 }
+  const preferences = prefsRes
+    ? {
+        email_enabled: prefsRes.email_enabled,
+        send_day: prefsRes.send_day,
+        send_hour: prefsRes.send_hour,
+      }
+    : { email_enabled: true, send_day: 'sunday', send_hour: 8 }
 
   return (
     <div className="min-h-screen bg-black px-6 py-8">

--- a/web/app/(main)/settings/notifications/page.tsx
+++ b/web/app/(main)/settings/notifications/page.tsx
@@ -4,6 +4,10 @@ import { redirect } from 'next/navigation'
 import NotificationPrefsForm, {
   type NotificationPrefs,
 } from './notification-prefs-form'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: notification_prefs on Convex.
 
 export const metadata: Metadata = {
   title: 'Notifications - Clapcheeks',
@@ -29,11 +33,8 @@ export default async function NotificationsSettingsPage() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/auth')
 
-  const { data: row } = await supabase
-    .from('clapcheeks_notification_prefs')
-    .select('email, phone_e164, channels_per_event, quiet_hours_start, quiet_hours_end')
-    .eq('user_id', user.id)
-    .maybeSingle()
+  const convex = getConvexServerClient()
+  const row = await convex.query(api.notifications.getPrefs, { user_id: user.id })
 
   const initial: NotificationPrefs = {
     email: row?.email ?? user.email ?? '',

--- a/web/app/(main)/studio/voice/page.tsx
+++ b/web/app/(main)/studio/voice/page.tsx
@@ -8,6 +8,10 @@
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import VoiceStudioClient, { type VoiceProfile } from './voice-studio-client'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: voice_profiles on Convex.
 
 export const dynamic = 'force-dynamic'
 
@@ -22,19 +26,15 @@ export default async function VoiceStudioPage() {
   } = await supabase.auth.getUser()
   if (!user) redirect('/login')
 
-  const { data, error } = await supabase
-    .from('clapcheeks_voice_profiles')
-    .select(
-      'user_id, style_summary, tone, sample_phrases, profile_data, ' +
-        'messages_analyzed, digest, boosted_samples, last_scan_at, updated_at'
-    )
-    .eq('user_id', user.id)
-    .maybeSingle()
-
-  // maybeSingle() returns the row or null. Treat any read error as "no
-  // profile yet" rather than crashing — the client component handles the
-  // empty state with onboarding instructions.
-  const profile = error ? null : (data as unknown as VoiceProfile | null)
+  let profile: VoiceProfile | null = null
+  try {
+    const convex = getConvexServerClient()
+    const data = await convex.query(api.voice.getProfile, { user_id: user.id })
+    profile = (data as unknown as VoiceProfile | null) ?? null
+  } catch {
+    // empty-state path; client handles
+    profile = null
+  }
 
   return <VoiceStudioClient initialProfile={profile} />
 }

--- a/web/app/admin/launch/page.tsx
+++ b/web/app/admin/launch/page.tsx
@@ -3,6 +3,10 @@ import { createAdminClient } from "@/lib/supabase/admin"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Users, TrendingUp, Gift, AlertTriangle, Target, UserMinus } from "lucide-react"
+import { getConvexServerClient } from "@/lib/convex/server"
+import { api } from "@/convex/_generated/api"
+
+// AI-9537: clapcheeks_referrals migrated to Convex referrals.
 
 export const metadata: Metadata = { title: 'Soft Launch | Admin' }
 export const dynamic = "force-dynamic"
@@ -12,12 +16,13 @@ const LAUNCH_DATE = '2026-04-20'
 
 export default async function SoftLaunchPage() {
   const supabase = createAdminClient()
+  const convex = getConvexServerClient()
   const [
     { count: totalUsers },
     { data: paidProfiles },
     { data: recentChurn },
     { data: referralSignups },
-    { data: allReferrals },
+    allReferralsRaw,
     { data: weeklySignups },
     { data: dailyActive },
   ] = await Promise.all([
@@ -25,10 +30,11 @@ export default async function SoftLaunchPage() {
     supabase.from("profiles").select("id, subscription_tier, created_at").neq("subscription_tier", "free"),
     supabase.from("profiles").select("id, email, subscription_tier, updated_at").eq("subscription_tier", "free").not("stripe_customer_id", "is", null),
     supabase.from("profiles").select("id, created_at").not("referred_by", "is", null),
-    supabase.from("clapcheeks_referrals").select("id, status, created_at"),
+    convex.query(api.referrals.summary, {}),
     supabase.from("profiles").select("id, created_at").gte("created_at", new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()),
     supabase.from("clapcheeks_analytics_daily").select("user_id, date").gte("date", new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().split("T")[0]),
   ])
+  const allReferrals = (allReferralsRaw ?? []) as Array<{ id: string; status: string; created_at: number }>
   const paidCount = paidProfiles?.length ?? 0
   const total = totalUsers ?? 0
   const capacityPct = Math.round((paidCount / SOFT_LAUNCH_CAP) * 100)

--- a/web/app/api/agent/status/route.ts
+++ b/web/app/api/agent/status/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: devices on Convex.
 
 export async function GET() {
   const supabase = await createClient()
@@ -9,16 +13,12 @@ export async function GET() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  // AI-8926: read both legacy `devices` and modern `clapcheeks_device_heartbeats`
+  // AI-8926: read both Convex `devices` and Supabase `clapcheeks_device_heartbeats`
   // and report the fresher of the two.  Daemons running the post-AI-8876 stack
-  // upsert heartbeats every minute; the older `devices` table can lag for hours.
-  const [deviceRes, agentTokenRes, heartbeatRes] = await Promise.all([
-    supabase
-      .from('devices')
-      .select('last_seen_at, is_active')
-      .eq('user_id', user.id)
-      .order('last_seen_at', { ascending: false })
-      .limit(1),
+  // upsert heartbeats every minute; the Convex `devices` rows can lag.
+  const convex = getConvexServerClient()
+  const [deviceListRes, agentTokenRes, heartbeatRes] = await Promise.all([
+    convex.query(api.devices.listForUser, { user_id: user.id }),
     supabase
       .from('clapcheeks_agent_tokens')
       .select('status, degraded_platform, degraded_reason')
@@ -34,12 +34,15 @@ export async function GET() {
       .maybeSingle(),
   ])
 
-  const oldDevice = deviceRes.data?.[0] || null
+  const deviceList = (deviceListRes ?? []) as Array<{ last_seen_at: number; is_active: boolean }>
+  const oldDevice = deviceList.length
+    ? deviceList.reduce((best, d) => (d.last_seen_at > best.last_seen_at ? d : best))
+    : null
   const heartbeatTs = (heartbeatRes.data as { last_heartbeat_at: string | null } | null)?.last_heartbeat_at ?? null
 
   type DeviceShape = { last_seen_at: string; is_active: boolean }
   const candidates: DeviceShape[] = []
-  if (oldDevice?.last_seen_at) candidates.push({ last_seen_at: oldDevice.last_seen_at, is_active: oldDevice.is_active ?? true })
+  if (oldDevice) candidates.push({ last_seen_at: new Date(oldDevice.last_seen_at).toISOString(), is_active: oldDevice.is_active ?? true })
   if (heartbeatTs) candidates.push({ last_seen_at: heartbeatTs, is_active: true })
   const device: DeviceShape | null = candidates.length
     ? candidates.reduce((best, c) =>

--- a/web/app/api/ai-first-date/finalize/route.ts
+++ b/web/app/api/ai-first-date/finalize/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import Anthropic from '@anthropic-ai/sdk'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: voice_context now lives on Convex.
 
 export const runtime = 'nodejs'
 export const maxDuration = 60
@@ -16,11 +20,8 @@ export async function POST() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data: row } = await supabase
-    .from('user_voice_context')
-    .select('answers')
-    .eq('user_id', user.id)
-    .maybeSingle()
+  const convex = getConvexServerClient()
+  const row = await convex.query(api.voice.getContext, { user_id: user.id })
 
   const answers: Record<string, Answer> = (row?.answers as Record<string, Answer>) || {}
   const entries = Object.values(answers)
@@ -79,23 +80,19 @@ No preamble, no trailing commentary. Just the JSON.`,
     console.error('finalize parse error', err)
   }
 
-  const now = new Date().toISOString()
-  await supabase.from('user_voice_context').upsert(
-    {
-      user_id: user.id,
-      answers,
-      summary,
-      persona_blob: personaBlob,
-      completed_at: now,
-      updated_at: now,
-    },
-    { onConflict: 'user_id' },
-  )
+  const nowMs = Date.now()
+  await convex.mutation(api.voice.upsertContext, {
+    user_id: user.id,
+    answers,
+    summary,
+    persona_blob: personaBlob,
+    completed_at: nowMs,
+  })
 
   return NextResponse.json({
     summary,
     persona_blob: personaBlob,
     tags,
-    completed_at: now,
+    completed_at: new Date(nowMs).toISOString(),
   })
 }

--- a/web/app/api/ai-first-date/turn/route.ts
+++ b/web/app/api/ai-first-date/turn/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import Anthropic from '@anthropic-ai/sdk'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: voice_context now lives on Convex.
 import {
   SEED_QUESTIONS,
   getNextSeedQuestion,
@@ -42,11 +46,8 @@ export async function POST(req: NextRequest) {
     // empty body on the very first turn is fine
   }
 
-  const { data: existing } = await supabase
-    .from('user_voice_context')
-    .select('answers')
-    .eq('user_id', user.id)
-    .maybeSingle()
+  const convex = getConvexServerClient()
+  const existing = await convex.query(api.voice.getContext, { user_id: user.id })
 
   const answers: Record<string, Answer> = (existing?.answers as Record<string, Answer>) || {}
 
@@ -59,14 +60,10 @@ export async function POST(req: NextRequest) {
       purpose: q?.purpose ?? 'adaptive',
     }
 
-    await supabase.from('user_voice_context').upsert(
-      {
-        user_id: user.id,
-        answers,
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: 'user_id' },
-    )
+    await convex.mutation(api.voice.upsertContext, {
+      user_id: user.id,
+      answers,
+    })
   }
 
   const answeredIds = Object.keys(answers)

--- a/web/app/api/auth/google/callback/route.ts
+++ b/web/app/api/auth/google/callback/route.ts
@@ -1,13 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { exchangeCodeForTokens, fetchUserInfo } from '@/lib/google/calendar'
+import {
+  exchangeCodeForTokens,
+  fetchUserInfo,
+  persistCalendarTokensEncrypted,
+} from '@/lib/google/calendar'
 
 export const runtime = 'nodejs'
 
 /**
  * GET /api/auth/google/callback — OAuth return path.
- * Exchanges the code for tokens, fetches userinfo, persists to
- * google_calendar_tokens, then redirects back to `next`.
+ *
+ * AI-9537: tokens now encrypted at rest in Convex google_calendar_tokens
+ * via persistCalendarTokensEncrypted (uses the per-user AES-256-GCM vault
+ * from web/lib/crypto/token-vault.ts).
  */
 export async function GET(req: NextRequest) {
   const supabase = await createClient()
@@ -56,7 +62,7 @@ export async function GET(req: NextRequest) {
   try {
     const tokens = await exchangeCodeForTokens(code, req.nextUrl.origin)
     const userInfo = await fetchUserInfo(tokens.access_token)
-    const expiresAt = new Date(Date.now() + tokens.expires_in * 1000).toISOString()
+    const expiresAtMs = Date.now() + tokens.expires_in * 1000
 
     if (!tokens.refresh_token) {
       const url = new URL('/settings', req.url)
@@ -64,20 +70,16 @@ export async function GET(req: NextRequest) {
       return NextResponse.redirect(url)
     }
 
-    await supabase.from('google_calendar_tokens').upsert(
-      {
-        user_id: user.id,
-        google_email: userInfo.email,
-        google_sub: userInfo.sub,
-        access_token: tokens.access_token,
-        refresh_token: tokens.refresh_token,
-        expires_at: expiresAt,
-        scopes: tokens.scope.split(' '),
-        calendar_id: 'primary',
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: 'user_id' },
-    )
+    await persistCalendarTokensEncrypted({
+      userId: user.id,
+      googleEmail: userInfo.email,
+      googleSub: userInfo.sub ?? null,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      expiresAtMs,
+      scopes: tokens.scope.split(' '),
+      calendarId: 'primary',
+    })
 
     const next = parsedState.n.startsWith('/') ? parsedState.n : '/settings'
     const url = new URL(next, req.url)

--- a/web/app/api/auth/google/disconnect/route.ts
+++ b/web/app/api/auth/google/disconnect/route.ts
@@ -1,36 +1,49 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { loadDecryptedTokens } from '@/lib/google/calendar'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
 
 export const runtime = 'nodejs'
 
 /**
  * POST /api/auth/google/disconnect
- * Revokes the stored Google Calendar connection for the current user.
- * Attempts to revoke the token upstream so Google also forgets us.
+ *
+ * AI-9537: tokens now live in Convex google_calendar_tokens.
+ * loadDecryptedTokens() pulls the (decrypted) refresh_token so we can
+ * revoke it upstream before deleting the row.
  */
 export async function POST() {
   const supabase = await createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data: existing } = await supabase
-    .from('google_calendar_tokens')
-    .select('refresh_token, access_token')
-    .eq('user_id', user.id)
-    .maybeSingle()
+  let refreshToken: string | null = null
+  try {
+    const decrypted = await loadDecryptedTokens(user.id)
+    refreshToken = decrypted?.refresh_token ?? null
+  } catch (err) {
+    console.error('Calendar disconnect: failed to decrypt token', err)
+  }
 
-  if (existing?.refresh_token) {
+  if (refreshToken) {
     try {
       await fetch('https://oauth2.googleapis.com/revoke', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({ token: existing.refresh_token as string }),
+        body: new URLSearchParams({ token: refreshToken }),
       })
     } catch (err) {
       console.error('Google revoke failed (continuing):', err)
     }
   }
 
-  await supabase.from('google_calendar_tokens').delete().eq('user_id', user.id)
+  try {
+    const convex = getConvexServerClient()
+    await convex.mutation(api.calendarTokens.deleteForUser, { user_id: user.id })
+  } catch (err) {
+    console.error('Calendar disconnect: convex delete failed', err)
+    return NextResponse.json({ error: 'delete_failed' }, { status: 500 })
+  }
   return NextResponse.json({ ok: true })
 }

--- a/web/app/api/calendar/events/route.ts
+++ b/web/app/api/calendar/events/route.ts
@@ -1,9 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getValidAccessToken, createCalendarEvent, type CalendarEventInput } from '@/lib/google/calendar'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
 
 export const runtime = 'nodejs'
 export const maxDuration = 30
+
+// AI-9537: tokens now in Convex google_calendar_tokens (encrypted at rest).
 
 interface CreateEventRequest {
   summary: string
@@ -36,7 +40,7 @@ export async function POST(req: NextRequest) {
     )
   }
 
-  const token = await getValidAccessToken(supabase, user.id)
+  const token = await getValidAccessToken(user.id)
   if (!token) {
     return NextResponse.json(
       { error: 'Calendar not connected', code: 'NOT_CONNECTED' },
@@ -80,18 +84,15 @@ export async function GET() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data } = await supabase
-    .from('google_calendar_tokens')
-    .select('google_email, calendar_id, scopes, created_at, updated_at')
-    .eq('user_id', user.id)
-    .maybeSingle()
+  const convex = getConvexServerClient()
+  const meta = await convex.query(api.calendarTokens.getMetaForUser, { user_id: user.id })
 
-  if (!data) return NextResponse.json({ connected: false })
+  if (!meta) return NextResponse.json({ connected: false })
   return NextResponse.json({
     connected: true,
-    email: data.google_email,
-    calendarId: data.calendar_id,
-    scopes: data.scopes,
-    connectedAt: data.created_at,
+    email: meta.google_email,
+    calendarId: meta.calendar_id,
+    scopes: meta.scopes,
+    connectedAt: meta.created_at ? new Date(meta.created_at).toISOString() : null,
   })
 }

--- a/web/app/api/coaching/feedback/route.ts
+++ b/web/app/api/coaching/feedback/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+import type { Id } from '@/convex/_generated/dataModel'
+
+// AI-9537: tip feedback now lives on Convex tip_feedback.
 
 export async function POST(req: NextRequest) {
   const supabase = await createClient()
@@ -16,22 +21,18 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
   }
 
-  const { error } = await supabase
-    .from('clapcheeks_tip_feedback')
-    .upsert(
-      {
-        user_id: user.id,
-        coaching_session_id: sessionId,
-        tip_index: tipIndex,
-        helpful,
-      },
-      { onConflict: 'user_id,coaching_session_id,tip_index' }
-    )
-
-  if (error) {
-    console.error('Feedback error:', error)
-    return NextResponse.json({ error: 'Failed to save feedback' }, { status: 500 })
+  try {
+    const convex = getConvexServerClient()
+    await convex.mutation(api.coaching.upsertTipFeedback, {
+      user_id: user.id,
+      coaching_session_id: sessionId as Id<'coaching_sessions'>,
+      tip_index: tipIndex,
+      helpful,
+    })
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to save feedback'
+    console.error('Feedback error:', err)
+    return NextResponse.json({ error: msg }, { status: 500 })
   }
-
-  return NextResponse.json({ success: true })
 }

--- a/web/app/api/conversation/voice-profile/route.ts
+++ b/web/app/api/conversation/voice-profile/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import Anthropic from '@anthropic-ai/sdk'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: migrated from Supabase clapcheeks_voice_profiles to Convex voice_profiles.
 
 export async function GET() {
   const supabase = await createClient()
@@ -10,11 +14,8 @@ export async function GET() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const { data } = await supabase
-    .from('clapcheeks_voice_profiles')
-    .select('*')
-    .eq('user_id', user.id)
-    .single()
+  const convex = getConvexServerClient()
+  const data = await convex.query(api.voice.getProfile, { user_id: user.id })
 
   return NextResponse.json({ profile: data || null })
 }
@@ -85,30 +86,23 @@ Return ONLY a JSON object with these fields:
   }
 
   // Upsert voice profile
-  const { data, error } = await supabase
-    .from('clapcheeks_voice_profiles')
-    .upsert(
-      {
-        user_id: user.id,
-        style_summary: profileData.style_summary,
-        sample_phrases: profileData.sample_phrases || [],
-        tone: profileData.tone || 'casual',
-        profile_data: profileData.profile_data || {},
-        messages_analyzed: sampleMessages.length,
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: 'user_id' }
-    )
-    .select()
-    .single()
-
-  if (error) {
-    console.error('Voice profile error:', error)
+  try {
+    const convex = getConvexServerClient()
+    await convex.mutation(api.voice.upsertProfile, {
+      user_id: user.id,
+      style_summary: profileData.style_summary,
+      sample_phrases: profileData.sample_phrases || [],
+      tone: profileData.tone || 'casual',
+      profile_data: profileData.profile_data || {},
+      messages_analyzed: sampleMessages.length,
+    })
+    const data = await convex.query(api.voice.getProfile, { user_id: user.id })
+    return NextResponse.json({ profile: data })
+  } catch (err) {
+    console.error('Voice profile error:', err)
     return NextResponse.json(
       { error: 'Failed to save voice profile' },
       { status: 500 }
     )
   }
-
-  return NextResponse.json({ profile: data })
 }

--- a/web/app/api/memo/[handle]/route.ts
+++ b/web/app/api/memo/[handle]/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
 
 /**
  * GET  /api/memo/[handle]    — fetch the memo content for the current user + handle.
@@ -9,7 +11,7 @@ import { createClient } from '@/lib/supabase/server'
  *   - E.164 phone (e.g. "+15551234567") for contacts that have exchanged a number
  *   - platform external id (e.g. "tinder:abc123") otherwise
  *
- * RLS on clapcheeks_memos enforces ownership but we also pass user_id explicitly.
+ * AI-9537: migrated from Supabase clapcheeks_memos to Convex memos.
  */
 
 const MAX_CONTENT_LENGTH = 200_000 // ~200 KB markdown ceiling
@@ -40,26 +42,22 @@ export async function GET(
     return NextResponse.json({ error: 'handle required' }, { status: 400 })
   }
 
-  const { data, error } = await (supabase as any)
-    .from('clapcheeks_memos')
-    .select('content, updated_at')
-    .eq('user_id', user.id)
-    .eq('contact_handle', handle)
-    .maybeSingle()
-
-  if (error) {
-    return NextResponse.json(
-      { error: error.message || 'Failed to load memo' },
-      { status: 500 },
-    )
+  try {
+    const convex = getConvexServerClient()
+    const row = await convex.query(api.memos.getForContact, {
+      user_id: user.id,
+      contact_handle: handle,
+    })
+    return NextResponse.json({
+      handle,
+      content: row?.content ?? '',
+      updated_at: row?.updated_at ? new Date(row.updated_at).toISOString() : null,
+      exists: !!row,
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to load memo'
+    return NextResponse.json({ error: msg }, { status: 500 })
   }
-
-  return NextResponse.json({
-    handle,
-    content: data?.content ?? '',
-    updated_at: data?.updated_at ?? null,
-    exists: !!data,
-  })
 }
 
 export async function PUT(
@@ -100,32 +98,21 @@ export async function PUT(
     )
   }
 
-  const now = new Date().toISOString()
-
-  const { data, error } = await (supabase as any)
-    .from('clapcheeks_memos')
-    .upsert(
-      {
-        user_id: user.id,
-        contact_handle: handle,
-        content: body.content,
-        updated_at: now,
-      },
-      { onConflict: 'user_id,contact_handle' },
-    )
-    .select('content, updated_at')
-    .single()
-
-  if (error) {
-    return NextResponse.json(
-      { error: error.message || 'Failed to save memo' },
-      { status: 500 },
-    )
+  try {
+    const convex = getConvexServerClient()
+    const result = await convex.mutation(api.memos.upsertMemo, {
+      user_id: user.id,
+      contact_handle: handle,
+      content: body.content,
+    })
+    return NextResponse.json({
+      handle,
+      content: body.content,
+      updated_at: new Date().toISOString(),
+      action: result.action,
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Failed to save memo'
+    return NextResponse.json({ error: msg }, { status: 500 })
   }
-
-  return NextResponse.json({
-    handle,
-    content: data?.content ?? body.content,
-    updated_at: data?.updated_at ?? now,
-  })
 }

--- a/web/app/api/notifications/preferences/route.ts
+++ b/web/app/api/notifications/preferences/route.ts
@@ -9,6 +9,10 @@
  */
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: migrated to Convex notification_prefs.
 
 const ALLOWED_CHANNELS = new Set(['email', 'imessage', 'push'])
 const ALLOWED_EVENTS = new Set([
@@ -64,19 +68,24 @@ export async function GET() {
     if (!user) {
       return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
     }
-    const { data } = await supabase
-      .from('clapcheeks_notification_prefs')
-      .select('email, phone_e164, channels_per_event, quiet_hours_start, quiet_hours_end')
-      .eq('user_id', user.id)
-      .maybeSingle()
+    const convex = getConvexServerClient()
+    const data = await convex.query(api.notifications.getPrefs, { user_id: user.id })
     return NextResponse.json(
-      data || {
-        email: user.email ?? '',
-        phone_e164: '',
-        channels_per_event: {},
-        quiet_hours_start: 21,
-        quiet_hours_end: 8,
-      },
+      data
+        ? {
+            email: data.email ?? '',
+            phone_e164: data.phone_e164 ?? '',
+            channels_per_event: data.channels_per_event ?? {},
+            quiet_hours_start: data.quiet_hours_start,
+            quiet_hours_end: data.quiet_hours_end,
+          }
+        : {
+            email: user.email ?? '',
+            phone_e164: '',
+            channels_per_event: {},
+            quiet_hours_start: 21,
+            quiet_hours_end: 8,
+          },
     )
   } catch (err) {
     console.error('notif prefs GET error', err)
@@ -100,19 +109,20 @@ export async function PUT(req: NextRequest) {
       return NextResponse.json({ error: 'invalid_json' }, { status: 400 })
     }
     const clean = sanitize(body)
-    const { error } = await supabase
-      .from('clapcheeks_notification_prefs')
-      .upsert(
-        {
-          user_id: user.id,
-          ...clean,
-          updated_at: new Date().toISOString(),
-        },
-        { onConflict: 'user_id' },
-      )
-    if (error) {
-      console.error('notif prefs upsert error', error)
-      return NextResponse.json({ error: error.message }, { status: 500 })
+    try {
+      const convex = getConvexServerClient()
+      await convex.mutation(api.notifications.upsertPrefs, {
+        user_id: user.id,
+        email: clean.email ?? undefined,
+        phone_e164: clean.phone_e164 ?? undefined,
+        channels_per_event: clean.channels_per_event,
+        quiet_hours_start: clean.quiet_hours_start,
+        quiet_hours_end: clean.quiet_hours_end,
+      })
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'upsert_failed'
+      console.error('notif prefs upsert error', msg)
+      return NextResponse.json({ error: msg }, { status: 500 })
     }
     return NextResponse.json({ ok: true })
   } catch (err) {

--- a/web/app/api/notify/route.ts
+++ b/web/app/api/notify/route.ts
@@ -39,6 +39,10 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient as createSupabaseClient } from '@supabase/supabase-js'
 import { Resend } from 'resend'
 import { createClient as createServerSupabase } from '@/lib/supabase/server'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: notification_prefs + outbound_notifications + push_queue on Convex.
 
 type Channel = 'email' | 'imessage' | 'push'
 
@@ -181,24 +185,9 @@ export async function POST(req: NextRequest) {
   }
   const userId = auth.userId
 
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
-  if (!supabaseUrl || !serviceKey) {
-    return NextResponse.json(
-      { ok: false, error: 'server_unconfigured' },
-      { status: 500 },
-    )
-  }
-  const adminSb = createSupabaseClient(supabaseUrl, serviceKey, {
-    auth: { persistSession: false },
-  })
-
-  // Load preferences.
-  const { data: prefRow } = await adminSb
-    .from('clapcheeks_notification_prefs')
-    .select('email, phone_e164, channels_per_event, quiet_hours_start, quiet_hours_end')
-    .eq('user_id', userId)
-    .maybeSingle()
+  // Load preferences (Convex).
+  const convex = getConvexServerClient()
+  const prefRow = await convex.query(api.notifications.getPrefs, { user_id: userId })
 
   const channelsMap = (prefRow?.channels_per_event as Record<string, Channel[]> | null) || {}
   const channels = (channelsMap[body.event_type] || []) as Channel[]
@@ -271,36 +260,36 @@ export async function POST(req: NextRequest) {
     if (!phone) {
       results.push({ channel: 'imessage', status: 'skipped', detail: 'no_phone_on_file' })
     } else {
-      const { error } = await adminSb
-        .from('clapcheeks_outbound_notifications')
-        .insert({
+      try {
+        await convex.mutation(api.notifications.enqueueOutbound, {
           user_id: userId,
           channel: 'imessage',
           phone_e164: phone,
           body: `${title}\n${messageBody}`,
           event_type: body.event_type,
         })
-      if (error) {
-        results.push({ channel: 'imessage', status: 'error', detail: error.message })
-      } else {
         results.push({ channel: 'imessage', status: 'queued' })
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'enqueue_failed'
+        results.push({ channel: 'imessage', status: 'error', detail: msg })
       }
     }
   }
 
   // ---- Push channel (queued for the future PWA SW) ----
   if (channels.includes('push')) {
-    const { error } = await adminSb.from('clapcheeks_push_queue').insert({
-      user_id: userId,
-      title,
-      body: messageBody,
-      event_type: body.event_type,
-      payload: body.payload || {},
-    })
-    if (error) {
-      results.push({ channel: 'push', status: 'error', detail: error.message })
-    } else {
+    try {
+      await convex.mutation(api.notifications.enqueuePush, {
+        user_id: userId,
+        title,
+        body: messageBody,
+        event_type: body.event_type,
+        payload: body.payload || {},
+      })
       results.push({ channel: 'push', status: 'queued' })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'enqueue_failed'
+      results.push({ channel: 'push', status: 'error', detail: msg })
     }
   }
 

--- a/web/app/api/referral/convert/route.ts
+++ b/web/app/api/referral/convert/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { stripe } from '@/lib/stripe'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: clapcheeks_referrals migrated to Convex referrals.
 
 const supabaseAdmin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -31,13 +35,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ message: 'No referral to convert' })
   }
 
-  // Find the referral record
-  const { data: referral } = await supabaseAdmin
-    .from('clapcheeks_referrals')
-    .select('id, referrer_id, status')
-    .eq('referred_id', profile.id)
-    .eq('status', 'pending')
-    .single()
+  // Find the referral record (Convex)
+  const convex = getConvexServerClient()
+  const referral = await convex.query(api.referrals.findPendingByReferred, {
+    referred_id: profile.id,
+  })
 
   if (!referral) {
     return NextResponse.json({ message: 'No pending referral found' })
@@ -68,16 +70,10 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  // Update referral status
-  await supabaseAdmin
-    .from('clapcheeks_referrals')
-    .update({
-      status: 'credited',
-      credited_at: new Date().toISOString(),
-    })
-    .eq('id', referral.id)
+  // Mark rewarded
+  await convex.mutation(api.referrals.markRewarded, { id: referral._id })
 
-  // Increment referrer's credit count
+  // Increment referrer's credit count (still in Supabase profiles)
   await supabaseAdmin.rpc('increment_referral_credits', {
     p_user_id: referral.referrer_id,
   })

--- a/web/app/api/referral/list/route.ts
+++ b/web/app/api/referral/list/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: clapcheeks_referrals migrated to Convex.
+
+export async function GET() {
+  const supabase = await createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const convex = getConvexServerClient()
+    const rows = await convex.query(api.referrals.listForReferrer, { referrer_id: user.id })
+    return NextResponse.json({
+      referrals: (rows ?? [])
+        .map((r) => ({
+          id: r._id,
+          referred_id: r.referred_id ?? null,
+          status: r.status,
+          converted_at: r.converted_at ? new Date(r.converted_at).toISOString() : null,
+          rewarded_at: r.rewarded_at ? new Date(r.rewarded_at).toISOString() : null,
+          created_at: new Date(r.created_at).toISOString(),
+        }))
+        .sort((a, b) => (a.created_at < b.created_at ? 1 : -1)),
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'load_failed'
+    return NextResponse.json({ error: msg }, { status: 500 })
+  }
+}

--- a/web/app/api/reports/cron/route.ts
+++ b/web/app/api/reports/cron/route.ts
@@ -3,6 +3,10 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { generateReportData } from '@/lib/reports/generate-report-data'
 import { renderReportPdf } from '@/lib/reports/generate-pdf'
 import { sendReportEmail } from '@/lib/reports/send-report-email'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: subscriptions + report_preferences moved to Convex.
 
 export const maxDuration = 300
 
@@ -24,28 +28,23 @@ export async function GET(request: NextRequest) {
   const weekEnd = new Date(weekStart)
   weekEnd.setDate(weekEnd.getDate() + 6)
 
-  // Get all users with active subscriptions
-  const { data: subscribers } = await supabase
-    .from('clapcheeks_subscriptions')
-    .select('user_id')
-    .eq('status', 'active')
+  // Get all users with active subscriptions (Convex)
+  const convex = getConvexServerClient()
+  const userIds = await convex.query(api.billing.listActiveUserIds, {})
 
-  if (!subscribers || subscribers.length === 0) {
+  if (!userIds || userIds.length === 0) {
     return NextResponse.json({ message: 'No active subscribers', processed: 0 })
   }
 
-  // Filter by preferences (email_enabled)
-  const userIds = subscribers.map((s) => s.user_id)
-  const { data: prefs } = await supabase
-    .from('clapcheeks_report_preferences')
-    .select('user_id, email_enabled')
-    .in('user_id', userIds)
-
+  // Filter by preferences (email_enabled) — defaults to true if no row.
+  const prefs = await convex.query(api.reportPreferences.listEmailEnabledMap, {
+    user_ids: userIds,
+  })
   const disabledUsers = new Set(
-    (prefs || []).filter((p) => p.email_enabled === false).map((p) => p.user_id)
+    (prefs || []).filter((p) => p.email_enabled === false).map((p) => p.user_id),
   )
 
-  const eligibleUsers = userIds.filter((id) => !disabledUsers.has(id))
+  const eligibleUsers = userIds.filter((id: string) => !disabledUsers.has(id))
 
   let processed = 0
   let errors = 0

--- a/web/app/api/reports/generate/route.ts
+++ b/web/app/api/reports/generate/route.ts
@@ -4,6 +4,10 @@ import { createAdminClient } from '@/lib/supabase/admin'
 import { generateReportData } from '@/lib/reports/generate-report-data'
 import { renderReportPdf } from '@/lib/reports/generate-pdf'
 import { sendReportEmail } from '@/lib/reports/send-report-email'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: report_preferences moved to Convex.
 
 export const maxDuration = 60
 
@@ -88,11 +92,10 @@ export async function POST(request: NextRequest) {
     }
 
     // Send email if user has it enabled
-    const { data: prefs } = await supabase
-      .from('clapcheeks_report_preferences')
-      .select('email_enabled')
-      .eq('user_id', targetUserId)
-      .single()
+    const convex = getConvexServerClient()
+    const prefs = await convex.query(api.reportPreferences.getForUser, {
+      user_id: targetUserId,
+    })
 
     const emailEnabled = prefs?.email_enabled !== false // default true
 

--- a/web/app/api/reports/preferences/route.ts
+++ b/web/app/api/reports/preferences/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: report_preferences now lives on Convex.
 
 export async function GET() {
   try {
@@ -10,13 +14,18 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const { data } = await supabase
-      .from('clapcheeks_report_preferences')
-      .select('email_enabled, send_day, send_hour')
-      .eq('user_id', user.id)
-      .single()
+    const convex = getConvexServerClient()
+    const data = await convex.query(api.reportPreferences.getForUser, { user_id: user.id })
 
-    return NextResponse.json(data || { email_enabled: true, send_day: 'monday', send_hour: 9 })
+    return NextResponse.json(
+      data
+        ? {
+            email_enabled: data.email_enabled,
+            send_day: data.send_day,
+            send_hour: data.send_hour,
+          }
+        : { email_enabled: true, send_day: 'monday', send_hour: 9 },
+    )
   } catch (error) {
     console.error('Preferences GET error:', error)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
@@ -35,21 +44,17 @@ export async function PUT(request: NextRequest) {
     const body = await request.json()
     const { email_enabled, send_day, send_hour } = body
 
-    const { error } = await supabase
-      .from('clapcheeks_report_preferences')
-      .upsert(
-        {
-          user_id: user.id,
-          email_enabled: email_enabled ?? true,
-          send_day: send_day ?? 'sunday',
-          send_hour: send_hour ?? 8,
-          updated_at: new Date().toISOString(),
-        },
-        { onConflict: 'user_id' }
-      )
-
-    if (error) {
-      console.error('Preferences update error:', error)
+    try {
+      const convex = getConvexServerClient()
+      await convex.mutation(api.reportPreferences.upsertForUser, {
+        user_id: user.id,
+        email_enabled: email_enabled ?? true,
+        send_day: send_day ?? 'sunday',
+        send_hour: send_hour ?? 8,
+      })
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'failed'
+      console.error('Preferences update error:', msg)
       return NextResponse.json({ error: 'Failed to update preferences' }, { status: 500 })
     }
 

--- a/web/app/api/reports/weekly/route.ts
+++ b/web/app/api/reports/weekly/route.ts
@@ -4,6 +4,10 @@ import Anthropic from '@anthropic-ai/sdk'
 import { generateReportData } from '@/lib/reports/generate-report-data'
 import { renderWeeklyReportEmail } from '@/lib/email/weekly-report'
 import { Resend } from 'resend'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: subscriptions + report_preferences + coaching_sessions on Convex.
 
 export const maxDuration = 300
 
@@ -30,28 +34,23 @@ export async function GET(request: NextRequest) {
   const weekEnd = new Date(weekStart)
   weekEnd.setUTCDate(weekEnd.getUTCDate() + 6) // Last Sunday
 
-  // Get all users with active subscriptions
-  const { data: subscribers } = await supabaseAdmin
-    .from('clapcheeks_subscriptions')
-    .select('user_id')
-    .eq('status', 'active')
+  // Get all users with active subscriptions (Convex)
+  const convex = getConvexServerClient()
+  const userIds = await convex.query(api.billing.listActiveUserIds, {})
 
-  if (!subscribers || subscribers.length === 0) {
+  if (!userIds || userIds.length === 0) {
     return NextResponse.json({ message: 'No active subscribers', processed: 0 })
   }
 
-  // Filter by preferences (email_enabled)
-  const userIds = subscribers.map((s) => s.user_id)
-  const { data: prefs } = await supabaseAdmin
-    .from('clapcheeks_report_preferences')
-    .select('user_id, email_enabled')
-    .in('user_id', userIds)
-
+  // Filter by preferences (email_enabled). Defaults to true if no row.
+  const prefs = await convex.query(api.reportPreferences.listEmailEnabledMap, {
+    user_ids: userIds,
+  })
   const disabledUsers = new Set(
-    (prefs || []).filter((p) => p.email_enabled === false).map((p) => p.user_id)
+    (prefs || []).filter((p) => p.email_enabled === false).map((p) => p.user_id),
   )
 
-  const eligibleUserIds = userIds.filter((id) => !disabledUsers.has(id))
+  const eligibleUserIds = userIds.filter((id: string) => !disabledUsers.has(id))
 
   if (eligibleUserIds.length === 0) {
     return NextResponse.json({ message: 'No eligible users', processed: 0 })
@@ -189,18 +188,27 @@ Stats: ${stats.swipes} swipes (${stats.swipesChange}%), ${stats.matches} matches
 }
 
 async function getFallbackTip(): Promise<string> {
-  // Try to get latest coaching tip from DB
+  // Try to get the latest coaching tip from Convex (AI-9537).
+  // We don't have a user context here; we just want any recent tip.
+  // Falls back to the canned line if no rows exist.
   try {
-    const { data } = await supabaseAdmin
-      .from('clapcheeks_coaching_sessions')
-      .select('tips')
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .single()
-
-    if (data?.tips && Array.isArray(data.tips) && data.tips.length > 0) {
-      const tip = data.tips[0]
-      return typeof tip === 'string' ? tip : (tip as { tip?: string }).tip || 'Keep swiping and stay consistent with your messaging game!'
+    const convex = getConvexServerClient()
+    const userIds = await convex.query(api.billing.listActiveUserIds, {})
+    for (const uid of userIds.slice(0, 25)) {
+      const sessions = await convex.query(api.coaching.listRecentForUser, {
+        user_id: uid,
+        limit: 1,
+      })
+      if (sessions && sessions.length > 0) {
+        const tips = (sessions[0].tips as unknown[]) || []
+        if (Array.isArray(tips) && tips.length > 0) {
+          const tip = tips[0]
+          return typeof tip === 'string'
+            ? tip
+            : (tip as { tip?: string }).tip ||
+                'Keep swiping and stay consistent with your messaging game!'
+        }
+      }
     }
   } catch {
     // Ignore

--- a/web/app/api/stripe/webhook/route.ts
+++ b/web/app/api/stripe/webhook/route.ts
@@ -2,13 +2,67 @@ import type Stripe from 'stripe'
 import { NextRequest, NextResponse } from 'next/server'
 import { stripe } from '@/lib/stripe'
 import { createClient } from '@supabase/supabase-js'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
 
 export const runtime = 'nodejs'
+
+// AI-9537: subscriptions parallel-write to Supabase (profiles) + Convex
+// (subscriptions). Reads continue from Supabase profiles for now; Convex
+// reads come online once parity is verified.
 
 const supabaseAdmin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!
 )
+
+type ConvexPlan = 'starter' | 'pro' | 'elite'
+
+function normalizePlanForConvex(tier: string | undefined | null): ConvexPlan | null {
+  if (!tier) return null
+  if (tier === 'starter' || tier === 'pro' || tier === 'elite') return tier
+  return null
+}
+
+async function mirrorSubscriptionToConvex(args: {
+  user_id: string
+  stripe_subscription_id?: string | null
+  plan: string | null | undefined
+  status: string
+  current_period_start?: number | null
+  current_period_end?: number | null
+}): Promise<void> {
+  const plan = normalizePlanForConvex(args.plan)
+  if (!plan) return
+  try {
+    const convex = getConvexServerClient()
+    await convex.mutation(api.billing.upsertSubscription, {
+      user_id: args.user_id,
+      stripe_subscription_id: args.stripe_subscription_id ?? undefined,
+      plan,
+      status: args.status,
+      current_period_start: args.current_period_start ?? undefined,
+      current_period_end: args.current_period_end ?? undefined,
+    })
+  } catch (err) {
+    console.error('[AI-9537] convex subscription mirror failed:', err)
+  }
+}
+
+async function mirrorSubscriptionStatusByStripeId(
+  stripeSubscriptionId: string,
+  status: string,
+): Promise<void> {
+  try {
+    const convex = getConvexServerClient()
+    await convex.mutation(api.billing.updateStatusByStripeId, {
+      stripe_subscription_id: stripeSubscriptionId,
+      status,
+    })
+  } catch (err) {
+    console.error('[AI-9537] convex subscription status mirror failed:', err)
+  }
+}
 
 async function isEventProcessed(eventId: string): Promise<boolean> {
   const { data } = await supabaseAdmin
@@ -43,7 +97,6 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid signature' }, { status: 400 })
   }
 
-  // Idempotency: skip already-processed events
   if (await isEventProcessed(event.id)) {
     return NextResponse.json({ received: true })
   }
@@ -60,6 +113,13 @@ export async function POST(request: NextRequest) {
           subscription_tier: tierValue,
           subscription_status: 'active',
         }).eq('id', userId)
+        // AI-9537: parallel-write to Convex subscriptions.
+        await mirrorSubscriptionToConvex({
+          user_id: userId,
+          stripe_subscription_id: (session.subscription as string) || null,
+          plan: tierValue,
+          status: 'active',
+        })
       }
       break
     }
@@ -68,13 +128,11 @@ export async function POST(request: NextRequest) {
       const subscription = event.data.object as Stripe.Subscription
       const customerId = subscription.customer as string
 
-      // Determine plan from price lookup key (format: plan_interval e.g. "pro_monthly")
       const lookupKey = subscription.items.data[0]?.price?.lookup_key || ''
       const planFromKey = lookupKey.split('_')[0] || 'base'
       const validPlans = ['base', 'starter', 'pro', 'elite']
       const tier = validPlans.includes(planFromKey) ? planFromKey : 'base'
 
-      // For trialing subscriptions, grant pro-level access during trial
       const effectiveTier = subscription.status === 'trialing' ? 'pro' : tier
 
       await supabaseAdmin.from('profiles').update({
@@ -84,6 +142,31 @@ export async function POST(request: NextRequest) {
           ? new Date(subscription.trial_end * 1000).toISOString()
           : null,
       }).eq('stripe_customer_id', customerId)
+
+      // AI-9537: parallel-write to Convex subscriptions.
+      try {
+        const { data: linkedProfile } = await supabaseAdmin
+          .from('profiles')
+          .select('id')
+          .eq('stripe_customer_id', customerId)
+          .single()
+        if (linkedProfile?.id) {
+          const cps = (subscription as any).current_period_start as number | null | undefined
+          const cpe = (subscription as any).current_period_end as number | null | undefined
+          await mirrorSubscriptionToConvex({
+            user_id: linkedProfile.id,
+            stripe_subscription_id: subscription.id,
+            plan: effectiveTier,
+            status: subscription.status,
+            current_period_start: cps ? cps * 1000 : null,
+            current_period_end: cpe ? cpe * 1000 : null,
+          })
+        } else {
+          await mirrorSubscriptionStatusByStripeId(subscription.id, subscription.status)
+        }
+      } catch (err) {
+        console.error('[AI-9537] subscription.updated convex mirror error:', err)
+      }
       break
     }
 
@@ -110,6 +193,8 @@ export async function POST(request: NextRequest) {
         access_expires_at: null,
         trial_end: null,
       }).eq('stripe_customer_id', customerId)
+      // AI-9537: mirror status flip into Convex.
+      await mirrorSubscriptionStatusByStripeId(subscription.id, 'canceled')
       break
     }
 
@@ -117,7 +202,6 @@ export async function POST(request: NextRequest) {
       const invoice = event.data.object as Stripe.Invoice
       const customerId = invoice.customer as string
 
-      // Set 7-day grace period — access expires in 7 days
       const graceExpiry = new Date()
       graceExpiry.setDate(graceExpiry.getDate() + 7)
 
@@ -142,7 +226,6 @@ export async function POST(request: NextRequest) {
       const invoice = event.data.object as Stripe.Invoice
       const customerId = invoice.customer as string
 
-      // Clear past_due status and grace period on successful payment
       await supabaseAdmin.from('profiles').update({
         subscription_status: 'active',
         access_expires_at: null,
@@ -151,7 +234,6 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  // Mark event as processed for idempotency
   await markEventProcessed(event.id, event.type)
 
   return NextResponse.json({ received: true })

--- a/web/app/api/voice/train/route.ts
+++ b/web/app/api/voice/train/route.ts
@@ -18,6 +18,10 @@
  */
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: migrated voice profile reads/writes to Convex voice_profiles.
 
 export async function GET() {
   const supabase = await createClient()
@@ -28,17 +32,13 @@ export async function GET() {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const { data, error } = await supabase
-    .from('clapcheeks_voice_profiles')
-    .select(
-      'user_id, style_summary, tone, sample_phrases, profile_data, ' +
-        'messages_analyzed, digest, boosted_samples, last_scan_at, updated_at'
-    )
-    .eq('user_id', user.id)
-    .maybeSingle()
-
-  if (error && error.code !== 'PGRST116') {
-    return NextResponse.json({ error: error.message }, { status: 500 })
+  let data: unknown = null
+  try {
+    const convex = getConvexServerClient()
+    data = await convex.query(api.voice.getProfile, { user_id: user.id })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'voice_load_failed'
+    return NextResponse.json({ error: msg }, { status: 500 })
   }
 
   return NextResponse.json({
@@ -86,24 +86,16 @@ export async function POST(req: NextRequest) {
     .filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
     .map((s) => s.trim())
 
-  const { data, error } = await supabase
-    .from('clapcheeks_voice_profiles')
-    .upsert(
-      {
-        user_id: user.id,
-        boosted_samples: cleaned,
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: 'user_id' }
-    )
-    .select(
-      'user_id, boosted_samples, digest, messages_analyzed, last_scan_at, updated_at'
-    )
-    .single()
-
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 })
+  try {
+    const convex = getConvexServerClient()
+    await convex.mutation(api.voice.upsertProfileDigest, {
+      user_id: user.id,
+      boosted_samples: cleaned,
+    })
+    const data = await convex.query(api.voice.getProfile, { user_id: user.id })
+    return NextResponse.json({ profile: data })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'voice_save_failed'
+    return NextResponse.json({ error: msg }, { status: 500 })
   }
-
-  return NextResponse.json({ profile: data })
 }

--- a/web/app/notifications/page.tsx
+++ b/web/app/notifications/page.tsx
@@ -4,8 +4,13 @@ import { revalidatePath } from "next/cache"
 import { createClient } from "@/lib/supabase/server"
 import { ArrowLeft, Bell, Calendar, Users, AlertTriangle, X } from "lucide-react"
 import Link from "next/link"
+import { getConvexServerClient } from "@/lib/convex/server"
+import { api } from "@/convex/_generated/api"
+import type { Id } from "@/convex/_generated/dataModel"
 
 export const metadata: Metadata = { title: 'Notifications | Clapcheeks' }
+
+// AI-9537: notifications now live on Convex (read instead of is_read).
 
 async function markAllRead() {
   "use server"
@@ -15,11 +20,8 @@ async function markAllRead() {
   } = await supabase.auth.getUser()
   if (!user) return
 
-  await supabase
-    .from("notifications")
-    .update({ is_read: true, read_at: new Date().toISOString() })
-    .eq("user_id", user.id)
-    .eq("is_read", false)
+  const convex = getConvexServerClient()
+  await convex.mutation(api.notifications.markAllReadForUser, { user_id: user.id })
   revalidatePath("/notifications")
 }
 
@@ -31,7 +33,8 @@ async function clearRead() {
   } = await supabase.auth.getUser()
   if (!user) return
 
-  await supabase.from("notifications").delete().eq("user_id", user.id).eq("is_read", true)
+  const convex = getConvexServerClient()
+  await convex.mutation(api.notifications.deleteAllReadForUser, { user_id: user.id })
   revalidatePath("/notifications")
 }
 
@@ -43,8 +46,21 @@ async function dismissNotification(id: string) {
   } = await supabase.auth.getUser()
   if (!user) return
 
-  await supabase.from("notifications").delete().eq("id", id).eq("user_id", user.id)
+  const convex = getConvexServerClient()
+  await convex.mutation(api.notifications.deleteNotification, {
+    id: id as Id<"notifications">,
+    user_id: user.id,
+  })
   revalidatePath("/notifications")
+}
+
+interface DisplayNotification {
+  id: string
+  type: string
+  title: string
+  message: string
+  is_read: boolean
+  created_at: string
 }
 
 export default async function NotificationsPage() {
@@ -58,15 +74,24 @@ export default async function NotificationsPage() {
     redirect("/auth/login")
   }
 
-  // Fetch notifications
-  const { data: notifications } = await supabase
-    .from("notifications")
-    .select("*")
-    .eq("user_id", user.id)
-    .order("created_at", { ascending: false })
+  // Fetch notifications from Convex
+  const convex = getConvexServerClient()
+  const rows = await convex.query(api.notifications.listForUser, {
+    user_id: user.id,
+    limit: 200,
+  })
 
-  const hasUnread = notifications?.some((n) => !n.is_read) ?? false
-  const hasRead = notifications?.some((n) => n.is_read) ?? false
+  const notifications: DisplayNotification[] = (rows ?? []).map((n) => ({
+    id: n._id as unknown as string,
+    type: n.type ?? '',
+    title: n.title,
+    message: n.message ?? '',
+    is_read: n.read,
+    created_at: new Date(n.created_at).toISOString(),
+  }))
+
+  const hasUnread = notifications.some((n) => !n.is_read)
+  const hasRead = notifications.some((n) => n.is_read)
 
   const getIcon = (type: string) => {
     switch (type) {
@@ -133,7 +158,7 @@ export default async function NotificationsPage() {
           </div>
         ) : (
           <div className="space-y-3">
-            {notifications.map((notification: { id: string; type: string; title: string; message: string; is_read: boolean; created_at: string }) => (
+            {notifications.map((notification) => (
               <div
                 key={notification.id}
                 className={`rounded-xl p-4 transition-all ${

--- a/web/components/layout/connection-bar.tsx
+++ b/web/components/layout/connection-bar.tsx
@@ -15,6 +15,10 @@
  */
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/server'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: devices on Convex.
 
 type PillColor = 'green' | 'amber' | 'red' | 'gray'
 
@@ -204,7 +208,8 @@ export default async function ConnectionBar() {
   // AI-8926: clapcheeks_device_heartbeats is the modern source-of-truth for
   // agent freshness (the daemon upserts every heartbeat).  Older `devices`
   // rows can be stale; pick the freshest of the two.
-  const [settingsRes, eventsRes, deviceRes, heartbeatRes] = await Promise.all([
+  const convex = getConvexServerClient()
+  const [settingsRes, eventsRes, deviceListRes, heartbeatRes] = await Promise.all([
     (supabase as any)
       .from('clapcheeks_user_settings')
       .select(
@@ -221,13 +226,7 @@ export default async function ConnectionBar() {
       .gte('detected_at', since)
       .order('detected_at', { ascending: false })
       .limit(50),
-    (supabase as any)
-      .from('devices')
-      .select('last_seen_at,is_active')
-      .eq('user_id', user.id)
-      .order('last_seen_at', { ascending: false })
-      .limit(1)
-      .maybeSingle(),
+    convex.query(api.devices.listForUser, { user_id: user.id }),
     (supabase as any)
       .from('clapcheeks_device_heartbeats')
       .select('last_heartbeat_at')
@@ -239,7 +238,12 @@ export default async function ConnectionBar() {
 
   const settings = (settingsRes.data as UserSettingsRow | null) ?? null
   const events = ((eventsRes.data as BanEventRow[] | null) ?? []) as BanEventRow[]
-  const deviceRow = (deviceRes.data as DeviceRow | null) ?? null
+  const deviceList = (deviceListRes ?? []) as Array<{ last_seen_at: number; is_active: boolean }>
+  let deviceRow: DeviceRow | null = null
+  if (deviceList.length) {
+    const top = deviceList.reduce((best, d) => (d.last_seen_at > best.last_seen_at ? d : best))
+    deviceRow = { last_seen_at: new Date(top.last_seen_at).toISOString(), is_active: top.is_active } as DeviceRow
+  }
   const heartbeatRow = (heartbeatRes.data as { last_heartbeat_at: string | null } | null) ?? null
 
   // Compose a unified device view: take the freshest last_seen across both

--- a/web/convex/billing.ts
+++ b/web/convex/billing.ts
@@ -1,0 +1,172 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// AI-9537 — Billing on Convex.
+//
+// Replaces Supabase tables clapcheeks_subscriptions + dunning_events.
+// During the parallel-write window, the Stripe webhook + dunning helper
+// writes BOTH Supabase and Convex; reads continue from Supabase until
+// parity is verified, then reads flip to Convex.
+
+const PLAN = v.union(
+  v.literal("starter"),
+  v.literal("pro"),
+  v.literal("elite"),
+);
+
+const DUNNING_EVENT_TYPE = v.union(
+  v.literal("payment_failed"),
+  v.literal("payment_recovered"),
+  v.literal("grace_period_expired"),
+  v.literal("manual_retry"),
+  v.literal("subscription_canceled"),
+);
+
+// ---------------------------------------------------------------------------
+// upsertSubscription — write path. Idempotent on (user_id) OR (stripe_subscription_id).
+// Used by Stripe webhook + admin tooling.
+// ---------------------------------------------------------------------------
+export const upsertSubscription = mutation({
+  args: {
+    user_id: v.string(),
+    stripe_subscription_id: v.optional(v.string()),
+    plan: PLAN,
+    status: v.string(),
+    current_period_start: v.optional(v.number()),
+    current_period_end: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    // Prefer match on stripe_subscription_id (when present), else user_id.
+    let existing = null as Awaited<ReturnType<typeof ctx.db.query>>["first"] extends () => Promise<infer R> ? R : never;
+    if (args.stripe_subscription_id) {
+      existing = await ctx.db
+        .query("subscriptions")
+        .withIndex("by_stripe_id", (q) => q.eq("stripe_subscription_id", args.stripe_subscription_id))
+        .first();
+    }
+    if (!existing) {
+      existing = await ctx.db
+        .query("subscriptions")
+        .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+        .first();
+    }
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        user_id: args.user_id,
+        stripe_subscription_id: args.stripe_subscription_id,
+        plan: args.plan,
+        status: args.status,
+        current_period_start: args.current_period_start,
+        current_period_end: args.current_period_end,
+        updated_at: now,
+      });
+      return { ok: true as const, action: "updated" as const, id: existing._id };
+    }
+    const id = await ctx.db.insert("subscriptions", {
+      user_id: args.user_id,
+      stripe_subscription_id: args.stripe_subscription_id,
+      plan: args.plan,
+      status: args.status,
+      current_period_start: args.current_period_start,
+      current_period_end: args.current_period_end,
+      created_at: now,
+      updated_at: now,
+    });
+    return { ok: true as const, action: "inserted" as const, id };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// updateStatusByStripeId — narrow patch used by webhook flows that only
+// know the Stripe subscription id.
+// ---------------------------------------------------------------------------
+export const updateStatusByStripeId = mutation({
+  args: {
+    stripe_subscription_id: v.string(),
+    status: v.string(),
+    plan: v.optional(PLAN),
+    current_period_start: v.optional(v.number()),
+    current_period_end: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_stripe_id", (q) => q.eq("stripe_subscription_id", args.stripe_subscription_id))
+      .first();
+    if (!row) return { ok: false as const, reason: "not_found" as const };
+    const patch: Record<string, unknown> = {
+      status: args.status,
+      updated_at: Date.now(),
+    };
+    if (args.plan) patch.plan = args.plan;
+    if (args.current_period_start !== undefined) patch.current_period_start = args.current_period_start;
+    if (args.current_period_end !== undefined) patch.current_period_end = args.current_period_end;
+    await ctx.db.patch(row._id, patch);
+    return { ok: true as const, id: row._id };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// getByUser / listActiveUserIds — read paths.
+// ---------------------------------------------------------------------------
+export const getByUser = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("subscriptions")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+  },
+});
+
+export const listActiveUserIds = query({
+  args: {},
+  handler: async (ctx) => {
+    const rows = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_status", (q) => q.eq("status", "active"))
+      .collect();
+    return rows.map((r) => r.user_id);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// insertDunningEvent — append-only audit log.
+// ---------------------------------------------------------------------------
+export const insertDunningEvent = mutation({
+  args: {
+    user_id: v.optional(v.string()),
+    stripe_customer_id: v.optional(v.string()),
+    stripe_invoice_id: v.optional(v.string()),
+    event_type: DUNNING_EVENT_TYPE,
+    attempt_number: v.optional(v.number()),
+    grace_period_end: v.optional(v.number()),
+    metadata: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    const id = await ctx.db.insert("dunning_events", {
+      user_id: args.user_id,
+      stripe_customer_id: args.stripe_customer_id,
+      stripe_invoice_id: args.stripe_invoice_id,
+      event_type: args.event_type,
+      attempt_number: args.attempt_number,
+      grace_period_end: args.grace_period_end,
+      metadata: args.metadata,
+      created_at: Date.now(),
+    });
+    return { ok: true as const, id };
+  },
+});
+
+export const recentDunningForUser = query({
+  args: { user_id: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const limit = args.limit ?? 25;
+    return await ctx.db
+      .query("dunning_events")
+      .withIndex("by_user_ts", (q) => q.eq("user_id", args.user_id))
+      .order("desc")
+      .take(limit);
+  },
+});

--- a/web/convex/calendarTokens.ts
+++ b/web/convex/calendarTokens.ts
@@ -1,0 +1,139 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// AI-9537 — Google Calendar OAuth tokens on Convex.
+//
+// SENSITIVE: refresh_token + access_token are AES-256-GCM encrypted by the
+// caller (web/lib/crypto/token-vault.ts → encryptToken) before being passed
+// in. They are NEVER stored as plaintext at rest.
+
+// ---------------------------------------------------------------------------
+// upsertEncrypted — write path. Caller (Next.js route or Python backfill)
+// pre-encrypts both tokens with the user's vault key and passes ciphertext.
+// ---------------------------------------------------------------------------
+export const upsertEncrypted = mutation({
+  args: {
+    user_id: v.string(),
+    google_email: v.string(),
+    google_sub: v.optional(v.string()),
+    access_token_encrypted: v.bytes(),
+    refresh_token_encrypted: v.bytes(),
+    enc_version: v.number(),
+    expires_at: v.number(),                  // unix ms
+    scopes: v.array(v.string()),
+    calendar_id: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("google_calendar_tokens")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+    const calendar_id = args.calendar_id ?? "primary";
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        google_email: args.google_email,
+        google_sub: args.google_sub,
+        access_token_encrypted: args.access_token_encrypted,
+        refresh_token_encrypted: args.refresh_token_encrypted,
+        enc_version: args.enc_version,
+        expires_at: args.expires_at,
+        scopes: args.scopes,
+        calendar_id,
+        updated_at: now,
+      });
+      return { ok: true as const, id: existing._id, action: "updated" as const };
+    }
+    const id = await ctx.db.insert("google_calendar_tokens", {
+      user_id: args.user_id,
+      google_email: args.google_email,
+      google_sub: args.google_sub,
+      access_token_encrypted: args.access_token_encrypted,
+      refresh_token_encrypted: args.refresh_token_encrypted,
+      enc_version: args.enc_version,
+      expires_at: args.expires_at,
+      scopes: args.scopes,
+      calendar_id,
+      created_at: now,
+      updated_at: now,
+    });
+    return { ok: true as const, id, action: "inserted" as const };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// updateAccessTokenEncrypted — token-refresh narrow patch. Only the
+// short-lived access_token rotates; refresh_token stays put.
+// ---------------------------------------------------------------------------
+export const updateAccessTokenEncrypted = mutation({
+  args: {
+    user_id: v.string(),
+    access_token_encrypted: v.bytes(),
+    expires_at: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("google_calendar_tokens")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+    if (!row) return { ok: false as const, reason: "not_connected" as const };
+    await ctx.db.patch(row._id, {
+      access_token_encrypted: args.access_token_encrypted,
+      expires_at: args.expires_at,
+      updated_at: Date.now(),
+    });
+    return { ok: true as const };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// getEncryptedForUser — read path. Caller decrypts with token-vault.
+// ---------------------------------------------------------------------------
+export const getEncryptedForUser = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("google_calendar_tokens")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+  },
+});
+
+// ---------------------------------------------------------------------------
+// getMetaForUser — non-sensitive metadata (no ciphertext) for the "is the
+// calendar connected?" UI hint.
+// ---------------------------------------------------------------------------
+export const getMetaForUser = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("google_calendar_tokens")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+    if (!row) return null;
+    return {
+      google_email: row.google_email,
+      calendar_id: row.calendar_id,
+      scopes: row.scopes,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+      expires_at: row.expires_at,
+    };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// deleteForUser — disconnect path.
+// ---------------------------------------------------------------------------
+export const deleteForUser = mutation({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("google_calendar_tokens")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+    if (!row) return { ok: true as const, action: "noop" as const };
+    await ctx.db.delete(row._id);
+    return { ok: true as const, action: "deleted" as const };
+  },
+});

--- a/web/convex/coaching.ts
+++ b/web/convex/coaching.ts
@@ -1,0 +1,115 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// AI-9537 — Coaching sessions + tip feedback (replaces
+// clapcheeks_coaching_sessions + clapcheeks_tip_feedback).
+
+// ---------------------------------------------------------------------------
+// coaching_sessions
+// ---------------------------------------------------------------------------
+export const upsertSession = mutation({
+  args: {
+    user_id: v.string(),
+    week_start: v.string(),
+    generated_at: v.optional(v.number()),
+    tips: v.any(),
+    stats_snapshot: v.optional(v.any()),
+    feedback_score: v.optional(v.number()),
+    model_used: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const generated_at = args.generated_at ?? now;
+    const existing = await ctx.db
+      .query("coaching_sessions")
+      .withIndex("by_user_week", (q) => q.eq("user_id", args.user_id).eq("week_start", args.week_start))
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        generated_at,
+        tips: args.tips,
+        stats_snapshot: args.stats_snapshot,
+        feedback_score: args.feedback_score,
+        model_used: args.model_used,
+      });
+      return { ok: true as const, id: existing._id, action: "updated" as const };
+    }
+    const id = await ctx.db.insert("coaching_sessions", {
+      user_id: args.user_id,
+      generated_at,
+      week_start: args.week_start,
+      tips: args.tips,
+      stats_snapshot: args.stats_snapshot,
+      feedback_score: args.feedback_score,
+      model_used: args.model_used,
+      created_at: now,
+    });
+    return { ok: true as const, id, action: "inserted" as const };
+  },
+});
+
+export const getSessionForWeek = query({
+  args: { user_id: v.string(), week_start: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("coaching_sessions")
+      .withIndex("by_user_week", (q) => q.eq("user_id", args.user_id).eq("week_start", args.week_start))
+      .first();
+  },
+});
+
+export const listRecentForUser = query({
+  args: { user_id: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("coaching_sessions")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .order("desc")
+      .take(args.limit ?? 8);
+  },
+});
+
+// ---------------------------------------------------------------------------
+// tip_feedback
+// ---------------------------------------------------------------------------
+export const upsertTipFeedback = mutation({
+  args: {
+    user_id: v.string(),
+    coaching_session_id: v.id("coaching_sessions"),
+    tip_index: v.number(),
+    helpful: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("tip_feedback")
+      .withIndex("by_user_session_tip", (q) =>
+        q
+          .eq("user_id", args.user_id)
+          .eq("coaching_session_id", args.coaching_session_id)
+          .eq("tip_index", args.tip_index),
+      )
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, { helpful: args.helpful });
+      return { ok: true as const, id: existing._id, action: "updated" as const };
+    }
+    const id = await ctx.db.insert("tip_feedback", {
+      user_id: args.user_id,
+      coaching_session_id: args.coaching_session_id,
+      tip_index: args.tip_index,
+      helpful: args.helpful,
+      created_at: Date.now(),
+    });
+    return { ok: true as const, id, action: "inserted" as const };
+  },
+});
+
+export const listFeedbackForSession = query({
+  args: { coaching_session_id: v.id("coaching_sessions") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("tip_feedback")
+      .withIndex("by_session", (q) => q.eq("coaching_session_id", args.coaching_session_id))
+      .collect();
+  },
+});

--- a/web/convex/devices.ts
+++ b/web/convex/devices.ts
@@ -1,0 +1,84 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// AI-9537 — Registered iOS / Mac devices per user (replaces public.devices).
+
+export const listForUser = query({
+  args: { user_id: v.string(), only_active: v.optional(v.boolean()) },
+  handler: async (ctx, args) => {
+    if (args.only_active) {
+      return await ctx.db
+        .query("devices")
+        .withIndex("by_user_active", (q) => q.eq("user_id", args.user_id).eq("is_active", true))
+        .collect();
+    }
+    return await ctx.db
+      .query("devices")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .collect();
+  },
+});
+
+export const upsertDevice = mutation({
+  args: {
+    user_id: v.string(),
+    device_name: v.string(),
+    platform: v.string(),
+    agent_version: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const matches = await ctx.db
+      .query("devices")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .collect();
+    const existing = matches.find((d) => d.device_name === args.device_name);
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        platform: args.platform,
+        agent_version: args.agent_version,
+        last_seen_at: now,
+        is_active: true,
+      });
+      return { ok: true as const, id: existing._id, action: "updated" as const };
+    }
+    const id = await ctx.db.insert("devices", {
+      user_id: args.user_id,
+      device_name: args.device_name,
+      platform: args.platform,
+      agent_version: args.agent_version,
+      last_seen_at: now,
+      is_active: true,
+      created_at: now,
+    });
+    return { ok: true as const, id, action: "inserted" as const };
+  },
+});
+
+export const heartbeat = mutation({
+  args: { user_id: v.string(), device_name: v.string() },
+  handler: async (ctx, args) => {
+    const matches = await ctx.db
+      .query("devices")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .collect();
+    const existing = matches.find((d) => d.device_name === args.device_name);
+    if (!existing) return { ok: false as const, reason: "not_found" as const };
+    await ctx.db.patch(existing._id, { last_seen_at: Date.now(), is_active: true });
+    return { ok: true as const };
+  },
+});
+
+export const deactivate = mutation({
+  args: { user_id: v.string(), device_name: v.string() },
+  handler: async (ctx, args) => {
+    const matches = await ctx.db
+      .query("devices")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .collect();
+    const existing = matches.find((d) => d.device_name === args.device_name);
+    if (!existing) return { ok: false as const, reason: "not_found" as const };
+    await ctx.db.patch(existing._id, { is_active: false });
+    return { ok: true as const };
+  },
+});

--- a/web/convex/memos.ts
+++ b/web/convex/memos.ts
@@ -1,0 +1,45 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// AI-9537 — Per-contact operator memos (replaces clapcheeks_memos).
+
+export const getForContact = query({
+  args: { user_id: v.string(), contact_handle: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("memos")
+      .withIndex("by_user_handle", (q) =>
+        q.eq("user_id", args.user_id).eq("contact_handle", args.contact_handle),
+      )
+      .first();
+  },
+});
+
+export const upsertMemo = mutation({
+  args: {
+    user_id: v.string(),
+    contact_handle: v.string(),
+    content: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("memos")
+      .withIndex("by_user_handle", (q) =>
+        q.eq("user_id", args.user_id).eq("contact_handle", args.contact_handle),
+      )
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, { content: args.content, updated_at: now });
+      return { ok: true as const, id: existing._id, action: "updated" as const };
+    }
+    const id = await ctx.db.insert("memos", {
+      user_id: args.user_id,
+      contact_handle: args.contact_handle,
+      content: args.content,
+      created_at: now,
+      updated_at: now,
+    });
+    return { ok: true as const, id, action: "inserted" as const };
+  },
+});

--- a/web/convex/notifications.ts
+++ b/web/convex/notifications.ts
@@ -1,0 +1,243 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// AI-9537 — Notification prefs + queues + in-app notifications list.
+// Replaces:
+//   - clapcheeks_notification_prefs
+//   - clapcheeks_outbound_notifications
+//   - clapcheeks_push_queue
+//   - public.notifications
+
+// ---------------------------------------------------------------------------
+// notification_prefs
+// ---------------------------------------------------------------------------
+export const getPrefs = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("notification_prefs")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+  },
+});
+
+export const upsertPrefs = mutation({
+  args: {
+    user_id: v.string(),
+    email: v.optional(v.string()),
+    phone_e164: v.optional(v.string()),
+    channels_per_event: v.any(),
+    quiet_hours_start: v.number(),
+    quiet_hours_end: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("notification_prefs")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        email: args.email,
+        phone_e164: args.phone_e164,
+        channels_per_event: args.channels_per_event,
+        quiet_hours_start: args.quiet_hours_start,
+        quiet_hours_end: args.quiet_hours_end,
+        updated_at: now,
+      });
+      return { ok: true as const, id: existing._id, action: "updated" as const };
+    }
+    const id = await ctx.db.insert("notification_prefs", {
+      user_id: args.user_id,
+      email: args.email,
+      phone_e164: args.phone_e164,
+      channels_per_event: args.channels_per_event,
+      quiet_hours_start: args.quiet_hours_start,
+      quiet_hours_end: args.quiet_hours_end,
+      updated_at: now,
+    });
+    return { ok: true as const, id, action: "inserted" as const };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// outbound_notifications (iMessage queue)
+// ---------------------------------------------------------------------------
+export const enqueueOutbound = mutation({
+  args: {
+    user_id: v.string(),
+    channel: v.string(),
+    phone_e164: v.string(),
+    body: v.string(),
+    event_type: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const id = await ctx.db.insert("outbound_notifications", {
+      user_id: args.user_id,
+      channel: args.channel,
+      phone_e164: args.phone_e164,
+      body: args.body,
+      event_type: args.event_type,
+      status: "pending",
+      attempts: 0,
+      created_at: Date.now(),
+    });
+    return { ok: true as const, id };
+  },
+});
+
+export const listPendingOutbound = query({
+  args: { user_id: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("outbound_notifications")
+      .withIndex("by_user_pending", (q) => q.eq("user_id", args.user_id).eq("status", "pending"))
+      .order("asc")
+      .take(args.limit ?? 50);
+  },
+});
+
+export const markOutboundSent = mutation({
+  args: { id: v.id("outbound_notifications") },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.id, {
+      status: "sent",
+      sent_at: Date.now(),
+    });
+    return { ok: true as const };
+  },
+});
+
+export const markOutboundFailed = mutation({
+  args: { id: v.id("outbound_notifications"), last_error: v.string() },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.id);
+    if (!existing) return { ok: false as const };
+    await ctx.db.patch(args.id, {
+      status: "failed",
+      attempts: (existing.attempts ?? 0) + 1,
+      last_error: args.last_error,
+    });
+    return { ok: true as const };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// push_queue
+// ---------------------------------------------------------------------------
+export const enqueuePush = mutation({
+  args: {
+    user_id: v.string(),
+    title: v.string(),
+    body: v.string(),
+    event_type: v.optional(v.string()),
+    payload: v.optional(v.any()),
+  },
+  handler: async (ctx, args) => {
+    const id = await ctx.db.insert("push_queue", {
+      user_id: args.user_id,
+      title: args.title,
+      body: args.body,
+      event_type: args.event_type,
+      payload: args.payload ?? {},
+      status: "pending",
+      created_at: Date.now(),
+    });
+    return { ok: true as const, id };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// notifications (in-app list)
+// ---------------------------------------------------------------------------
+export const listForUser = query({
+  args: { user_id: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("notifications")
+      .withIndex("by_user_recent", (q) => q.eq("user_id", args.user_id))
+      .order("desc")
+      .take(args.limit ?? 50);
+  },
+});
+
+export const listUnreadForUser = query({
+  args: { user_id: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("notifications")
+      .withIndex("by_user_unread", (q) => q.eq("user_id", args.user_id).eq("read", false))
+      .order("desc")
+      .take(args.limit ?? 50);
+  },
+});
+
+export const insertNotification = mutation({
+  args: {
+    user_id: v.string(),
+    title: v.string(),
+    message: v.optional(v.string()),
+    type: v.optional(v.string()),
+    action_url: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const id = await ctx.db.insert("notifications", {
+      user_id: args.user_id,
+      title: args.title,
+      message: args.message,
+      type: args.type,
+      action_url: args.action_url,
+      read: false,
+      created_at: Date.now(),
+    });
+    return { ok: true as const, id };
+  },
+});
+
+export const markRead = mutation({
+  args: { id: v.id("notifications"), user_id: v.string() },
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.id);
+    if (!row || row.user_id !== args.user_id) {
+      return { ok: false as const, reason: "not_owner" as const };
+    }
+    await ctx.db.patch(args.id, { read: true });
+    return { ok: true as const };
+  },
+});
+
+export const markAllReadForUser = mutation({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("notifications")
+      .withIndex("by_user_unread", (q) => q.eq("user_id", args.user_id).eq("read", false))
+      .collect();
+    for (const r of rows) await ctx.db.patch(r._id, { read: true });
+    return { ok: true as const, updated: rows.length };
+  },
+});
+
+export const deleteNotification = mutation({
+  args: { id: v.id("notifications"), user_id: v.string() },
+  handler: async (ctx, args) => {
+    const row = await ctx.db.get(args.id);
+    if (!row || row.user_id !== args.user_id) {
+      return { ok: false as const, reason: "not_owner" as const };
+    }
+    await ctx.db.delete(args.id);
+    return { ok: true as const };
+  },
+});
+
+export const deleteAllReadForUser = mutation({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("notifications")
+      .withIndex("by_user_unread", (q) => q.eq("user_id", args.user_id).eq("read", true))
+      .collect();
+    for (const r of rows) await ctx.db.delete(r._id);
+    return { ok: true as const, deleted: rows.length };
+  },
+});

--- a/web/convex/referrals.ts
+++ b/web/convex/referrals.ts
@@ -1,0 +1,88 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// AI-9537 — Referral codes / credits (replaces clapcheeks_referrals).
+
+export const getByCode = query({
+  args: { referral_code: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("referrals")
+      .withIndex("by_code", (q) => q.eq("referral_code", args.referral_code))
+      .first();
+  },
+});
+
+export const listForReferrer = query({
+  args: { referrer_id: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("referrals")
+      .withIndex("by_referrer", (q) => q.eq("referrer_id", args.referrer_id))
+      .collect();
+  },
+});
+
+export const findPendingByReferred = query({
+  args: { referred_id: v.string() },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("referrals")
+      .withIndex("by_referred", (q) => q.eq("referred_id", args.referred_id))
+      .collect();
+    return rows.find((r) => r.status === "pending") ?? null;
+  },
+});
+
+export const insertReferral = mutation({
+  args: {
+    referrer_id: v.string(),
+    referral_code: v.string(),
+    referred_id: v.optional(v.string()),
+    status: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const id = await ctx.db.insert("referrals", {
+      referrer_id: args.referrer_id,
+      referral_code: args.referral_code,
+      referred_id: args.referred_id,
+      status: args.status ?? "pending",
+      created_at: Date.now(),
+    });
+    return { ok: true as const, id };
+  },
+});
+
+export const markConverted = mutation({
+  args: { referral_code: v.string(), referred_id: v.string() },
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("referrals")
+      .withIndex("by_code", (q) => q.eq("referral_code", args.referral_code))
+      .first();
+    if (!row) return { ok: false as const, reason: "not_found" as const };
+    await ctx.db.patch(row._id, {
+      referred_id: args.referred_id,
+      status: "converted",
+      converted_at: Date.now(),
+    });
+    return { ok: true as const, id: row._id };
+  },
+});
+
+export const markRewarded = mutation({
+  args: { id: v.id("referrals") },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.id, { status: "rewarded", rewarded_at: Date.now() });
+    return { ok: true as const };
+  },
+});
+
+export const summary = query({
+  args: {},
+  handler: async (ctx) => {
+    // Used by /admin/launch — total counts grouped by status.
+    const all = await ctx.db.query("referrals").collect();
+    return all.map((r) => ({ id: r._id, status: r.status, created_at: r.created_at }));
+  },
+});

--- a/web/convex/reportPreferences.ts
+++ b/web/convex/reportPreferences.ts
@@ -1,0 +1,65 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// AI-9537 — Weekly report email settings (replaces clapcheeks_report_preferences).
+
+export const getForUser = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("report_preferences")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+  },
+});
+
+export const listEmailEnabledMap = query({
+  args: { user_ids: v.array(v.string()) },
+  handler: async (ctx, args) => {
+    // Cron call site reads pref-overrides for a batch of subscriber user_ids.
+    // Returns array of {user_id, email_enabled}.
+    const out: Array<{ user_id: string; email_enabled: boolean }> = [];
+    for (const uid of args.user_ids) {
+      const row = await ctx.db
+        .query("report_preferences")
+        .withIndex("by_user", (q) => q.eq("user_id", uid))
+        .first();
+      out.push({ user_id: uid, email_enabled: row ? row.email_enabled : true });
+    }
+    return out;
+  },
+});
+
+export const upsertForUser = mutation({
+  args: {
+    user_id: v.string(),
+    email_enabled: v.boolean(),
+    send_day: v.string(),
+    send_hour: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("report_preferences")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        email_enabled: args.email_enabled,
+        send_day: args.send_day,
+        send_hour: args.send_hour,
+        updated_at: now,
+      });
+      return { ok: true as const, id: existing._id, action: "updated" as const };
+    }
+    const id = await ctx.db.insert("report_preferences", {
+      user_id: args.user_id,
+      email_enabled: args.email_enabled,
+      send_day: args.send_day,
+      send_hour: args.send_hour,
+      created_at: now,
+      updated_at: now,
+    });
+    return { ok: true as const, id, action: "inserted" as const };
+  },
+});

--- a/web/convex/schema.ts
+++ b/web/convex/schema.ts
@@ -961,4 +961,387 @@ export default defineSchema({
   })
     .index("by_token", ["token"])
     .index("by_user", ["user_id"]),
+
+  // ==========================================================================
+  // AI-9535 outbound migration — tables migrated from Supabase off the legacy
+  // clapcheeks_* schemas. These mirror the public.clapcheeks_* shapes 1:1 so
+  // the existing Next.js routes + Mac Mini Python pollers can swap call sites
+  // with minimal logic changes. Auth still resolves user_id via Supabase.
+  // ==========================================================================
+
+  // AI-9535 outbound migration — replaces public.clapcheeks_scheduled_messages
+  // (legacy match-name-keyed scheduled outbound messages — separate from the
+  // AI-9196 conversation-keyed `scheduled_messages` table above).
+  outbound_scheduled_messages: defineTable({
+    user_id: v.string(),                  // Supabase auth uuid
+    match_id: v.optional(v.string()),     // platform-specific match id (text)
+    match_name: v.string(),
+    platform: v.string(),                 // "iMessage", "tinder", "hinge", etc.
+    phone: v.optional(v.string()),
+    message_text: v.string(),
+    scheduled_at: v.number(),             // unix ms (was timestamptz on Postgres)
+    status: v.union(
+      v.literal("pending"),
+      v.literal("approved"),
+      v.literal("rejected"),
+      v.literal("sent"),
+      v.literal("failed"),
+    ),
+    sequence_type: v.union(
+      v.literal("follow_up"),
+      v.literal("manual"),
+      v.literal("app_to_text"),
+    ),
+    sequence_step: v.optional(v.number()),
+    delay_hours: v.optional(v.number()),
+    rejection_reason: v.optional(v.string()),
+    sent_at: v.optional(v.number()),
+    god_draft_id: v.optional(v.string()),
+    legacy_id: v.optional(v.string()),    // backfill: original Supabase UUID
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_user_status", ["user_id", "status"])
+    .index("by_user_match", ["user_id", "match_id"])
+    .index("by_status_due", ["status", "scheduled_at"])
+    .index("by_legacy_id", ["legacy_id"]),
+
+  // AI-9535 outbound migration — replaces public.clapcheeks_followup_sequences
+  // (per-user drip cadence config). One row per user_id (uniqueness enforced
+  // in mutation logic, not at index level).
+  followup_sequences: defineTable({
+    user_id: v.string(),
+    enabled: v.boolean(),
+    delays_hours: v.array(v.number()),    // ordered list, e.g. [24, 72, 168]
+    max_followups: v.number(),
+    app_to_text_enabled: v.boolean(),
+    warmth_threshold: v.number(),         // 0..1
+    min_messages_before_transition: v.number(),
+    optimal_send_start_hour: v.number(),  // 0-23
+    optimal_send_end_hour: v.number(),
+    quiet_hours_start: v.number(),
+    quiet_hours_end: v.number(),
+    timezone: v.string(),
+    legacy_id: v.optional(v.string()),
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_user", ["user_id"])
+    .index("by_legacy_id", ["legacy_id"]),
+
+  // AI-9535 outbound migration — replaces public.clapcheeks_queued_replies.
+  // Operator-approved or AI-drafted iMessage queue consumed by the Mac Mini
+  // queue_poller within ~30s.
+  queued_replies: defineTable({
+    user_id: v.string(),
+    match_name: v.optional(v.string()),
+    platform: v.optional(v.string()),
+    text: v.optional(v.string()),         // legacy column name
+    body: v.optional(v.string()),         // newer column name (imessage/test)
+    recipient_handle: v.optional(v.string()),
+    source: v.optional(v.string()),       // "web_test", "drip", "ai_suggestion", etc.
+    status: v.union(
+      v.literal("queued"),
+      v.literal("sent"),
+      v.literal("failed"),
+    ),
+    legacy_id: v.optional(v.string()),
+    created_at: v.number(),
+  })
+    .index("by_user_status", ["user_id", "status"])
+    .index("by_user_created", ["user_id", "created_at"])
+    .index("by_user_source", ["user_id", "source"])
+    .index("by_legacy_id", ["legacy_id"]),
+
+  // AI-9535 outbound migration — replaces public.clapcheeks_posting_queue.
+  // 7-day rolling outbound posting schedule consumed by the publisher.
+  posting_queue: defineTable({
+    user_id: v.string(),
+    content_library_id: v.string(),       // FK to clapcheeks_content_library on PG; remains string until that table migrates
+    scheduled_for: v.number(),            // unix ms
+    status: v.union(
+      v.literal("pending"),
+      v.literal("in_progress"),
+      v.literal("posted"),
+      v.literal("failed"),
+      v.literal("cancelled"),
+    ),
+    agent_job_id: v.optional(v.string()), // FK to agent_jobs row id (text); null until claimed
+    posted_at: v.optional(v.number()),
+    error: v.optional(v.string()),
+    legacy_id: v.optional(v.string()),
+    created_at: v.number(),
+  })
+    .index("by_status_due", ["status", "scheduled_for"])
+    .index("by_user_scheduled", ["user_id", "scheduled_for"])
+    .index("by_user_status", ["user_id", "status"])
+    .index("by_content_library", ["content_library_id"])
+    .index("by_legacy_id", ["legacy_id"]),
+
+  // AI-9535 outbound migration — replaces public.clapcheeks_approval_queue.
+  // Generic per-action approval queue used by the autonomy engine. Operator
+  // approves/rejects via /autonomy dashboard.
+  approval_queue: defineTable({
+    user_id: v.string(),
+    action_type: v.string(),
+    match_id: v.optional(v.string()),
+    match_name: v.optional(v.string()),
+    platform: v.optional(v.string()),
+    proposed_text: v.optional(v.string()),
+    proposed_data: v.optional(v.any()),
+    confidence: v.number(),               // 0..1
+    ai_reasoning: v.optional(v.string()),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("approved"),
+      v.literal("rejected"),
+      v.literal("expired"),
+    ),
+    expires_at: v.number(),               // unix ms
+    decided_at: v.optional(v.number()),
+    legacy_id: v.optional(v.string()),
+    created_at: v.number(),
+  })
+    .index("by_user_status", ["user_id", "status"])
+    .index("by_status_expires", ["status", "expires_at"])
+    .index("by_legacy_id", ["legacy_id"]),
+
+  // ==========================================================================
+  // AI-9537 billing+misc migration
+  // Replaces Supabase tables: clapcheeks_subscriptions, dunning_events,
+  // clapcheeks_voice_profiles, user_voice_context, clapcheeks_notification_prefs,
+  // clapcheeks_outbound_notifications, clapcheeks_push_queue,
+  // clapcheeks_report_preferences, clapcheeks_coaching_sessions,
+  // clapcheeks_tip_feedback, clapcheeks_memos, clapcheeks_referrals,
+  // notifications, devices, google_calendar_tokens.
+  //
+  // Stripe webhook reliability: subscriptions + dunning_events run in
+  // parallel-write mode (Supabase + Convex) on first deploy cycle, reads
+  // can flip to Convex once parity is confirmed.
+  // ==========================================================================
+
+  // AI-9537 — Stripe subscription state per user. Mirror of Supabase
+  // clapcheeks_subscriptions. Money-flow: read by dashboard / weekly reports
+  // cron / dogfood / usage gates. Writes happen on Stripe webhook + admin
+  // tooling (parallel-write window).
+  subscriptions: defineTable({
+    user_id: v.string(),                      // Supabase auth uuid
+    stripe_subscription_id: v.optional(v.string()),
+    plan: v.union(
+      v.literal("starter"),
+      v.literal("pro"),
+      v.literal("elite"),
+    ),
+    status: v.string(),                       // active | past_due | canceled | trialing | ...
+    current_period_start: v.optional(v.number()),  // unix ms
+    current_period_end: v.optional(v.number()),
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_user", ["user_id"])
+    .index("by_stripe_id", ["stripe_subscription_id"])
+    .index("by_status", ["status"]),
+
+  // AI-9537 — Failed-payment / grace-period / recovery audit log.
+  // Reads: admin dashboards, dunning cron. Writes: stripe webhook +
+  // dunning helper.
+  dunning_events: defineTable({
+    user_id: v.optional(v.string()),
+    stripe_customer_id: v.optional(v.string()),
+    stripe_invoice_id: v.optional(v.string()),
+    event_type: v.union(
+      v.literal("payment_failed"),
+      v.literal("payment_recovered"),
+      v.literal("grace_period_expired"),
+      v.literal("manual_retry"),
+      v.literal("subscription_canceled"),
+    ),
+    attempt_number: v.optional(v.number()),
+    grace_period_end: v.optional(v.number()),  // unix ms
+    metadata: v.optional(v.any()),
+    created_at: v.number(),
+  })
+    .index("by_user_ts", ["user_id", "created_at"])
+    .index("by_customer_ts", ["stripe_customer_id", "created_at"]),
+
+  // AI-9537 — Voice cloning settings per user (replaces clapcheeks_voice_profiles).
+  voice_profiles: defineTable({
+    user_id: v.string(),
+    style_summary: v.optional(v.string()),
+    sample_phrases: v.optional(v.array(v.any())),
+    tone: v.optional(v.string()),                 // casual | formal | playful
+    profile_data: v.optional(v.any()),
+    messages_analyzed: v.optional(v.number()),
+    digest: v.optional(v.any()),                  // chat.db-derived style digest
+    boosted_samples: v.optional(v.any()),
+    last_scan_at: v.optional(v.number()),
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_user", ["user_id"]),
+
+  // AI-9537 — AI First Date interview answers / voice context corpus
+  // (replaces user_voice_context).
+  voice_context: defineTable({
+    user_id: v.string(),
+    answers: v.optional(v.any()),                 // {question_id: answer}
+    summary: v.optional(v.string()),
+    persona_blob: v.optional(v.string()),
+    completed_at: v.optional(v.number()),
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_user", ["user_id"]),
+
+  // AI-9537 — Notification on/off per channel per event-type
+  // (replaces clapcheeks_notification_prefs).
+  notification_prefs: defineTable({
+    user_id: v.string(),
+    email: v.optional(v.string()),
+    phone_e164: v.optional(v.string()),
+    channels_per_event: v.any(),                  // {event_type: [channel_ids]}
+    quiet_hours_start: v.number(),                // 0-23
+    quiet_hours_end: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_user", ["user_id"]),
+
+  // AI-9537 — iMessage outbound queue
+  // (replaces clapcheeks_outbound_notifications).
+  outbound_notifications: defineTable({
+    user_id: v.string(),
+    channel: v.string(),                          // "imessage"
+    phone_e164: v.string(),
+    body: v.string(),
+    event_type: v.optional(v.string()),
+    status: v.string(),                           // pending | sent | failed
+    attempts: v.number(),
+    last_error: v.optional(v.string()),
+    created_at: v.number(),
+    sent_at: v.optional(v.number()),
+  })
+    .index("by_user_pending", ["user_id", "status", "created_at"]),
+
+  // AI-9537 — Web push queue (replaces clapcheeks_push_queue).
+  push_queue: defineTable({
+    user_id: v.string(),
+    title: v.string(),
+    body: v.string(),
+    event_type: v.optional(v.string()),
+    payload: v.optional(v.any()),
+    status: v.string(),                           // pending | sent | failed
+    created_at: v.number(),
+    sent_at: v.optional(v.number()),
+  })
+    .index("by_user_pending", ["user_id", "status", "created_at"]),
+
+  // AI-9537 — Weekly report email settings
+  // (replaces clapcheeks_report_preferences).
+  report_preferences: defineTable({
+    user_id: v.string(),
+    email_enabled: v.boolean(),
+    send_day: v.string(),                         // monday..sunday
+    send_hour: v.number(),                        // 0-23
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_user", ["user_id"]),
+
+  // AI-9537 — AI coaching session transcripts (one per user per week_start).
+  // Replaces clapcheeks_coaching_sessions.
+  coaching_sessions: defineTable({
+    user_id: v.string(),
+    generated_at: v.number(),
+    week_start: v.string(),                       // ISO date YYYY-MM-DD
+    tips: v.any(),                                // JSON array
+    stats_snapshot: v.optional(v.any()),
+    feedback_score: v.optional(v.number()),
+    model_used: v.optional(v.string()),
+    created_at: v.number(),
+  })
+    .index("by_user", ["user_id"])
+    .index("by_user_week", ["user_id", "week_start"]),
+
+  // AI-9537 — Per-tip feedback (helpful y/n) per coaching session.
+  tip_feedback: defineTable({
+    user_id: v.string(),
+    coaching_session_id: v.id("coaching_sessions"),
+    tip_index: v.number(),
+    helpful: v.boolean(),
+    created_at: v.number(),
+  })
+    .index("by_session", ["coaching_session_id"])
+    .index("by_user_session_tip", ["user_id", "coaching_session_id", "tip_index"]),
+
+  // AI-9537 — Operator memo history per contact handle (replaces clapcheeks_memos).
+  memos: defineTable({
+    user_id: v.string(),
+    contact_handle: v.string(),                   // E.164 phone or "tinder:abc123"
+    content: v.string(),
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_user_handle", ["user_id", "contact_handle"]),
+
+  // AI-9537 — Referral codes / credits (replaces clapcheeks_referrals).
+  referrals: defineTable({
+    referrer_id: v.string(),
+    referred_id: v.optional(v.string()),
+    referral_code: v.string(),
+    status: v.string(),                           // pending | converted | rewarded
+    converted_at: v.optional(v.number()),
+    rewarded_at: v.optional(v.number()),
+    created_at: v.number(),
+  })
+    .index("by_referrer", ["referrer_id"])
+    .index("by_code", ["referral_code"])
+    .index("by_referred", ["referred_id"]),
+
+  // AI-9537 — In-app notification list (replaces public.notifications).
+  notifications: defineTable({
+    user_id: v.string(),
+    title: v.string(),
+    message: v.optional(v.string()),
+    type: v.optional(v.string()),
+    read: v.boolean(),
+    action_url: v.optional(v.string()),
+    created_at: v.number(),
+  })
+    .index("by_user_unread", ["user_id", "read"])
+    .index("by_user_recent", ["user_id", "created_at"]),
+
+  // AI-9537 — Registered iOS / Mac devices per user (replaces public.devices).
+  devices: defineTable({
+    user_id: v.string(),
+    device_name: v.string(),
+    platform: v.string(),                         // ios | mac | linux | windows | other
+    agent_version: v.optional(v.string()),
+    last_seen_at: v.number(),
+    is_active: v.boolean(),
+    created_at: v.number(),
+  })
+    .index("by_user", ["user_id"])
+    .index("by_user_active", ["user_id", "is_active"]),
+
+  // AI-9537 — Google Calendar OAuth refresh tokens (replaces google_calendar_tokens).
+  // SENSITIVE: refresh_token + access_token MUST be encrypted at rest with
+  // the same per-user AES-256-GCM key vault used for platform_tokens
+  // (web/lib/crypto/token-vault.ts).
+  google_calendar_tokens: defineTable({
+    user_id: v.string(),
+    google_email: v.string(),
+    google_sub: v.optional(v.string()),
+    // Encrypted access_token — rotates on refresh.
+    access_token_encrypted: v.bytes(),
+    // Encrypted long-lived refresh_token — never plaintext at rest.
+    refresh_token_encrypted: v.bytes(),
+    enc_version: v.number(),                      // currently 1
+    expires_at: v.number(),                       // unix ms
+    scopes: v.array(v.string()),
+    calendar_id: v.string(),                      // default "primary"
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index("by_user", ["user_id"])
+    .index("by_email", ["google_email"]),
 });

--- a/web/convex/voice.ts
+++ b/web/convex/voice.ts
@@ -1,0 +1,136 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+// AI-9537 — Voice profile + voice context (replaces clapcheeks_voice_profiles
+// and user_voice_context).
+
+// ---------------------------------------------------------------------------
+// voice_profiles
+// ---------------------------------------------------------------------------
+export const getProfile = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("voice_profiles")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+  },
+});
+
+export const upsertProfile = mutation({
+  args: {
+    user_id: v.string(),
+    style_summary: v.optional(v.string()),
+    sample_phrases: v.optional(v.array(v.any())),
+    tone: v.optional(v.string()),
+    profile_data: v.optional(v.any()),
+    messages_analyzed: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("voice_profiles")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+    const patch = {
+      style_summary: args.style_summary,
+      sample_phrases: args.sample_phrases,
+      tone: args.tone,
+      profile_data: args.profile_data,
+      messages_analyzed: args.messages_analyzed,
+      updated_at: now,
+    };
+    if (existing) {
+      await ctx.db.patch(existing._id, patch);
+      return { ok: true as const, id: existing._id, action: "updated" as const };
+    }
+    const id = await ctx.db.insert("voice_profiles", {
+      user_id: args.user_id,
+      ...patch,
+      created_at: now,
+    });
+    return { ok: true as const, id, action: "inserted" as const };
+  },
+});
+
+export const upsertProfileDigest = mutation({
+  args: {
+    user_id: v.string(),
+    digest: v.optional(v.any()),
+    boosted_samples: v.optional(v.any()),
+    last_scan_at: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("voice_profiles")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+    if (existing) {
+      const patch: Record<string, unknown> = { updated_at: now };
+      if (args.digest !== undefined) patch.digest = args.digest;
+      if (args.boosted_samples !== undefined) patch.boosted_samples = args.boosted_samples;
+      if (args.last_scan_at !== undefined) patch.last_scan_at = args.last_scan_at;
+      await ctx.db.patch(existing._id, patch);
+      return { ok: true as const, id: existing._id, action: "updated" as const };
+    }
+    const id = await ctx.db.insert("voice_profiles", {
+      user_id: args.user_id,
+      digest: args.digest,
+      boosted_samples: args.boosted_samples,
+      last_scan_at: args.last_scan_at,
+      created_at: now,
+      updated_at: now,
+    });
+    return { ok: true as const, id, action: "inserted" as const };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// voice_context
+// ---------------------------------------------------------------------------
+export const getContext = query({
+  args: { user_id: v.string() },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("voice_context")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+  },
+});
+
+export const upsertContext = mutation({
+  args: {
+    user_id: v.string(),
+    answers: v.optional(v.any()),
+    summary: v.optional(v.string()),
+    persona_blob: v.optional(v.string()),
+    completed_at: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("voice_context")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+    if (existing) {
+      const patch: Record<string, unknown> = { updated_at: now };
+      if (args.answers !== undefined) patch.answers = args.answers;
+      if (args.summary !== undefined) patch.summary = args.summary;
+      if (args.persona_blob !== undefined) patch.persona_blob = args.persona_blob;
+      if (args.completed_at !== undefined) patch.completed_at = args.completed_at;
+      await ctx.db.patch(existing._id, patch);
+      return { ok: true as const, id: existing._id, action: "updated" as const };
+    }
+    const id = await ctx.db.insert("voice_context", {
+      user_id: args.user_id,
+      answers: args.answers,
+      summary: args.summary,
+      persona_blob: args.persona_blob,
+      completed_at: args.completed_at,
+      created_at: now,
+      updated_at: now,
+    });
+    return { ok: true as const, id, action: "inserted" as const };
+  },
+});

--- a/web/lib/billing/dunning.ts
+++ b/web/lib/billing/dunning.ts
@@ -1,5 +1,46 @@
 import { createClient } from '@supabase/supabase-js'
 import { stripe, stripeLog } from '@/lib/stripe'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: dunning_events run in PARALLEL-WRITE mode to Supabase + Convex
+// during the rollout window. Reads continue from Supabase until parity
+// is verified. Once flipped, the supabase.insert() lines can be removed.
+
+async function logDunningEvent(args: {
+  user_id?: string | null
+  stripe_customer_id?: string | null
+  stripe_invoice_id?: string | null
+  event_type:
+    | 'payment_failed'
+    | 'payment_recovered'
+    | 'grace_period_expired'
+    | 'manual_retry'
+    | 'subscription_canceled'
+  attempt_number?: number
+  grace_period_end?: string | null
+  metadata?: Record<string, unknown>
+}): Promise<void> {
+  // Convex write (new authoritative target).
+  try {
+    const convex = getConvexServerClient()
+    await convex.mutation(api.billing.insertDunningEvent, {
+      user_id: args.user_id ?? undefined,
+      stripe_customer_id: args.stripe_customer_id ?? undefined,
+      stripe_invoice_id: args.stripe_invoice_id ?? undefined,
+      event_type: args.event_type,
+      attempt_number: args.attempt_number,
+      grace_period_end: args.grace_period_end
+        ? new Date(args.grace_period_end).getTime()
+        : undefined,
+      metadata: args.metadata,
+    })
+  } catch (err) {
+    stripeLog(
+      `[AI-9537] convex dunning insert failed (continuing): ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Dunning / Grace Period Engine
@@ -65,21 +106,35 @@ export async function handlePaymentFailed(
     last_payment_failure_at: new Date().toISOString(),
   }).eq('id', profile.id)
 
-  // Log to dunning_events for audit trail
-  await supabase.from('dunning_events').insert({
-    user_id: profile.id,
-    stripe_customer_id: customerId,
-    stripe_invoice_id: invoiceId,
-    event_type: 'payment_failed',
-    attempt_number: attemptCount || currentFailCount,
-    grace_period_end: graceExpiry.toISOString(),
-    metadata: {
-      grace_days: graceDays,
-      is_first_failure: isFirstFailure,
-    },
-  }).then(({ error }) => {
-    if (error) stripeLog(`Failed to log dunning event: ${error.message}`)
-  })
+  // Log to dunning_events for audit trail (parallel-write to Convex + Supabase).
+  await Promise.all([
+    supabase.from('dunning_events').insert({
+      user_id: profile.id,
+      stripe_customer_id: customerId,
+      stripe_invoice_id: invoiceId,
+      event_type: 'payment_failed',
+      attempt_number: attemptCount || currentFailCount,
+      grace_period_end: graceExpiry.toISOString(),
+      metadata: {
+        grace_days: graceDays,
+        is_first_failure: isFirstFailure,
+      },
+    }).then(({ error }) => {
+      if (error) stripeLog(`Failed to log dunning event: ${error.message}`)
+    }),
+    logDunningEvent({
+      user_id: profile.id,
+      stripe_customer_id: customerId,
+      stripe_invoice_id: invoiceId,
+      event_type: 'payment_failed',
+      attempt_number: attemptCount || currentFailCount,
+      grace_period_end: graceExpiry.toISOString(),
+      metadata: {
+        grace_days: graceDays,
+        is_first_failure: isFirstFailure,
+      },
+    }),
+  ])
 
   stripeLog(
     `Payment failed for ${profile.email} (attempt ${currentFailCount}). ` +
@@ -109,14 +164,21 @@ export async function handlePaymentSucceeded(customerId: string): Promise<void> 
     last_payment_failure_at: null,
   }).eq('stripe_customer_id', customerId)
 
-  // Log recovery
-  await supabase.from('dunning_events').insert({
-    stripe_customer_id: customerId,
-    event_type: 'payment_recovered',
-    metadata: { recovered_at: new Date().toISOString() },
-  }).then(({ error }) => {
-    if (error) stripeLog(`Failed to log recovery event: ${error.message}`)
-  })
+  // Log recovery (parallel-write to Convex + Supabase).
+  await Promise.all([
+    supabase.from('dunning_events').insert({
+      stripe_customer_id: customerId,
+      event_type: 'payment_recovered',
+      metadata: { recovered_at: new Date().toISOString() },
+    }).then(({ error }) => {
+      if (error) stripeLog(`Failed to log recovery event: ${error.message}`)
+    }),
+    logDunningEvent({
+      stripe_customer_id: customerId,
+      event_type: 'payment_recovered',
+      metadata: { recovered_at: new Date().toISOString() },
+    }),
+  ])
 
   stripeLog(`Payment recovered for customer ${customerId}`)
 }

--- a/web/lib/coaching/generate.ts
+++ b/web/lib/coaching/generate.ts
@@ -1,5 +1,9 @@
 import Anthropic from '@anthropic-ai/sdk'
 import { SupabaseClient } from '@supabase/supabase-js'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: coaching_sessions + tip_feedback now live on Convex.
 
 interface CoachingTip {
   category: 'timing' | 'messaging' | 'platform' | 'general'
@@ -30,28 +34,31 @@ function getWeekStart(): string {
   return monday.toISOString().split('T')[0]
 }
 
-export async function getLatestCoaching(supabase: SupabaseClient, userId: string) {
+export async function getLatestCoaching(_supabase: SupabaseClient, userId: string) {
   const weekStart = getWeekStart()
 
-  const { data } = await supabase
-    .from('clapcheeks_coaching_sessions')
-    .select('*')
-    .eq('user_id', userId)
-    .eq('week_start', weekStart)
-    .single()
+  const convex = getConvexServerClient()
+  const session = await convex.query(api.coaching.getSessionForWeek, {
+    user_id: userId,
+    week_start: weekStart,
+  })
+  if (!session) return null
 
-  if (!data) return null
-
-  // Fetch feedback for this session
-  const { data: feedback } = await supabase
-    .from('clapcheeks_tip_feedback')
-    .select('tip_index, helpful')
-    .eq('coaching_session_id', data.id)
-    .eq('user_id', userId)
+  const feedback = await convex.query(api.coaching.listFeedbackForSession, {
+    coaching_session_id: session._id,
+  })
 
   return {
-    ...data,
-    feedback: feedback || [],
+    ...session,
+    id: session._id,
+    generated_at:
+      typeof session.generated_at === 'number'
+        ? new Date(session.generated_at).toISOString()
+        : session.generated_at,
+    feedback: (feedback || []).map((f) => ({
+      tip_index: f.tip_index,
+      helpful: f.helpful,
+    })),
   }
 }
 
@@ -177,19 +184,30 @@ Generate 3 personalized coaching tips for this week.`,
     }
   }
 
-  // Store in database
-  const { data: session, error } = await supabase
-    .from('clapcheeks_coaching_sessions')
-    .upsert({
-      user_id: userId,
-      week_start: weekStart,
-      tips,
-      stats_snapshot: statsSnapshot,
-    }, { onConflict: 'user_id,week_start' })
-    .select()
-    .single()
+  // Store in Convex
+  const convex = getConvexServerClient()
+  const result = await convex.mutation(api.coaching.upsertSession, {
+    user_id: userId,
+    week_start: weekStart,
+    tips,
+    stats_snapshot: statsSnapshot,
+    generated_at: Date.now(),
+  })
 
-  if (error) throw error
-
-  return { ...session, feedback: [] }
+  const stored = await convex.query(api.coaching.getSessionForWeek, {
+    user_id: userId,
+    week_start: weekStart,
+  })
+  return {
+    ...(stored ?? {}),
+    id: result.id,
+    user_id: userId,
+    week_start: weekStart,
+    tips,
+    stats_snapshot: statsSnapshot,
+    generated_at: stored?.generated_at
+      ? new Date(stored.generated_at).toISOString()
+      : new Date().toISOString(),
+    feedback: [] as Array<{ tip_index: number; helpful: boolean }>,
+  }
 }

--- a/web/lib/conversation-ai/generate-replies.ts
+++ b/web/lib/conversation-ai/generate-replies.ts
@@ -126,12 +126,24 @@ export async function generateReplies(
   platform: string,
   profileContext?: string
 ): Promise<ReplySuggestion[]> {
-  // Fetch voice profile
-  const { data: voiceProfile } = await supabase
-    .from('clapcheeks_voice_profiles')
-    .select('style_summary, sample_phrases, tone, profile_data')
-    .eq('user_id', userId)
-    .single()
+  // Fetch voice profile (AI-9537: now Convex voice_profiles).
+  let voiceProfile: { style_summary?: string; sample_phrases?: unknown; tone?: string; profile_data?: Record<string, unknown> } | null = null
+  try {
+    const { getConvexServerClient } = await import('@/lib/convex/server')
+    const { api } = await import('@/convex/_generated/api')
+    const convex = getConvexServerClient()
+    const row = await convex.query(api.voice.getProfile, { user_id: userId })
+    if (row) {
+      voiceProfile = {
+        style_summary: row.style_summary,
+        sample_phrases: row.sample_phrases,
+        tone: row.tone,
+        profile_data: (row.profile_data as Record<string, unknown>) ?? {},
+      }
+    }
+  } catch {
+    voiceProfile = null
+  }
 
   // PHASE-E (AI-8319) — also load persona from clapcheeks_user_settings so the
   // persona.message_formatting_rules / banned_words / signature_phrases get

--- a/web/lib/convex/server.ts
+++ b/web/lib/convex/server.ts
@@ -1,0 +1,17 @@
+// AI-9535 — Shared Convex HTTP client for Next.js server-side routes.
+//
+// Auth still resolves user_id via Supabase in the calling route. This helper
+// is just the wire to talk to Convex from API handlers.
+import { ConvexHttpClient } from 'convex/browser'
+
+let cached: ConvexHttpClient | null = null
+
+export function getConvexServerClient(): ConvexHttpClient {
+  if (cached) return cached
+  const url = process.env.NEXT_PUBLIC_CONVEX_URL
+  if (!url) {
+    throw new Error('NEXT_PUBLIC_CONVEX_URL is not configured')
+  }
+  cached = new ConvexHttpClient(url)
+  return cached
+}

--- a/web/lib/google/calendar.ts
+++ b/web/lib/google/calendar.ts
@@ -1,4 +1,13 @@
-import type { SupabaseClient } from '@supabase/supabase-js'
+// AI-9537 — Google Calendar OAuth + helpers.
+//
+// Token storage migrated from Supabase google_calendar_tokens to Convex
+// google_calendar_tokens. Both refresh_token and access_token are
+// AES-256-GCM encrypted at rest using the per-user vault from
+// web/lib/crypto/token-vault.ts. Plaintext only exists in-memory inside
+// this Node runtime, never in transit to/from Convex.
+import { encryptToken, decryptToken } from '@/lib/crypto/token-vault'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
 
 export const CALENDAR_SCOPES = [
   'https://www.googleapis.com/auth/calendar.events',
@@ -99,55 +108,117 @@ export async function fetchUserInfo(accessToken: string): Promise<UserInfo> {
   return (await res.json()) as UserInfo
 }
 
-interface StoredTokens {
+interface DecryptedTokens {
   user_id: string
   google_email: string
   google_sub: string | null
   access_token: string
   refresh_token: string
-  expires_at: string
+  expires_at_ms: number
   scopes: string[]
   calendar_id: string
 }
 
+function bufferToArrayBuffer(buf: Buffer): ArrayBuffer {
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer
+}
+
+function bytesToBuffer(b: ArrayBuffer | Uint8Array | Buffer | null | undefined): Buffer | null {
+  if (!b) return null
+  if (Buffer.isBuffer(b)) return b
+  if (b instanceof Uint8Array) return Buffer.from(b)
+  return Buffer.from(new Uint8Array(b as ArrayBuffer))
+}
+
 /**
- * Get a valid access token for the user, refreshing if necessary.
- * Returns null if the user has not connected their calendar.
+ * AI-9537 — write encrypted Google Calendar tokens to Convex. Used by the
+ * OAuth callback. Both access_token and refresh_token are encrypted with
+ * the per-user AES-256-GCM vault key before crossing the wire.
+ */
+export async function persistCalendarTokensEncrypted(params: {
+  userId: string
+  googleEmail: string
+  googleSub: string | null
+  accessToken: string
+  refreshToken: string
+  expiresAtMs: number
+  scopes: string[]
+  calendarId?: string
+}): Promise<void> {
+  const accessCt = encryptToken(params.accessToken, params.userId)
+  const refreshCt = encryptToken(params.refreshToken, params.userId)
+  const convex = getConvexServerClient()
+  await convex.mutation(api.calendarTokens.upsertEncrypted, {
+    user_id: params.userId,
+    google_email: params.googleEmail,
+    google_sub: params.googleSub ?? undefined,
+    access_token_encrypted: bufferToArrayBuffer(accessCt),
+    refresh_token_encrypted: bufferToArrayBuffer(refreshCt),
+    enc_version: 1,
+    expires_at: params.expiresAtMs,
+    scopes: params.scopes,
+    calendar_id: params.calendarId ?? 'primary',
+  })
+}
+
+/**
+ * AI-9537 — load + decrypt the user's stored tokens. Returns null if the
+ * user has not connected Calendar.
+ */
+export async function loadDecryptedTokens(userId: string): Promise<DecryptedTokens | null> {
+  const convex = getConvexServerClient()
+  const row = await convex.query(api.calendarTokens.getEncryptedForUser, { user_id: userId })
+  if (!row) return null
+  const accessCt = bytesToBuffer(row.access_token_encrypted as ArrayBuffer | Uint8Array)
+  const refreshCt = bytesToBuffer(row.refresh_token_encrypted as ArrayBuffer | Uint8Array)
+  if (!accessCt || !refreshCt) return null
+  const accessToken = decryptToken(accessCt, userId)
+  const refreshToken = decryptToken(refreshCt, userId)
+  return {
+    user_id: row.user_id,
+    google_email: row.google_email,
+    google_sub: row.google_sub ?? null,
+    access_token: accessToken,
+    refresh_token: refreshToken,
+    expires_at_ms: row.expires_at,
+    scopes: row.scopes,
+    calendar_id: row.calendar_id,
+  }
+}
+
+/**
+ * AI-9537 — get a valid access token (refreshing if expired). Replaces the
+ * old getValidAccessToken(supabase, userId) signature; callers no longer
+ * need to pass a Supabase client.
  */
 export async function getValidAccessToken(
-  supabase: SupabaseClient,
   userId: string,
-): Promise<{ accessToken: string; tokens: StoredTokens } | null> {
-  const { data, error } = await supabase
-    .from('google_calendar_tokens')
-    .select('*')
-    .eq('user_id', userId)
-    .maybeSingle()
-
-  if (error || !data) return null
-
-  const tokens = data as StoredTokens
-  const expiresAt = new Date(tokens.expires_at).getTime()
+): Promise<{ accessToken: string; tokens: DecryptedTokens } | null> {
+  const tokens = await loadDecryptedTokens(userId)
+  if (!tokens) return null
   const bufferMs = 60_000
-  if (Date.now() + bufferMs < expiresAt) {
+  if (Date.now() + bufferMs < tokens.expires_at_ms) {
     return { accessToken: tokens.access_token, tokens }
   }
 
-  // Refresh
+  // Refresh upstream and persist new (encrypted) access token.
   const refreshed = await refreshAccessToken(tokens.refresh_token)
-  const newExpiresAt = new Date(Date.now() + refreshed.expires_in * 1000).toISOString()
-  await supabase
-    .from('google_calendar_tokens')
-    .update({
-      access_token: refreshed.access_token,
-      expires_at: newExpiresAt,
-      updated_at: new Date().toISOString(),
-    })
-    .eq('user_id', userId)
+  const newExpiresAtMs = Date.now() + refreshed.expires_in * 1000
+  const newAccessCt = encryptToken(refreshed.access_token, userId)
+  const convex = getConvexServerClient()
+  await convex.mutation(api.calendarTokens.updateAccessTokenEncrypted, {
+    user_id: userId,
+    access_token_encrypted: bufferToArrayBuffer(newAccessCt),
+    expires_at: newExpiresAtMs,
+  })
 
   return {
     accessToken: refreshed.access_token,
-    tokens: { ...tokens, access_token: refreshed.access_token, expires_at: newExpiresAt },
+    tokens: {
+      ...tokens,
+      access_token: refreshed.access_token,
+      expires_at_ms: newExpiresAtMs,
+    },
   }
 }
 

--- a/web/lib/reports/generate-report-data.ts
+++ b/web/lib/reports/generate-report-data.ts
@@ -1,5 +1,9 @@
 import { SupabaseClient } from '@supabase/supabase-js'
 import type { ReportData } from './generate-pdf'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: coaching tips for reports now sourced from Convex coaching_sessions.
 
 export async function generateReportData(
   supabase: SupabaseClient,
@@ -18,8 +22,9 @@ export async function generateReportData(
   const prevStartStr = prevStart.toISOString().split('T')[0]
   const prevEndStr = prevEnd.toISOString().split('T')[0]
 
-  // Fetch this week + last week analytics
-  const [thisWeekRes, prevWeekRes, coachingRes] = await Promise.all([
+  // Fetch this week + last week analytics; coaching tips come from Convex.
+  const convex = getConvexServerClient()
+  const [thisWeekRes, prevWeekRes, coachingSessions] = await Promise.all([
     supabase
       .from('clapcheeks_analytics_daily')
       .select('app, swipes_right, swipes_left, matches, conversations_started, dates_booked')
@@ -32,18 +37,19 @@ export async function generateReportData(
       .eq('user_id', userId)
       .gte('date', prevStartStr)
       .lte('date', prevEndStr),
-    supabase
-      .from('clapcheeks_coaching_sessions')
-      .select('tips')
-      .eq('user_id', userId)
-      .gte('created_at', weekStart.toISOString())
-      .lte('created_at', weekEnd.toISOString())
-      .order('created_at', { ascending: false })
-      .limit(1),
+    convex.query(api.coaching.listRecentForUser, { user_id: userId, limit: 4 }),
   ])
 
   const thisWeek = thisWeekRes.data || []
   const prevWeek = prevWeekRes.data || []
+  const weekStartMs = weekStart.getTime()
+  const weekEndMs = weekEnd.getTime() + 24 * 3600 * 1000 - 1
+  const coachingRes = {
+    data: (coachingSessions || [])
+      .filter((s) => s.created_at >= weekStartMs && s.created_at <= weekEndMs)
+      .map((s) => ({ tips: s.tips }))
+      .slice(0, 1),
+  }
 
   // Aggregate this week
   const tw = aggregateRows(thisWeek)

--- a/web/lib/usage.ts
+++ b/web/lib/usage.ts
@@ -1,4 +1,8 @@
 import { createClient } from '@/lib/supabase/server'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+
+// AI-9537: subscription plan now read from Convex subscriptions.
 
 export const PLAN_LIMITS = {
   base: { swipes: 500, coaching_calls: 5, ai_replies: 20 },
@@ -20,16 +24,17 @@ export interface UsageSummary {
 }
 
 async function getUserPlan(userId: string): Promise<'base' | 'elite'> {
-  const supabase = await createClient()
-  const { data } = await supabase
-    .from('clapcheeks_subscriptions')
-    .select('plan')
-    .eq('user_id', userId)
-    .eq('status', 'active')
-    .limit(1)
-    .single()
-
-  return (data?.plan as 'base' | 'elite') || 'base'
+  try {
+    const convex = getConvexServerClient()
+    const sub = await convex.query(api.billing.getByUser, { user_id: userId })
+    if (sub && sub.status === 'active') {
+      // Map plan tiers — elite is the only "unlimited" plan in PLAN_LIMITS.
+      return (sub.plan === 'elite' ? 'elite' : 'base') as 'base' | 'elite'
+    }
+  } catch (e) {
+    console.warn('[usage] Convex subscription lookup failed, defaulting to base:', e)
+  }
+  return 'base'
 }
 
 export async function checkLimit(


### PR DESCRIPTION
## Summary

Migrates billing + miscellaneous tables from Supabase to Convex (AI-9537, parent AI-9526):

**Billing (parallel-write window):**
- `clapcheeks_subscriptions` -> `subscriptions`
- `dunning_events` -> `dunning_events`

**Misc:**
- `clapcheeks_voice_profiles` -> `voice_profiles`
- `user_voice_context` -> `voice_context`
- `clapcheeks_notification_prefs` -> `notification_prefs`
- `clapcheeks_outbound_notifications` -> `outbound_notifications`
- `clapcheeks_push_queue` -> `push_queue`
- `clapcheeks_report_preferences` -> `report_preferences`
- `clapcheeks_coaching_sessions` -> `coaching_sessions`
- `clapcheeks_tip_feedback` -> `tip_feedback`
- `clapcheeks_memos` -> `memos`
- `clapcheeks_referrals` -> `referrals`
- `notifications` -> `notifications`
- `devices` -> `devices`
- `google_calendar_tokens` -> `google_calendar_tokens` (encrypted at rest)

## Reliability notes

- **Stripe webhook + dunning helper** parallel-write to Supabase + Convex
  for the first deploy cycle. Reads stay on Supabase `profiles` (no plan
  field flip). Once parity is verified, the Supabase writes can be removed.
- **`google_calendar_tokens`**: refresh_token and access_token are
  AES-256-GCM encrypted with the per-user vault (`lib/crypto/token-vault.ts`)
  before being sent to Convex. Plaintext never appears at rest in Convex.
  OAuth callback + refresh + disconnect routes handle encryption end-to-end.
- **`devices`**: continues to read alongside `clapcheeks_device_heartbeats`
  on Supabase (sibling agent owns telemetry); the freshest of the two wins.

## Test plan

- [ ] Backfill script runs to completion (`--dry-run` first):
      `python3 clapcheeks-local/scripts/backfill_misc_supabase_to_convex.py --dry-run`
- [ ] Test Stripe webhook event (`stripe trigger customer.subscription.updated`)
      lands a row in Convex `subscriptions`.
- [ ] google_calendar_tokens roundtrip:
      - OAuth callback writes encrypted refresh_token
      - `getValidAccessToken(user_id)` decrypts + refreshes successfully
      - Calendar event creation succeeds against the live Google API
- [ ] Vercel prod deploy SUCCESS for the merge SHA.