### PR TITLE
feat(clapcheeks): AI-9537 finishup — migrate remaining 15 misc call sites to Convex

### DIFF
--- a/web/app/(main)/dashboard/page.tsx
+++ b/web/app/(main)/dashboard/page.tsx
@@ -104,18 +104,18 @@ export default async function Dashboard() {
       .select('amount, category, date')
       .eq('user_id', user.id)
       .gte('date', sinceStr),
-    supabase
-      .from('devices')
-      .select('last_seen_at, is_active')
-      .eq('user_id', user.id)
-      .order('last_seen_at', { ascending: false })
-      .limit(1),
-    supabase
-      .from('clapcheeks_subscriptions')
-      .select('status')
-      .eq('user_id', user.id)
-      .limit(1)
-      .single(),
+    // AI-9537: devices migrated to Convex.
+    convex
+      ? convex
+          .query(api.devices.listForUser, { user_id: user.id })
+          .catch(() => [] as Array<{ last_seen_at: number; is_active: boolean }>)
+      : Promise.resolve([] as Array<{ last_seen_at: number; is_active: boolean }>),
+    // AI-9537: subscriptions migrated to Convex.
+    convex
+      ? convex
+          .query(api.billing.getByUser, { user_id: user.id })
+          .catch(() => null as { status: string } | null)
+      : Promise.resolve(null as { status: string } | null),
     supabase
       .from('profiles')
       .select('subscription_tier, subscription_status')
@@ -164,7 +164,8 @@ export default async function Dashboard() {
   // Fetch coaching session
   const coachingSession = await getLatestCoaching(supabase, user.id)
 
-  const isSubscribed = subRes.data?.status === 'active'
+  // AI-9537: subRes is now the Convex row directly (or null).
+  const isSubscribed = (subRes as { status?: string } | null)?.status === 'active'
   const userPlan = (profileRes.data?.subscription_tier || 'base') as 'base' | 'elite'
   const userSubStatus = profileRes.data?.subscription_status || 'inactive'
   const userIsElite = userPlan === 'elite' && userSubStatus === 'active'
@@ -174,13 +175,21 @@ export default async function Dashboard() {
   type SpendingRow = { amount: number | string; category: string; date: string }
   const spending: SpendingRow[] = (spendRes.data as SpendingRow[] | null) ?? []
 
-  // AI-8926/AI-9536: pick the freshest of (devices.last_seen_at, Convex device_heartbeats.last_heartbeat_at).
-  const oldDevice = deviceRes.data?.[0] || null
+  // AI-8926/AI-9536/AI-9537: pick the freshest of (Convex devices.last_seen_at, Convex device_heartbeats.last_heartbeat_at).
+  const deviceRows = (deviceRes as Array<{ last_seen_at: number; is_active: boolean }>) ?? []
+  const oldDevice = deviceRows.length
+    ? deviceRows.reduce((best, d) => (d.last_seen_at > best.last_seen_at ? d : best))
+    : null
   const heartbeatTsMs =
     (heartbeatRow as { last_heartbeat_at?: number } | null)?.last_heartbeat_at ?? null
   const heartbeatTs = heartbeatTsMs ? new Date(heartbeatTsMs).toISOString() : null
   const candidates: { last_seen_at: string; is_active: boolean }[] = []
-  if (oldDevice?.last_seen_at) candidates.push({ last_seen_at: oldDevice.last_seen_at, is_active: oldDevice.is_active })
+  if (oldDevice?.last_seen_at) {
+    candidates.push({
+      last_seen_at: new Date(oldDevice.last_seen_at).toISOString(),
+      is_active: oldDevice.is_active,
+    })
+  }
   if (heartbeatTs) candidates.push({ last_seen_at: heartbeatTs, is_active: true })
   const device: DeviceRow | null = candidates.length
     ? candidates.reduce((best, c) =>

--- a/web/app/(main)/dogfood/page.tsx
+++ b/web/app/(main)/dogfood/page.tsx
@@ -49,12 +49,12 @@ export default async function DogfoodPage() {
           })
           .catch(() => [])
       : Promise.resolve([]),
-    supabase
-      .from('clapcheeks_subscriptions')
-      .select('status, plan_id')
-      .eq('user_id', user.id)
-      .limit(1)
-      .single(),
+    // AI-9537: subscriptions migrated to Convex.
+    convex
+      ? convex
+          .query(api.billing.getByUser, { user_id: user.id })
+          .catch(() => null as { status: string; plan?: string } | null)
+      : Promise.resolve(null as { status: string; plan?: string } | null),
   ])
 
   const health = healthRes.data || []
@@ -95,7 +95,14 @@ export default async function DogfoodPage() {
     metrics_snapshot: (r.metrics_snapshot ?? {}) as Record<string, unknown>,
     created_at: new Date(r._creationTime).toISOString(),
   }))
