### PR TITLE
fix(convex): AI-9545 audit + fix failed Convex functions

### DIFF
--- a/web/convex/calendar.ts
+++ b/web/convex/calendar.ts
@@ -70,6 +70,10 @@ export const enqueueFetchJob = internalMutation({
 export const upsertSlots = mutation({
   args: {
     user_id: v.string(),
+    // AI-9545: runner emits window_start_ms / window_end_ms as scoping hints —
+    // accept them as optional for back-compat. Currently unused server-side.
+    window_start_ms: v.optional(v.number()),
+    window_end_ms: v.optional(v.number()),
     slots: v.array(v.object({
       slot_start_ms: v.number(),
       slot_end_ms: v.number(),

--- a/web/convex/media_assets.ts
+++ b/web/convex/media_assets.ts
@@ -1,0 +1,14 @@
+// AI-9545 — runner-compat shim. The Mac Mini runner calls the function path
+// `media_assets:get` (mirroring the table name) but the canonical media
+// module lives at `media.ts`. This file re-exports the same query at the
+// path the runner expects.
+
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const get = query({
+  args: { id: v.id("media_assets") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.id);
+  },
+});

--- a/web/convex/people.ts
+++ b/web/convex/people.ts
@@ -374,6 +374,17 @@ export const getDossier = query({
   },
 });
 
+// AI-9545 — runner-compat alias used by clapcheeks-local convex_runner.py
+// Returns the raw person row by Convex _id. Different from getDossier (which
+// includes recent messages + conversations + computed fields).
+export const get = query({
+  args: { id: v.id("people") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.id);
+  },
+});
+
+
 export const findByHandle = query({
   args: {
     user_id: v.string(),


### PR DESCRIPTION
## Summary

Mac Mini runner has been failing 3 distinct Convex calls. Audited via runner.err.log + grep over `convex_runner.py` calls.

| Failure | Root cause | Fix |
|---|---|---|
| `Could not find public function for 'people:get'` (198x) | `people.ts` has `getDossier` but runner queries `get` | Added `people:get` thin alias |
| `Object contains extra field 'window_end_ms'` (43x) | Validator rejected runner's scoping hints | Added `v.optional(v.number())` for window_start_ms + window_end_ms (closes AI-9530) |
| `Could not find public function for 'media_assets:get'` | Runner expects file path `media_assets.ts`; canonical is `media.ts` | Added shim file `web/convex/media_assets.ts` |

## Verification (live against valiant-oriole-651)

- `people:get` → deployed, validator works (fake id rejected as expected)
- `media_assets:get` → deployed, validator works
- `calendar:upsertSlots` → test slot inserted: `{inserted: 1, total: 1}`

## Out of scope

- Anthropic credit balance too low (37 errors) — billing issue Julian needs to top up