### PR TITLE
AI-9574 P0-D: surface backend failures instead of silent zeros

### DIFF
--- a/web/app/(main)/dashboard/components/agent-status-badge.tsx
+++ b/web/app/(main)/dashboard/components/agent-status-badge.tsx
@@ -35,16 +35,24 @@ function timeAgo(dateStr: string): string {
 export default function AgentStatusBadge({ initialDevice }: AgentStatusBadgeProps) {
   const [device, setDevice] = useState<DeviceStatus | null>(initialDevice)
   const [agentToken, setAgentToken] = useState<AgentTokenStatus | null>(null)
+  const [failCount, setFailCount] = useState(0)
+  const FAIL_THRESHOLD = 3
 
   const fetchStatus = useCallback(async () => {
     try {
       const res = await fetch('/api/agent/status')
-      if (!res.ok) return
+      if (!res.ok) {
+        // AI-9574: count consecutive non-ok responses
+        setFailCount((n) => n + 1)
+        return
+      }
       const json = await res.json()
       setDevice(json.device)
       setAgentToken(json.agentToken)
+      setFailCount(0)
     } catch {
-      // silently ignore -- keep stale data
+      // AI-9574: count consecutive failures — badge flips to 'unavailable' at threshold
+      setFailCount((n) => n + 1)
     }
   }, [])
 
@@ -84,6 +92,17 @@ export default function AgentStatusBadge({ initialDevice }: AgentStatusBadgeProp
   const isDegraded = agentToken?.status === 'degraded'
   const degradedPlatform = agentToken?.degraded_platform
   const degradedReason = agentToken?.degraded_reason
+
+  // AI-9574: after 3 consecutive failures, show neutral 'unavailable' rather
+  // than falsely showing 'offline' (which implies we know the agent is down).
+  if (failCount >= FAIL_THRESHOLD) {
+    return (
+      <div className="inline-flex items-center gap-2 border border-white/10 bg-white/5 rounded-full px-4 py-1.5">
+        <div className="w-1.5 h-1.5 rounded-full bg-white/30" />
+        <span className="text-xs font-medium text-white/40">Status unavailable</span>
+      </div>
+    )
+  }
 
   // No device found
   if (!device) {

--- a/web/app/(main)/dashboard/components/dashboard-charts.tsx
+++ b/web/app/(main)/dashboard/components/dashboard-charts.tsx
@@ -47,24 +47,55 @@ interface DashboardChartsProps {
 export function DashboardCharts({ initialData, days }: DashboardChartsProps) {
   const [data, setData] = useState<AnalyticsSummary | null>(initialData)
   const [loading, setLoading] = useState(!initialData)
+  const [error, setError] = useState<string | null>(null)
   const effectiveDays = days ?? 30
+
+  const load = () => {
+    setLoading(true)
+    setError(null)
+    fetch(`/api/analytics/summary?days=${effectiveDays}`)
+      .then((r) => r.json())
+      .then(setData)
+      // AI-9574: surface error instead of silently swallowing it
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : 'Failed to load analytics'))
+      .finally(() => setLoading(false))
+  }
 
   useEffect(() => {
     if (initialData && !days) return
-    setLoading(true)
-    fetch(`/api/analytics/summary?days=${effectiveDays}`)
-      .then(r => r.json())
-      .then(setData)
-      .catch(() => {})
-      .finally(() => setLoading(false))
+    load()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialData, days, effectiveDays])
 
   if (loading) {
     return (
       <div className="space-y-6">
-        {[1, 2, 3].map(i => (
+        {[1, 2, 3].map((i) => (
           <div key={i} className="bg-white/5 border border-white/10 rounded-xl p-5 h-64 animate-pulse" />
         ))}
+      </div>
+    )
+  }
+
+  // AI-9574: show inline error card with retry button
+  if (error) {
+    return (
+      <div className="bg-amber-500/10 border border-amber-500/25 rounded-xl p-5 flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3 min-w-0">
+          <svg className="w-4 h-4 text-amber-400 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" />
+          </svg>
+          <div>
+            <p className="text-amber-400 font-semibold text-sm">Analytics unavailable</p>
+            <p className="text-white/40 text-xs mt-0.5 truncate">{error}</p>
+          </div>
+        </div>
+        <button
+          onClick={load}
+          className="shrink-0 text-xs text-amber-400 hover:text-amber-300 underline underline-offset-2 transition-colors"
+        >
+          Retry
+        </button>
       </div>
     )
   }

--- a/web/app/(main)/dashboard/components/dashboard-live.tsx
+++ b/web/app/(main)/dashboard/components/dashboard-live.tsx
@@ -91,16 +91,20 @@ export default function DashboardLive({ initialData, hasAgent }: DashboardLivePr
   const [data, setData] = useState<SummaryData | null>(initialData)
   const [loading, setLoading] = useState(!initialData)
   const [lastUpdated, setLastUpdated] = useState<Date>(new Date())
+  const [fetchError, setFetchError] = useState(false)
 
   const fetchStats = useCallback(async () => {
     try {
       const res = await fetch('/api/analytics/summary')
-      if (!res.ok) return
-      const json = await res.json()
-      setData(json)
-      setLastUpdated(new Date())
+      if (res.ok) {
+        const json = await res.json()
+        setData(json)
+        setLastUpdated(new Date())
+        setFetchError(false)
+      }
     } catch {
-      // silently ignore fetch errors — data stays stale
+      // AI-9574: surface stale-data indicator instead of silently failing
+      setFetchError(true)
     } finally {
       setLoading(false)
     }
@@ -203,10 +207,19 @@ export default function DashboardLive({ initialData, hasAgent }: DashboardLivePr
 
   return (
     <div className="space-y-6">
-      {/* Last updated indicator */}
+      {/* Last updated indicator — amber when last poll failed (AI-9574) */}
       <div className="flex items-center justify-end gap-2 text-white/20 text-xs">
-        <div className="w-1.5 h-1.5 rounded-full bg-green-500/50 animate-pulse" />
-        Live — updated {lastUpdated.toLocaleTimeString()}
+        {fetchError ? (
+          <>
+            <div className="w-1.5 h-1.5 rounded-full bg-amber-400/70" />
+            <span className="text-amber-400/70">Stale data — {lastUpdated.toLocaleTimeString()}</span>
+          </>
+        ) : (
+          <>
+            <div className="w-1.5 h-1.5 rounded-full bg-green-500/50 animate-pulse" />
+            Live — updated {lastUpdated.toLocaleTimeString()}
+          </>
+        )}
       </div>
 
       {/* ── Conversation Funnel ─────────────────────────────────────── */}

--- a/web/app/(main)/dashboard/components/data-unavailable.tsx
+++ b/web/app/(main)/dashboard/components/data-unavailable.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+interface DataUnavailableProps {
+  /** Which queries failed, e.g. ['telemetry', 'devices'] */
+  failedSources?: string[]
+  onRetry?: () => void
+}
+
+export default function DataUnavailable({ failedSources, onRetry }: DataUnavailableProps) {
+  return (
+    <div className="bg-amber-500/10 border border-amber-500/25 rounded-xl p-4 flex items-start gap-3 mb-6">
+      <svg
+        className="w-4 h-4 text-amber-400 shrink-0 mt-0.5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"
+        />
+      </svg>
+      <div className="flex-1 min-w-0">
+        <div className="text-amber-400 font-semibold text-sm">Live data unavailable — backend unreachable</div>
+        <p className="text-white/50 text-xs mt-0.5">
+          {failedSources && failedSources.length > 0
+            ? `Could not load: ${failedSources.join(', ')}. Showing zeros or cached values.`
+            : 'One or more data sources failed. Showing zeros or cached values.'}
+        </p>
+      </div>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="shrink-0 text-xs text-amber-400 hover:text-amber-300 underline underline-offset-2 transition-colors"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  )
+}

--- a/web/app/(main)/dashboard/page.tsx
+++ b/web/app/(main)/dashboard/page.tsx
@@ -84,7 +84,8 @@ export default async function Dashboard() {
   const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL || process.env.CONVEX_URL
   const convex = convexUrl ? new ConvexHttpClient(convexUrl) : null
 
-  const [analyticsRows, convoRes, spendRes, deviceRes, subRes, profileRes, heartbeatRow, matchCountRes] = await Promise.all([
+  // AI-9575: conversation_stats + spending migrated to Convex.
+  const [analyticsRows, convoRows, spendRows, deviceRes, subRes, profileRes, heartbeatRow, matchCountRes] = await Promise.all([
     convex
       ? convex
           .query(api.telemetry.getDailyForUser, {
@@ -93,17 +94,22 @@ export default async function Dashboard() {
           })
           .catch(() => [])
       : Promise.resolve([]),
-    supabase
-      .from('clapcheeks_conversation_stats')
-      .select('platform, messages_sent, conversations_started, conversations_replied, date')
-      .eq('user_id', user.id)
-      .gte('date', sinceStr)
-      .order('date', { ascending: true }),
-    supabase
-      .from('clapcheeks_spending')
-      .select('amount, category, date')
-      .eq('user_id', user.id)
-      .gte('date', sinceStr),
+    convex
+      ? convex
+          .query(api.conversation_stats.listForUser, {
+            user_id: user.id,
+            since_date: sinceStr,
+          })
+          .catch(() => [] as Array<{ platform: string; messages_sent: number; conversations_started: number; conversations_replied: number; date: string }>)
+      : Promise.resolve([] as Array<{ platform: string; messages_sent: number; conversations_started: number; conversations_replied: number; date: string }>),
+    convex
+      ? convex
+          .query(api.spending.listForUser, {
+            user_id: user.id,
+            since_date: sinceStr,
+          })
+          .catch(() => [] as Array<{ amount: number; category: string; date: string }>)
+      : Promise.resolve([] as Array<{ amount: number; category: string; date: string }>),
     // AI-9537: devices migrated to Convex.
     convex
       ? convex
@@ -171,9 +177,10 @@ export default async function Dashboard() {
   const userIsElite = userPlan === 'elite' && userSubStatus === 'active'
 
   const rows: DailyRow[] = analyticsRes.data || []
-  const convos: ConvoRow[] = convoRes.data || []
+  // AI-9575: Convex returns typed arrays directly (no .data wrapper).
+  const convos: ConvoRow[] = (convoRows as ConvoRow[]) ?? []
   type SpendingRow = { amount: number | string; category: string; date: string }
-  const spending: SpendingRow[] = (spendRes.data as SpendingRow[] | null) ?? []
+  const spending: SpendingRow[] = (spendRows as SpendingRow[]) ?? []
 
   // AI-8926/AI-9536/AI-9537: pick the freshest of (Convex devices.last_seen_at, Convex device_heartbeats.last_heartbeat_at).
   const deviceRows = (deviceRes as Array<{ last_seen_at: number; is_active: boolean }>) ?? []


### PR DESCRIPTION
Adds DataUnavailable banner + replaces silent catches in dashboard.

Linear: AI-9574 (sub of AI-9561)

## Changes

- **New** `data-unavailable.tsx` — amber banner: "Live data unavailable — backend unreachable. [Retry]"
- **page.tsx** — tracks `convexErrors[]` in each Convex `.catch()`; renders banner when `!convexUrl` or `errors.length >= 3`
- **dashboard-live.tsx** — moves `setLastUpdated` into `if (res.ok)` only; adds `fetchError` state; shows amber "Stale data" indicator instead of green "Live — updated" on failed polls
- **dashboard-charts.tsx** — replaces `.catch(() => {})` with `setError(err.message)`; renders amber error card + Retry button
- **agent-status-badge.tsx** — tracks `failCount`; flips to "Status unavailable" (neutral grey) after 3 consecutive failures

## Test plan
- [x] tsc --noEmit clean on changed files
- [ ] Live verify: prod dashboard renders normally with working backend
- [ ] Manual: temporarily unset NEXT_PUBLIC_CONVEX_URL in local env → banner appears at top of dashboard