-  const subscription = subscriptionRes.data
+  // AI-9537: subscriptionRes is now the Convex row directly (or null).
+  // Map plan -> plan_id for the legacy subscription shape consumed by DogfoodDashboard.
+  const subscription = subscriptionRes
+    ? {
+        status: (subscriptionRes as { status: string }).status,
+        plan_id: (subscriptionRes as { plan?: string }).plan ?? '',
+      }
+    : null
 
   // Calculate current streak from health data
   const latestHealth = health[0]

--- a/web/app/(main)/reports/page.tsx
+++ b/web/app/(main)/reports/page.tsx
@@ -33,11 +33,12 @@ export default async function ReportsPage() {
           })
           .catch(() => [])
       : Promise.resolve([]),
-    supabase
-      .from('clapcheeks_report_preferences')
-      .select('*')
-      .eq('user_id', user.id)
-      .single(),
+    // AI-9537: report_preferences migrated to Convex.
+    convex
+      ? convex
+          .query(api.reportPreferences.getForUser, { user_id: user.id })
+          .catch(() => null as { email_enabled: boolean; send_day: string; send_hour: number } | null)
+      : Promise.resolve(null as { email_enabled: boolean; send_day: string; send_hour: number } | null),
   ])
 
   // Map Convex schema (week_start_ms / week_start_iso / week_end_ms) to the
@@ -63,7 +64,9 @@ export default async function ReportsPage() {
     sent_at: r.sent_at ? new Date(r.sent_at).toISOString() : null,
     created_at: new Date(r._creationTime).toISOString(),
   }))
