### PR TITLE
AI-9580 P1-J: disable status buttons during load + error toasts

### DIFF
--- a/web/components/matches/AiActiveSwitchPerMatch.tsx
+++ b/web/components/matches/AiActiveSwitchPerMatch.tsx
@@ -11,6 +11,7 @@ import { useState, useEffect } from 'react'
 import { useQuery, useMutation } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import type { Id } from '@/convex/_generated/dataModel'
+import { toast } from 'sonner'
 
 type Props = {
   matchId: string
@@ -44,8 +45,11 @@ export default function AiActiveSwitchPerMatch({ matchId }: Props) {
     setActive(next) // optimistic
     try {
       await patch({ id: row._id, ai_active: next })
-    } catch {
+    } catch (err) {
       setActive(!next) // rollback
+      toast.error(
+        `Failed to toggle AI for this match${err instanceof Error && err.message ? ': ' + err.message : '.'}`,
+      )
     } finally {
       setSaving(false)
     }

--- a/web/components/matches/MatchDetail.tsx
+++ b/web/components/matches/MatchDetail.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useMutation, useQuery } from 'convex/react'
 import { api } from '@/convex/_generated/api'
 import type { Id } from '@/convex/_generated/dataModel'
+import { toast } from 'sonner'
 import {
   ClapcheeksMatchRow,
   ConversationMessage,
@@ -50,18 +51,24 @@ export default function MatchDetail({ match, messages, clusterRisk }: Props) {
   ) as (Record<string, unknown> & { _id?: Id<'matches'> }) | null | undefined
   const patch = useMutation(api.matches.patch)
 
+  // row === undefined means Convex is still loading; null means not found.
+  const rowLoading = row === undefined
+
   async function updateStatus(next: MatchStatus) {
+    if (rowLoading) return
     setStatusBusy(next)
     try {
       if (!row?._id) {
-        console.warn('[MatchDetail] status update: row not loaded yet')
+        toast.error('Match not loaded — please wait and try again.')
         return
       }
       try {
         await patch({ id: row._id, status: next })
         setCurrent((prev) => ({ ...prev, status: next }))
       } catch (err) {
-        console.warn('[MatchDetail] status update failed:', err)
+        toast.error(
+          err instanceof Error ? err.message : 'Failed to update status.',
+        )
       }
     } finally {
       setStatusBusy(null)
@@ -136,18 +143,32 @@ export default function MatchDetail({ match, messages, clusterRisk }: Props) {
           </div>
 
           {/* Action bar */}
-          <div className="flex gap-2 flex-wrap">
+          <div className="flex gap-2 flex-wrap items-center">
+            {rowLoading && (
+              <span className="flex items-center gap-1 text-[10px] text-white/30 font-mono">
+                <svg
+                  className="animate-spin h-3 w-3 text-white/30"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                loading
+              </span>
+            )}
             {ACTIONABLE_STATUSES.map((s) => (
               <button
                 key={s.key}
                 type="button"
                 onClick={() => updateStatus(s.key)}
-                disabled={statusBusy !== null}
+                disabled={rowLoading || statusBusy !== null}
                 className={`text-xs px-3 py-1.5 rounded-lg border transition-all ${
                   current.status === s.key
                     ? 'bg-yellow-500/25 text-yellow-200 border-yellow-500/50'
                     : 'bg-white/5 text-white/70 border-white/10 hover:bg-white/10'
-                } disabled:opacity-50`}
+                } disabled:opacity-50 disabled:cursor-not-allowed`}
               >
                 {statusBusy === s.key ? '...' : s.label}
               </button>

--- a/web/components/matches/SocialGraphPanel.tsx
+++ b/web/components/matches/SocialGraphPanel.tsx
@@ -217,7 +217,7 @@ export default function SocialGraphPanel({
             </span>
           </label>
           {saveError && (
-            <p className="text-[10px] text-amber-400 mt-2 font-mono">{saveError}</p>
+            <p className="text-sm text-red-400 mt-2 border border-red-500/30 rounded px-2 py-1 font-mono">{saveError}</p>
           )}
         </div>
       )}


### PR DESCRIPTION
Linear: AI-9580 (sub of AI-9561)

## Changes

- `MatchDetail.tsx`: added `rowLoading = row === undefined` guard; status buttons `disabled` during Convex load; loading spinner shown; `toast.error` on patch failure instead of `console.warn`
- `AiActiveSwitchPerMatch.tsx`: `toast.error` on patch failure (keep optimistic rollback, now surface it)
- `SocialGraphPanel.tsx`: promoted `saveError` from `text-[10px] text-amber-400` to `text-sm text-red-400` with border — visually unmissable

`sonner` was already installed and `<Toaster>` already mounted in `(main)/layout.tsx`.

## Test plan
- [x] tsc clean in changed files
- [x] commit 810864d
- [ ] Live verify: refresh match detail → buttons greyed during load → enable when data lands