### PR TITLE
fix(convex): AI-9545 add 2 missing fns (claimByTypes, listForPerson)

### DIFF
--- a/web/convex/agent_jobs.ts
+++ b/web/convex/agent_jobs.ts
@@ -29,6 +29,42 @@ export const enqueue = mutation({
 // Local agent claims the next-highest-priority queued job for a user.
 // Atomic via Convex's optimistic concurrency — two agents can't grab
 // the same job.
+// AI-9545 — claim a queued job whose job_type is in `allowed_job_types`.
+// Used by the VPS cc-calendar-worker (only handles fetch_calendar_slots /
+// related calendar jobs) so a single broad runner doesn't steal jobs.
+export const claimByTypes = mutation({
+  args: {
+    user_id: v.string(),
+    agent_instance_id: v.string(),
+    allowed_job_types: v.array(v.string()),
+    lock_seconds: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const queued = await ctx.db
+      .query("agent_jobs")
+      .withIndex("by_user_status", (q) =>
+        q.eq("user_id", args.user_id).eq("status", "queued"),
+      )
+      .order("desc")
+      .collect();
+
+    const allowed = new Set(args.allowed_job_types);
+    const target = queued.find((j) => allowed.has(j.job_type));
+    if (!target) return null;
+
+    const now = Date.now();
+    const lockMs = (args.lock_seconds ?? 120) * 1000;
+    await ctx.db.patch(target._id, {
+      status: "running",
+      locked_by: args.agent_instance_id,
+      locked_until: now + lockMs,
+      attempts: target.attempts + 1,
+      updated_at: now,
+    });
+    return await ctx.db.get(target._id);
+  },
+});
+
 export const claim = mutation({
   args: {
     user_id: v.string(),

--- a/web/convex/conversations.ts
+++ b/web/convex/conversations.ts
@@ -35,6 +35,20 @@ export const listForUser = query({
   },
 });
 
+// AI-9545 — list a person's conversations across all platforms.
+// Used by clapcheeks-local cadence_runner.py to evaluate cadence per
+// person regardless of which channel the thread is on.
+export const listForPerson = query({
+  args: { person_id: v.id("people") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("conversations")
+      .withIndex("by_person", (q) => q.eq("person_id", args.person_id))
+      .order("desc")
+      .take(50);
+  },
+});
+
 // Single conversation with most recent N messages.
 export const getWithMessages = query({
   args: {


### PR DESCRIPTION
End-to-end audit of 167 Convex paths surfaced 2 missing. Both round-trip verified on prod after this PR's deploy.