### PR TITLE
AI-9573 P0-C: kill fabricated dashboard KPIs

### DIFF
--- a/web/app/(main)/dashboard/components/dashboard-live.tsx
+++ b/web/app/(main)/dashboard/components/dashboard-live.tsx
@@ -188,17 +188,15 @@ export default function DashboardLive({ initialData, hasAgent }: DashboardLivePr
     { stage: 'Swipes', value: data.totals.swipes_right },
     { stage: 'Matches', value: data.totals.matches },
     { stage: 'Conversations', value: data.totals.conversations || data.totals.messages_sent },
-    { stage: 'Date-ready', value: Math.round((data.totals.conversations || data.totals.messages_sent) * 0.3) },
     { stage: 'Dates Booked', value: data.totals.dates_booked },
   ]
 
-  // Ensure we have 5 stages for the display
+  // Ensure we have 4 stages for the display
   const funnelStages = [
     { label: 'Swipes', value: funnel[0]?.value ?? data.totals.swipes_right },
     { label: 'Matches', value: funnel[1]?.value ?? data.totals.matches },
     { label: 'Conversations', value: funnel[2]?.value ?? data.totals.messages_sent },
-    { label: 'Date-ready', value: funnel[3]?.value ?? Math.round(data.totals.messages_sent * 0.3) },
-    { label: 'Dates Booked', value: funnel[4]?.value ?? data.totals.dates_booked },
+    { label: 'Dates Booked', value: funnel[3]?.value ?? data.totals.dates_booked },
   ]
 
   return (

--- a/web/app/(main)/dashboard/page.tsx
+++ b/web/app/(main)/dashboard/page.tsx
@@ -354,7 +354,6 @@ export default async function Dashboard() {
       { stage: 'Swipes', value: totals.swipes_right },
       { stage: 'Matches', value: totals.matches },
       { stage: 'Conversations', value: totals.messages },
-      { stage: 'Date-ready', value: Math.round(totals.messages * 0.3) },
       { stage: 'Dates Booked', value: totals.dates },
     ],
   }

--- a/web/app/(main)/intelligence/page.tsx
+++ b/web/app/(main)/intelligence/page.tsx
@@ -322,7 +322,7 @@ export default function IntelligencePage() {
               <div className="bg-white/[0.03] rounded-xl p-4">
                 <div className="text-white/40 text-[10px] uppercase tracking-wider mb-2">They Respond Best To</div>
                 <div className="text-lg font-bold text-white mb-1">
-                  {abTest ? getBestStyle(abTest.styles) : 'Warm'}
+                  {abTest ? getBestStyle(abTest.styles) : '--'}
                 </div>
                 <div className="text-white/40 text-xs leading-relaxed">
                   {abTest?.winner
@@ -337,7 +337,7 @@ export default function IntelligencePage() {
                 <div className="text-lg font-bold text-white mb-1">
                   {stats.best_send_time
                     ? `${stats.best_send_time.day} ${stats.best_send_time.hour}:00`
-                    : 'Eve / Weekends'}
+                    : '--'}
                 </div>
                 <div className="text-white/40 text-xs leading-relaxed">
                   {stats.best_send_time


### PR DESCRIPTION
Removes Date-ready funnel heuristic + Warm/Eve-Weekends fake intelligence labels.

Linear: AI-9573 (sub of AI-9561)

## Test plan
- [x] tsc clean (pre-existing errors only, unrelated to this change)
- [x] Grepped: 0 hits for Date-ready heuristic, 'Warm' fallback, 'Eve / Weekends' fallback in target files
- [ ] Live verify: dashboard funnel has no Date-ready; intelligence shows -- when empty