-  const preferences = prefsRes.data || { email_enabled: true, send_day: 'sunday', send_hour: 8 }
+  // AI-9537: prefsRes is now the Convex row directly (or null).
+  const preferences = (prefsRes as { email_enabled: boolean; send_day: string; send_hour: number } | null) ||
+    { email_enabled: true, send_day: 'sunday', send_hour: 8 }
 
   return (
     <div className="min-h-screen bg-black px-6 py-8">

--- a/web/app/api/agent/status/route.ts
+++ b/web/app/api/agent/status/route.ts
@@ -20,12 +20,12 @@ export async function GET() {
   const convex = convexUrl ? new ConvexHttpClient(convexUrl) : null
 
   const [deviceRes, agentTokenRes, heartbeatRow] = await Promise.all([
-    supabase
-      .from('devices')
-      .select('last_seen_at, is_active')
-      .eq('user_id', user.id)
-      .order('last_seen_at', { ascending: false })
-      .limit(1),
+    // AI-9537: devices migrated to Convex.
+    convex
+      ? convex
+          .query(api.devices.listForUser, { user_id: user.id })
+          .catch(() => [] as Array<{ last_seen_at: number; is_active: boolean }>)
+      : Promise.resolve([] as Array<{ last_seen_at: number; is_active: boolean }>),
     supabase
       .from('clapcheeks_agent_tokens')
       .select('status, degraded_platform, degraded_reason')
@@ -39,14 +39,17 @@ export async function GET() {
       : Promise.resolve(null),
   ])
 
-  const oldDevice = deviceRes.data?.[0] || null
+  const deviceRows = (deviceRes as Array<{ last_seen_at: number; is_active: boolean }>) ?? []
+  const oldDevice = deviceRows.length
+    ? deviceRows.reduce((best, d) => (d.last_seen_at > best.last_seen_at ? d : best))
+    : null
   const heartbeatTsMs = heartbeatRow?.last_heartbeat_at ?? null
 
   type DeviceShape = { last_seen_at: string; is_active: boolean }
   const candidates: DeviceShape[] = []
   if (oldDevice?.last_seen_at) {
     candidates.push({
-      last_seen_at: oldDevice.last_seen_at,
+      last_seen_at: new Date(oldDevice.last_seen_at).toISOString(),
       is_active: oldDevice.is_active ?? true,
     })
   }

--- a/web/app/api/reports/cron/route.ts
+++ b/web/app/api/reports/cron/route.ts
@@ -20,6 +20,11 @@ export async function GET(request: NextRequest) {
 
   const supabase = createAdminClient()
 
+  // AI-9537: subscriptions + report preferences read from Convex.
+  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL
+  if (!convexUrl) throw new Error('CONVEX_URL not set')
+  const convex = new ConvexHttpClient(convexUrl)
+
   // Calculate last week boundaries
   const now = new Date()
   const dayOfWeek = now.getUTCDay()
@@ -30,24 +35,20 @@ export async function GET(request: NextRequest) {
   weekEnd.setDate(weekEnd.getDate() + 6)
 
   // Get all users with active subscriptions
-  const { data: subscribers } = await supabase
-    .from('clapcheeks_subscriptions')
-    .select('user_id')
-    .eq('status', 'active')
+  const userIds: string[] = await convex.query(api.billing.listActiveUserIds, {})
 
-  if (!subscribers || subscribers.length === 0) {
+  if (!userIds || userIds.length === 0) {
     return NextResponse.json({ message: 'No active subscribers', processed: 0 })
   }
 
   // Filter by preferences (email_enabled)
-  const userIds = subscribers.map((s) => s.user_id)
-  const { data: prefs } = await supabase
-    .from('clapcheeks_report_preferences')
-    .select('user_id, email_enabled')
-    .in('user_id', userIds)
+  const prefs: Array<{ user_id: string; email_enabled: boolean }> = await convex.query(
+    api.reportPreferences.listEmailEnabledMap,
+    { user_ids: userIds }
+  )
 
   const disabledUsers = new Set(
-    (prefs || []).filter((p) => p.email_enabled === false).map((p) => p.user_id)
+    prefs.filter((p) => p.email_enabled === false).map((p) => p.user_id)
   )
 
   const eligibleUsers = userIds.filter((id) => !disabledUsers.has(id))
@@ -77,9 +78,6 @@ export async function GET(request: NextRequest) {
             .getPublicUrl(filename)
 
           // Save report (Convex)
-          const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL
-          if (!convexUrl) throw new Error('CONVEX_URL not set')
-          const convex = new ConvexHttpClient(convexUrl)
           const upsertResult = await convex.mutation(
             api.reports.upsertWeeklyReport,
             {

--- a/web/app/api/reports/generate/route.ts
+++ b/web/app/api/reports/generate/route.ts
@@ -103,13 +103,18 @@ export async function POST(request: NextRequest) {
     }
 
     // Send email if user has it enabled
-    const { data: prefs } = await supabase
-      .from('clapcheeks_report_preferences')
-      .select('email_enabled')
-      .eq('user_id', targetUserId)
-      .single()
-
-    const emailEnabled = prefs?.email_enabled !== false // default true
+    // AI-9537: report preferences live on Convex.
+    let emailEnabled = true
+    if (convex) {
+      try {
+        const prefs = await convex.query(api.reportPreferences.getForUser, {
+          user_id: targetUserId,
+        })
+        if (prefs && prefs.email_enabled === false) emailEnabled = false
+      } catch (err) {
+        console.error('Convex report_preferences read failed:', err)
+      }
+    }
 
     if (emailEnabled) {
       const supabaseAdmin = createAdminClient()

--- a/web/app/api/reports/weekly/route.ts
+++ b/web/app/api/reports/weekly/route.ts
@@ -26,6 +26,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
+  // AI-9537: subscriptions + report_preferences read from Convex.
+  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL
+  if (!convexUrl) throw new Error('CONVEX_URL not set')
+  const convex = new ConvexHttpClient(convexUrl)
+
   // Calculate last week boundaries (Monday to Sunday)
   const now = new Date()
   const dayOfWeek = now.getUTCDay()
@@ -36,24 +41,20 @@ export async function GET(request: NextRequest) {
   weekEnd.setUTCDate(weekEnd.getUTCDate() + 6) // Last Sunday
 
   // Get all users with active subscriptions
-  const { data: subscribers } = await supabaseAdmin
-    .from('clapcheeks_subscriptions')
-    .select('user_id')
-    .eq('status', 'active')
+  const userIds: string[] = await convex.query(api.billing.listActiveUserIds, {})
 
-  if (!subscribers || subscribers.length === 0) {
+  if (!userIds || userIds.length === 0) {
     return NextResponse.json({ message: 'No active subscribers', processed: 0 })
   }
 
   // Filter by preferences (email_enabled)
-  const userIds = subscribers.map((s) => s.user_id)
-  const { data: prefs } = await supabaseAdmin
-    .from('clapcheeks_report_preferences')
-    .select('user_id, email_enabled')
-    .in('user_id', userIds)
+  const prefs: Array<{ user_id: string; email_enabled: boolean }> = await convex.query(
+    api.reportPreferences.listEmailEnabledMap,
+    { user_ids: userIds }
+  )
 
   const disabledUsers = new Set(
-    (prefs || []).filter((p) => p.email_enabled === false).map((p) => p.user_id)
+    prefs.filter((p) => p.email_enabled === false).map((p) => p.user_id)
   )
 
   const eligibleUserIds = userIds.filter((id) => !disabledUsers.has(id))
@@ -128,20 +129,15 @@ export async function GET(request: NextRequest) {
 
           // Record in weekly_reports (Convex)
           const weekStartStr = weekStart.toISOString().split('T')[0]
-          const convexUrl =
-            process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL
-          if (convexUrl) {
-            const convex = new ConvexHttpClient(convexUrl)
-            await convex.mutation(api.reports.upsertWeeklyReport, {
-              user_id: userId,
-              week_start_ms: weekStart.getTime(),
-              week_end_ms: weekEnd.getTime(),
-              week_start_iso: weekStartStr,
-              metrics_snapshot: reportData,
-              sent_at: Date.now(),
-              report_type: 'weekly',
-            })
-          }
+          await convex.mutation(api.reports.upsertWeeklyReport, {
+            user_id: userId,
+            week_start_ms: weekStart.getTime(),
+            week_end_ms: weekEnd.getTime(),
+            week_start_iso: weekStartStr,
+            metrics_snapshot: reportData,
+            sent_at: Date.now(),
+            report_type: 'weekly',
+          })
 
           processed++
         } catch (err) {
@@ -196,17 +192,16 @@ Stats: ${stats.swipes} swipes (${stats.swipesChange}%), ${stats.matches} matches
 }
 
 async function getFallbackTip(): Promise<string> {
-  // Try to get latest coaching tip from DB
+  // AI-9537: latest coaching tip from Convex.
   try {
-    const { data } = await supabaseAdmin
-      .from('clapcheeks_coaching_sessions')
-      .select('tips')
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .single()
-
-    if (data?.tips && Array.isArray(data.tips) && data.tips.length > 0) {
-      const tip = data.tips[0]
+    const convexUrl =
+      process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL
+    if (!convexUrl) return 'Keep swiping and stay consistent with your messaging game!'
+    const convex = new ConvexHttpClient(convexUrl)
+    const session = await convex.query(api.coaching.getMostRecentSession, {})
+    const tips = session?.tips
+    if (tips && Array.isArray(tips) && tips.length > 0) {
+      const tip = tips[0]
       return typeof tip === 'string' ? tip : (tip as { tip?: string }).tip || 'Keep swiping and stay consistent with your messaging game!'
     }
   } catch {

--- a/web/components/layout/connection-bar.tsx
+++ b/web/components/layout/connection-bar.tsx
@@ -225,7 +225,24 @@ export default async function ConnectionBar() {
     }
   }
 
-  const [settingsRes, eventsRes, deviceRes, heartbeatPayload] = await Promise.all([
+  // AI-9537: devices migrated to Convex.
+  const fetchDevices = async (): Promise<Array<{ last_seen_at: number; is_active: boolean }>> => {
+    const url = process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL
+    if (!url) return []
+    try {
+      const { ConvexHttpClient } = await import('convex/browser')
+      const { api } = await import('@/convex/_generated/api')
+      const convex = new ConvexHttpClient(url)
+      const rows = (await convex.query(api.devices.listForUser, {
+        user_id: user.id,
+      })) as Array<{ last_seen_at: number; is_active: boolean }>
+      return rows ?? []
+    } catch {
+      return []
+    }
+  }
+
+  const [settingsRes, eventsRes, deviceRows, heartbeatPayload] = await Promise.all([
     (supabase as any)
       .from('clapcheeks_user_settings')
       .select(
@@ -242,19 +259,21 @@ export default async function ConnectionBar() {
       .gte('detected_at', since)
       .order('detected_at', { ascending: false })
       .limit(50),
-    (supabase as any)
-      .from('devices')
-      .select('last_seen_at,is_active')
-      .eq('user_id', user.id)
-      .order('last_seen_at', { ascending: false })
-      .limit(1)
-      .maybeSingle(),
+    fetchDevices(),
     fetchHeartbeat(),
   ])
 
   const settings = (settingsRes.data as UserSettingsRow | null) ?? null
   const events = ((eventsRes.data as BanEventRow[] | null) ?? []) as BanEventRow[]
-  const deviceRow = (deviceRes.data as DeviceRow | null) ?? null
+  const deviceRowRaw = (deviceRows ?? []).length
+    ? (deviceRows ?? []).reduce((best, d) => (d.last_seen_at > best.last_seen_at ? d : best))
+    : null
+  const deviceRow: DeviceRow | null = deviceRowRaw
+    ? {
+        last_seen_at: new Date(deviceRowRaw.last_seen_at).toISOString(),
+        is_active: deviceRowRaw.is_active,
+      }
+    : null
   const heartbeatRow = heartbeatPayload
 
   // Compose a unified device view: take the freshest last_seen across both

--- a/web/convex/coaching.ts
+++ b/web/convex/coaching.ts
@@ -69,6 +69,38 @@ export const listRecentForUser = query({
   },
 });
 
+// AI-9537 — Used by weekly-report fallback tip helper.
+// Returns the single most recent session row across all users.
+export const getMostRecentSession = query({
+  args: {},
+  handler: async (ctx) => {
+    const rows = await ctx.db.query("coaching_sessions").order("desc").take(1);
+    return rows[0] ?? null;
+  },
+});
+
+// AI-9537 — Used by weekly report generator.
+// Returns the most recent session for a user whose created_at falls in the
+// inclusive [start_ms, end_ms] window. Falls back to null when none exists.
+export const getRecentForUserInRange = query({
+  args: {
+    user_id: v.string(),
+    start_ms: v.number(),
+    end_ms: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const rows = await ctx.db
+      .query("coaching_sessions")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .order("desc")
+      .collect();
+    for (const r of rows) {
+      if (r.created_at >= args.start_ms && r.created_at <= args.end_ms) return r;
+    }
+    return null;
+  },
+});
+
 // ---------------------------------------------------------------------------
 // tip_feedback
 // ---------------------------------------------------------------------------

--- a/web/lib/coaching/generate.ts
+++ b/web/lib/coaching/generate.ts
@@ -35,28 +35,41 @@ function getWeekStart(): string {
   return monday.toISOString().split('T')[0]
 }
 
-export async function getLatestCoaching(supabase: SupabaseClient, userId: string) {
+export async function getLatestCoaching(_supabase: SupabaseClient, userId: string) {
+  // AI-9537: coaching_sessions + tip_feedback migrated to Convex.
   const weekStart = getWeekStart()
-
-  const { data } = await supabase
-    .from('clapcheeks_coaching_sessions')
-    .select('*')
-    .eq('user_id', userId)
-    .eq('week_start', weekStart)
-    .single()
-
-  if (!data) return null
-
-  // Fetch feedback for this session
-  const { data: feedback } = await supabase
-    .from('clapcheeks_tip_feedback')
-    .select('tip_index, helpful')
-    .eq('coaching_session_id', data.id)
-    .eq('user_id', userId)
-
-  return {
-    ...data,
-    feedback: feedback || [],
+  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL
+  if (!convexUrl) return null
+  const convex = new ConvexHttpClient(convexUrl)
+  try {
+    const session = await convex.query(api.coaching.getSessionForWeek, {
+      user_id: userId,
+      week_start: weekStart,
+    })
+    if (!session) return null
+    const feedback = await convex.query(api.coaching.listFeedbackForSession, {
+      coaching_session_id: session._id,
+    })
+    // Map Convex shape (generated_at: number ms) into the legacy
+    // {id, tips, generated_at: string ISO, feedback} contract that downstream
+    // CoachingSession-typed consumers expect.
+    return {
+      id: session._id as string,
+      tips: (session.tips ?? []) as Array<{
+        category: string
+        title: string
+        tip: string
+        supporting_data: string
+        priority: string
+      }>,
+      generated_at: new Date(session.generated_at).toISOString(),
+      feedback: (feedback || []).map((f) => ({
+        tip_index: f.tip_index,
+        helpful: f.helpful,
+      })),
+    }
+  } catch {
+    return null
   }
 }
 
@@ -214,19 +227,35 @@ Generate 3 personalized coaching tips for this week.`,
     }
   }
 
-  // Store in database
-  const { data: session, error } = await supabase
-    .from('clapcheeks_coaching_sessions')
-    .upsert({
-      user_id: userId,
-      week_start: weekStart,
-      tips,
-      stats_snapshot: statsSnapshot,
-    }, { onConflict: 'user_id,week_start' })
-    .select()
-    .single()
+  // Store in database — AI-9537: coaching_sessions on Convex.
+  if (!convexUrl) {
+    throw new Error('CONVEX_URL not set — cannot persist coaching session')
+  }
+  const convex = new ConvexHttpClient(convexUrl)
+  const upsertResult = await convex.mutation(api.coaching.upsertSession, {
+    user_id: userId,
+    week_start: weekStart,
+    tips,
+    stats_snapshot: statsSnapshot,
+  })
+  const session = await convex.query(api.coaching.getSessionForWeek, {
+    user_id: userId,
+    week_start: weekStart,
+  })
+  if (!session) {
+    throw new Error('coaching session vanished after upsert')
+  }
 
-  if (error) throw error
-
-  return { ...session, feedback: [] }
+  return {
+    id: upsertResult.id as string,
+    tips: (session.tips ?? []) as Array<{
+      category: string
+      title: string
+      tip: string
+      supporting_data: string
+      priority: string
+    }>,
+    generated_at: new Date(session.generated_at).toISOString(),
+    feedback: [] as Array<{ tip_index: number; helpful: boolean }>,
+  }
 }

--- a/web/lib/reports/generate-report-data.ts
+++ b/web/lib/reports/generate-report-data.ts
@@ -59,17 +59,21 @@ export async function generateReportData(
   const prevEndStr = prevEnd.toISOString().split('T')[0]
 
   // Fetch this week + last week analytics
-  const [thisWeek, prevWeek, coachingRes] = await Promise.all([
+  // AI-9537: coaching_sessions migrated to Convex.
+  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL
+  const convex = convexUrl ? new ConvexHttpClient(convexUrl) : null
+  const [thisWeek, prevWeek, coachingRow] = await Promise.all([
     fetchAnalyticsRange(userId, weekStartStr, weekEndStr),
     fetchAnalyticsRange(userId, prevStartStr, prevEndStr),
-    supabase
-      .from('clapcheeks_coaching_sessions')
-      .select('tips')
-      .eq('user_id', userId)
-      .gte('created_at', weekStart.toISOString())
-      .lte('created_at', weekEnd.toISOString())
-      .order('created_at', { ascending: false })
-      .limit(1),
+    convex
+      ? convex
+          .query(api.coaching.getRecentForUserInRange, {
+            user_id: userId,
+            start_ms: weekStart.getTime(),
+            end_ms: weekEnd.getTime(),
+          })
+          .catch(() => null as { tips?: unknown } | null)
+      : Promise.resolve(null as { tips?: unknown } | null),
   ])
 
   // Aggregate this week
@@ -109,7 +113,7 @@ export async function generateReportData(
 
   // Coaching tips
   const coachingTips: string[] = []
-  const tipData = coachingRes.data?.[0]?.tips
+  const tipData = coachingRow?.tips
   if (Array.isArray(tipData)) {
     coachingTips.push(...tipData.slice(0, 3))
   }

--- a/web/lib/usage.ts
+++ b/web/lib/usage.ts
@@ -1,9 +1,9 @@
 import { ConvexHttpClient } from 'convex/browser'
 
-import { createClient } from '@/lib/supabase/server'
 import { api } from '@/convex/_generated/api'
 
 // AI-9536 — clapcheeks_usage_daily migrated to Convex usage_daily.
+// AI-9537 — clapcheeks_subscriptions migrated to Convex subscriptions.
 
 export const PLAN_LIMITS = {
   base: { swipes: 500, coaching_calls: 5, ai_replies: 20 },
@@ -39,16 +39,16 @@ function todayIso(): string {
 }
 
 async function getUserPlan(userId: string): Promise<'base' | 'elite'> {
-  const supabase = await createClient()
-  const { data } = await supabase
-    .from('clapcheeks_subscriptions')
-    .select('plan')
-    .eq('user_id', userId)
-    .eq('status', 'active')
-    .limit(1)
-    .single()
-
-  return (data?.plan as 'base' | 'elite') || 'base'
+  // AI-9537: read subscription from Convex.
+  const convex = getConvex()
+  if (!convex) return 'base'
+  try {
+    const sub = await convex.query(api.billing.getByUser, { user_id: userId })
+    if (sub?.status === 'active' && sub.plan === 'elite') return 'elite'
+    return 'base'
+  } catch {
+    return 'base'
+  }
 }
 
 async function getUsageRow(


### PR DESCRIPTION
## Summary
- Closes the AI-9537 misc-table migration by rewiring the last 15 read sites that still hit Supabase for `clapcheeks_subscriptions`, `clapcheeks_report_preferences`, `clapcheeks_coaching_sessions`, and `devices`.
- Convex API surface (`billing`, `reportPreferences`, `coaching`, `devices`) was already shipped in PR #135; this PR completes the read-path cutover.
- Adds 2 small Convex helpers in `convex/coaching.ts` (`getMostRecentSession`, `getRecentForUserInRange`) that the weekly-report flow needs.

## Files migrated (15)

| Table | Files |
|---|---|
| `clapcheeks_subscriptions` (5) | `web/app/api/reports/cron/route.ts`, `web/app/api/reports/weekly/route.ts`, `web/lib/usage.ts`, `web/app/(main)/dashboard/page.tsx`, `web/app/(main)/dogfood/page.tsx` |
| `clapcheeks_report_preferences` (4) | `web/app/api/reports/generate/route.ts`, `web/app/api/reports/weekly/route.ts`, `web/app/api/reports/cron/route.ts`, `web/app/(main)/reports/page.tsx` |
| `clapcheeks_coaching_sessions` (3) | `web/app/api/reports/weekly/route.ts`, `web/lib/reports/generate-report-data.ts`, `web/lib/coaching/generate.ts` |
| `devices` (3) | `web/app/api/agent/status/route.ts`, `web/app/(main)/dashboard/page.tsx`, `web/components/layout/connection-bar.tsx` |

## Verification

- `npx tsc --noEmit` clean on all 15 touched files
- Sibling sweep: 0 remaining `supabase.from('<tbl>')` call sites for the 4 migrated tables
- Convex deploy successful (`valiant-oriole-651`); 4 round-trip tests passed (`billing.listActiveUserIds`, `coaching.getMostRecentSession`, `reportPreferences.listEmailEnabledMap`, `devices.listForUser`)
- Supabase columns preserved as rollback insurance per the AI-9526 migration plan

## Test plan
- [ ] Wait for Vercel prod deploy success on merge SHA
- [ ] Re-run sibling sweep on `main` after merge: `for tbl in clapcheeks_subscriptions clapcheeks_report_preferences clapcheeks_coaching_sessions devices; do grep -rln --include='*.ts' --include='*.tsx' "from(.\${tbl}.)" web/app web/lib web/components | grep -v __tests__; done` should return nothing
- [ ] Confirm `/dashboard`, `/reports`, `/dogfood` render against live data without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)