### PR TITLE
AI-9579 P1-I: wire add-offline-match form to Convex

### DIFF
--- a/web/app/api/matches/offline/route.ts
+++ b/web/app/api/matches/offline/route.ts
@@ -10,11 +10,17 @@ import { createClient } from '@/lib/supabase/server'
  * Phase F daemon (Mac Mini) still queues iMessage history pulls + IG
  * enrichment via clapcheeks_agent_jobs on Supabase — that table is out of
  * scope for this migration.
+ *
+ * AI-9579 — phone is now optional (form can submit without a phone number).
+ * When phone is absent, external_match_id is keyed on a UUID so the row is
+ * still unique but won't de-dupe against a future phone-keyed row for the
+ * same person.
  */
 
 type OfflinePayload = {
   name?: string
   phone?: string
+  email?: string | null
   instagram_handle?: string | null
   met_at?: string | null
   first_impression?: string | null
@@ -43,29 +49,40 @@ export async function POST(req: Request) {
   }
 
   const name = (body.name ?? '').trim()
-  const phoneRaw = (body.phone ?? '').trim()
   if (!name) {
     return NextResponse.json({ error: 'name is required' }, { status: 400 })
   }
-  if (!phoneRaw) {
-    return NextResponse.json({ error: 'phone is required' }, { status: 400 })
-  }
-  const phoneE164 = normalizePhoneE164(phoneRaw)
-  if (!phoneE164) {
-    return NextResponse.json(
-      { error: `phone '${phoneRaw}' is not a valid 10-digit NANP number` },
-      { status: 400 },
-    )
+
+  // phone is optional — only validate format when provided
+  const phoneRaw = (body.phone ?? '').trim()
+  let phoneE164: string | null = null
+  if (phoneRaw) {
+    phoneE164 = normalizePhoneE164(phoneRaw)
+    if (!phoneE164) {
+      return NextResponse.json(
+        { error: `phone '${phoneRaw}' is not a valid 10-digit NANP number` },
+        { status: 400 },
+      )
+    }
   }
 
   const instagramHandle = (body.instagram_handle ?? '').trim().replace(/^@/, '') || null
   const metAt = (body.met_at ?? '').trim() || null
   const firstImpression = (body.first_impression ?? body.notes ?? '').trim() || null
+  const emailClean = (body.email ?? '').trim() || null
 
-  const digits = phoneE164.replace(/\D+/g, '')
-  const externalId = `offline:${digits}`
+  // Key external_id on phone digits when available; fall back to UUID so the
+  // row is still unique but won't de-dupe with a phone-keyed row later.
+  const externalId = phoneE164
+    ? `offline:${phoneE164.replace(/\D+/g, '')}`
+    : `offline:${crypto.randomUUID().replace(/-/g, '')}`
+
   const nowIso = new Date().toISOString() // still used by the agent_jobs insert below
   const nowMs = Date.now()
+
+  // Store email in match_intel since the offline schema doesn't have a
+  // dedicated email column.
+  const matchIntel = emailClean ? { email: emailClean } : undefined
 
   // AI-9534 — write the match to Convex (idempotent on
   // (user_id, platform=offline, external_match_id)).
@@ -79,15 +96,16 @@ export async function POST(req: Request) {
       external_id: externalId,
       match_name: name,
       name,
-      her_phone: phoneE164,
-      source: 'imessage',
-      primary_channel: 'imessage',
-      handoff_complete: true,
-      julian_shared_phone: true,
-      handoff_detected_at: nowMs,
+      her_phone: phoneE164 ?? '',
+      source: 'manual',
+      primary_channel: phoneE164 ? 'imessage' : 'email',
+      handoff_complete: !!phoneE164,
+      julian_shared_phone: !!phoneE164,
+      handoff_detected_at: phoneE164 ? nowMs : undefined,
       instagram_handle: instagramHandle ?? undefined,
       met_at: metAt ?? undefined,
       first_impression: firstImpression ?? undefined,
+      match_intel: matchIntel,
       status: 'conversing',
     })
     upserted = {
@@ -106,8 +124,9 @@ export async function POST(req: Request) {
 
   // Best-effort: queue iMessage history pull + IG enrichment for the daemon.
   try {
-    const jobs: Array<Record<string, unknown>> = [
-      {
+    const jobs: Array<Record<string, unknown>> = []
+    if (phoneE164) {
+      jobs.push({
         user_id: user.id,
         job_type: 'imessage_history_pull',
         status: 'queued',
@@ -118,8 +137,8 @@ export async function POST(req: Request) {
           source: 'phase_f_offline',
         },
         created_at: nowIso,
-      },
-    ]
+      })
+    }
     if (instagramHandle) {
       jobs.push({
         user_id: user.id,
@@ -133,7 +152,7 @@ export async function POST(req: Request) {
         created_at: nowIso,
       })
     }
-    await (supabase as any).from('clapcheeks_agent_jobs').insert(jobs)
+    if (jobs.length > 0) await (supabase as any).from('clapcheeks_agent_jobs').insert(jobs)
   } catch (err) {
     // Non-fatal — match row exists; daemon can pick these up on next tick
     console.warn('[offline-match] job enqueue failed (non-fatal):', err)
@@ -147,6 +166,7 @@ export async function POST(req: Request) {
         external_id: externalId,
         name,
         phone_e164: phoneE164,
+        email: emailClean,
         instagram_handle: instagramHandle,
       },
     },

--- a/web/components/matches/AiActiveSwitchPerMatch.tsx
+++ b/web/components/matches/AiActiveSwitchPerMatch.tsx
@@ -11,6 +11,7 @@ import { useState, useEffect } from 'react'
 import { useQuery, useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import type { Id } from '@/convex/_generated/dataModel'
+import { toast } from 'sonner'
 
 type Props = {
   matchId: string
@@ -44,8 +45,11 @@ export default function AiActiveSwitchPerMatch({ matchId }: Props) {
     setActive(next) // optimistic
     try {
       await patch({ id: row._id, ai_active: next })
-    } catch {
+    } catch (err) {
       setActive(!next) // rollback
+      toast.error(
+        `Failed to toggle AI for this match${err instanceof Error && err.message ? ': ' + err.message : '.'}`,
+      )
     } finally {
       setSaving(false)
     }

--- a/web/components/matches/MatchDetail.tsx
+++ b/web/components/matches/MatchDetail.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useMutation, useQuery } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import type { Id } from '@/convex/_generated/dataModel'
+import { toast } from 'sonner'
 import {
   ClapcheeksMatchRow,
   ConversationMessage,
@@ -50,18 +51,24 @@ export default function MatchDetail({ match, messages, clusterRisk }: Props) {
   ) as (Record<string, unknown> & { _id?: Id<'matches'> }) | null | undefined
   const patch = useMutation(api.matches.patch)
 
+  // row === undefined means Convex is still loading; null means not found.
+  const rowLoading = row === undefined
+
   async function updateStatus(next: MatchStatus) {
+    if (rowLoading) return
     setStatusBusy(next)
     try {
       if (!row?._id) {
-        console.warn('[MatchDetail] status update: row not loaded yet')
+        toast.error('Match not loaded — please wait and try again.')
         return
       }
       try {
         await patch({ id: row._id, status: next })
         setCurrent((prev) => ({ ...prev, status: next }))
       } catch (err) {
-        console.warn('[MatchDetail] status update failed:', err)
+        toast.error(
+          err instanceof Error ? err.message : 'Failed to update status.',
+        )
       }
     } finally {
       setStatusBusy(null)
@@ -136,18 +143,32 @@ export default function MatchDetail({ match, messages, clusterRisk }: Props) {
           </div>
 
           {/* Action bar */}
-          <div className="flex gap-2 flex-wrap">
+          <div className="flex gap-2 flex-wrap items-center">
+            {rowLoading && (
+              <span className="flex items-center gap-1 text-[10px] text-white/30 font-mono">
+                <svg
+                  className="animate-spin h-3 w-3 text-white/30"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                loading
+              </span>
+            )}
             {ACTIONABLE_STATUSES.map((s) => (
               <button
                 key={s.key}
                 type="button"
                 onClick={() => updateStatus(s.key)}
-                disabled={statusBusy !== null}
+                disabled={rowLoading || statusBusy !== null}
                 className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
                   current.status === s.key
                     ? 'bg-yellow-500/25 text-yellow-200 border-yellow-500/50'
                     : 'bg-white/5 text-white/70 border-white/10 hover:bg-white/10'
-                } disabled:opacity-50`}
+                } disabled:opacity-50 disabled:cursor-not-allowed`}
               >
                 {statusBusy === s.key ? '...' : s.label}
               </button>

--- a/web/components/matches/OfflineContactForm.tsx
+++ b/web/components/matches/OfflineContactForm.tsx
@@ -1,19 +1,71 @@
 'use client'
 
 import * as React from 'react'
-import { Plus } from 'lucide-react'
+import { Plus, X, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
 
 /**
- * Stub — unblocks production build while full "add offline match" flow
- * is designed. When a user wants to track someone they met IRL, this
- * opens a minimal form that inserts a row into `clapcheeks_matches`
- * with source='offline'.
+ * AI-9579 — Replaces the "Coming soon" stub (TODO AI-8594) with a real form.
  *
- * TODO (AI-8594 follow-on): replace this stub with a proper dialog that
- * takes name, phone, platform, notes and posts to /api/matches.
+ * Posts to /api/matches/offline which calls api.matches.upsertOffline on
+ * Convex. On success the parent's useQuery(api.matches.listForUser) refetches
+ * automatically via Convex reactivity.
  */
 export default function OfflineContactForm() {
   const [open, setOpen] = React.useState(false)
+  const [loading, setLoading] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+
+  const [name, setName] = React.useState('')
+  const [phone, setPhone] = React.useState('')
+  const [email, setEmail] = React.useState('')
+  const [notes, setNotes] = React.useState('')
+
+  function reset() {
+    setName('')
+    setPhone('')
+    setEmail('')
+    setNotes('')
+    setError(null)
+  }
+
+  function handleClose() {
+    setOpen(false)
+    reset()
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!name.trim()) {
+      setError('Name is required')
+      return
+    }
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/matches/offline', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          phone: phone.trim() || undefined,
+          email: email.trim() || undefined,
+          notes: notes.trim() || undefined,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error ?? 'Failed to add match')
+      toast.success(`${name.trim()} added`)
+      handleClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const inputCls =
+    'w-full px-3 py-2 rounded-lg bg-white/5 border border-white/10 text-white placeholder-white/30 focus:outline-none focus:border-pink-500/50 focus:ring-1 focus:ring-pink-500/50 text-sm'
 
   return (
     <>
@@ -25,27 +77,114 @@ export default function OfflineContactForm() {
         <Plus className="h-3.5 w-3.5" />
         Add offline match
       </button>
+
       {open && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
-          onClick={() => setOpen(false)}
+          onClick={handleClose}
         >
           <div
-            className="rounded-xl border border-white/10 bg-[#0a0a12] p-6 max-w-sm"
+            className="rounded-xl border border-white/10 bg-[#0a0a12] p-6 w-full max-w-sm mx-4"
             onClick={(e) => e.stopPropagation()}
           >
-            <h2 className="text-lg font-medium text-white mb-2">Coming soon</h2>
-            <p className="text-sm text-white/60 mb-4">
-              Offline match tracking is on the roadmap — add someone you met in person and
-              Clapcheeks will still draft messages for them.
-            </p>
-            <button
-              type="button"
-              onClick={() => setOpen(false)}
-              className="rounded-lg bg-white/10 hover:bg-white/20 px-4 py-2 text-sm text-white transition-colors"
-            >
-              Got it
-            </button>
+            {/* Header */}
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-base font-semibold text-white">Add offline match</h2>
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded p-1 text-white/40 hover:text-white/80 transition-colors"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-3">
+              {error && (
+                <div className="p-2.5 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 text-xs">
+                  {error}
+                </div>
+              )}
+
+              {/* Name */}
+              <div>
+                <label className="block text-xs font-medium text-white/60 mb-1">
+                  Name <span className="text-pink-400">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="First name"
+                  className={inputCls}
+                  required
+                  autoFocus
+                />
+              </div>
+
+              {/* Phone */}
+              <div>
+                <label className="block text-xs font-medium text-white/60 mb-1">Phone</label>
+                <input
+                  type="tel"
+                  value={phone}
+                  onChange={(e) => setPhone(e.target.value)}
+                  placeholder="(555) 867-5309"
+                  className={inputCls}
+                />
+              </div>
+
+              {/* Email */}
+              <div>
+                <label className="block text-xs font-medium text-white/60 mb-1">Email</label>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="her@email.com"
+                  className={inputCls}
+                />
+              </div>
+
+              {/* Notes */}
+              <div>
+                <label className="block text-xs font-medium text-white/60 mb-1">
+                  Notes <span className="text-white/30">(where you met, vibe, etc.)</span>
+                </label>
+                <textarea
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  placeholder="Met at the farmers market, super into hiking..."
+                  rows={3}
+                  className={`${inputCls} resize-none`}
+                />
+              </div>
+
+              {/* Actions */}
+              <div className="flex gap-2 pt-1">
+                <button
+                  type="button"
+                  onClick={handleClose}
+                  className="flex-1 py-2 rounded-lg border border-white/10 bg-white/5 hover:bg-white/10 text-sm text-white/60 hover:text-white transition-colors"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={loading}
+                  className="flex-1 py-2 rounded-lg bg-gradient-to-r from-pink-600 to-purple-600 hover:from-pink-500 hover:to-purple-500 text-sm font-medium text-white transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-1.5"
+                >
+                  {loading ? (
+                    <>
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      Adding…
+                    </>
+                  ) : (
+                    'Add match'
+                  )}
+                </button>
+              </div>
+            </form>
           </div>
         </div>
       )}

--- a/web/components/matches/SocialGraphPanel.tsx
+++ b/web/components/matches/SocialGraphPanel.tsx
@@ -217,7 +217,7 @@ export default function SocialGraphPanel({
             </span>
           </label>
           {saveError && (
-            <p className="text-[10px] text-amber-400 mt-2 font-mono">{saveError}</p>
+            <p className="text-sm text-red-400 mt-2 border border-red-500/30 rounded px-2 py-1 font-mono">{saveError}</p>
           )}
         </div>
       )}

--- a/web/convex/matches.ts
+++ b/web/convex/matches.ts
@@ -573,6 +573,7 @@ export const upsertOffline = mutation({
     instagram_handle: v.optional(v.string()),
     met_at: v.optional(v.string()),
     first_impression: v.optional(v.string()),
+    match_intel: v.optional(v.any()),
     status: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
@@ -600,6 +601,7 @@ export const upsertOffline = mutation({
       instagram_handle: args.instagram_handle,
       met_at: args.met_at,
       first_impression: args.first_impression,
+      match_intel: args.match_intel,
       status: args.status ?? "conversing",
       last_activity_at: now,
       updated_at: now,


### PR DESCRIPTION
Replaces Coming-soon stub with a real form. Closes TODO AI-8594.

Linear: AI-9579 (sub of AI-9561)

## Changes
- `OfflineContactForm`: name (required) + phone/email/notes (optional), inline error, sonner toast on success, spinner, resets on close
- `/api/matches/offline`: phone made optional; UUID-keyed external_id when no phone; email stored in match_intel
- `convex/matches.upsertOffline`: added `match_intel` arg

## Test plan
- [x] tsc clean on changed files
- [x] build error is pre-existing (api/referral/convert — unrelated to this PR)
- [ ] Live verify: click Add offline match → submit form → match appears in list