### PR TITLE
AI-9582 P0-K: fix dashboard user_id mismatch + queue shape transform

### DIFF
--- a/web/app/(main)/dashboard/content-library/page.tsx
+++ b/web/app/(main)/dashboard/content-library/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server'
 import ContentLibraryClient from './content-library-client'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 export const metadata: Metadata = {
   title: 'Content Library',
@@ -66,10 +67,10 @@ export default async function ContentLibraryPage() {
     const convex = getConvexServerClient()
     const [pending, inProgress] = await Promise.all([
       convex.query(api.queues.listPostsForUser, {
-        user_id: user.id, status: 'pending', limit: 100,
+        user_id: getFleetUserId(), status: 'pending', limit: 100,
       }),
       convex.query(api.queues.listPostsForUser, {
-        user_id: user.id, status: 'in_progress', limit: 100,
+        user_id: getFleetUserId(), status: 'in_progress', limit: 100,
       }),
     ])
     queue = [...(pending ?? []), ...(inProgress ?? [])]

--- a/web/app/(main)/dashboard/page.tsx
+++ b/web/app/(main)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { ConvexHttpClient } from 'convex/browser'
 import { createClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 // AI-9536 — clapcheeks_analytics_daily + clapcheeks_device_heartbeats
 // migrated to Convex.
@@ -89,7 +90,7 @@ export default async function Dashboard() {
     convex
       ? convex
           .query(api.telemetry.getDailyForUser, {
-            user_id: user.id,
+            user_id: getFleetUserId(),
             since_day_iso: sinceStr,
           })
           .catch(() => [])
@@ -97,7 +98,7 @@ export default async function Dashboard() {
     convex
       ? convex
           .query(api.conversation_stats.listForUser, {
-            user_id: user.id,
+            user_id: getFleetUserId(),
             since_date: sinceStr,
           })
           .catch(() => [] as Array<{ platform: string; messages_sent: number; conversations_started: number; conversations_replied: number; date: string }>)
@@ -105,7 +106,7 @@ export default async function Dashboard() {
     convex
       ? convex
           .query(api.spending.listForUser, {
-            user_id: user.id,
+            user_id: getFleetUserId(),
             since_date: sinceStr,
           })
           .catch(() => [] as Array<{ amount: number; category: string; date: string }>)
@@ -113,13 +114,13 @@ export default async function Dashboard() {
     // AI-9537: devices migrated to Convex.
     convex
       ? convex
-          .query(api.devices.listForUser, { user_id: user.id })
+          .query(api.devices.listForUser, { user_id: getFleetUserId() })
           .catch(() => [] as Array<{ last_seen_at: number; is_active: boolean }>)
       : Promise.resolve([] as Array<{ last_seen_at: number; is_active: boolean }>),
     // AI-9537: subscriptions migrated to Convex.
     convex
       ? convex
-          .query(api.billing.getByUser, { user_id: user.id })
+          .query(api.billing.getByUser, { user_id: getFleetUserId() })
           .catch(() => null as { status: string } | null)
       : Promise.resolve(null as { status: string } | null),
     supabase
@@ -130,14 +131,14 @@ export default async function Dashboard() {
     // AI-8926/AI-9536: modern device-presence source on Convex.
     convex
       ? convex
-          .query(api.telemetry.getLatestHeartbeat, { user_id: user.id })
+          .query(api.telemetry.getLatestHeartbeat, { user_id: getFleetUserId() })
           .catch(() => null)
       : Promise.resolve(null),
     // AI-8926/AI-9534: actual matches count (analytics_daily can be empty
     // for users whose agent does not aggregate per-day yet). Reads from
     // Convex via api.matches.countForUser.
     convex
-      ? convex.query(api.matches.countForUser, { user_id: user.id }).catch(() => 0)
+      ? convex.query(api.matches.countForUser, { user_id: getFleetUserId() }).catch(() => 0)
       : Promise.resolve(0),
   ])
 

--- a/web/app/(main)/matches/[id]/page.tsx
+++ b/web/app/(main)/matches/[id]/page.tsx
@@ -7,6 +7,7 @@ import { mapConvexMatchRowToLegacy } from '@/lib/matches/convex-mapper'
 import type { ChatMessage } from './conversation-thread'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 // AI-9534/AI-9537: matches and memos on Convex.
 
@@ -35,7 +36,8 @@ export default async function MatchDetailPage({
   const rawMatch = (await convex.query(api.matches.resolveByAnyId, { id })) as
     | (Record<string, unknown> & { user_id?: string })
     | null
-  if (!rawMatch || rawMatch.user_id !== user.id) notFound()
+  // AI-9582: ownership check compares Convex-stored fleet user_id (not Supabase auth UUID)
+  if (!rawMatch || rawMatch.user_id !== getFleetUserId()) notFound()
 
   // The MatchProfileView expects a wider shape than the shared legacy mapper
   // produces (it has its own MatchRow type with first_impression, attributes,
@@ -140,7 +142,7 @@ export default async function MatchDetailPage({
   if (externalId) {
     try {
       const conv = await convex.query(api.conversations.getByMatchId, {
-        user_id: user.id,
+        user_id: getFleetUserId(),
         external_match_id: externalId,
       })
       if (conv) convexConversationId = conv._id
@@ -173,7 +175,7 @@ export default async function MatchDetailPage({
   if (memoHandle) {
     try {
       const memoRow = await convex.query(api.memos.getForContact, {
-        user_id: user.id,
+        user_id: getFleetUserId(),
         contact_handle: memoHandle,
       })
       memoInitial = memoRow

--- a/web/app/api/agent/status/route.ts
+++ b/web/app/api/agent/status/route.ts
@@ -3,6 +3,7 @@ import { ConvexHttpClient } from 'convex/browser'
 
 import { createClient } from '@/lib/supabase/server'
 import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 export async function GET() {
   const supabase = await createClient()
@@ -23,7 +24,7 @@ export async function GET() {
     // AI-9537: devices migrated to Convex.
     convex
       ? convex
-          .query(api.devices.listForUser, { user_id: user.id })
+          .query(api.devices.listForUser, { user_id: getFleetUserId() })
           .catch(() => [] as Array<{ last_seen_at: number; is_active: boolean }>)
       : Promise.resolve([] as Array<{ last_seen_at: number; is_active: boolean }>),
     supabase
@@ -34,7 +35,7 @@ export async function GET() {
       .limit(1),
     convex
       ? convex
-          .query(api.telemetry.getLatestHeartbeat, { user_id: user.id })
+          .query(api.telemetry.getLatestHeartbeat, { user_id: getFleetUserId() })
           .catch(() => null)
       : Promise.resolve(null),
   ])

--- a/web/app/api/analytics/summary/route.ts
+++ b/web/app/api/analytics/summary/route.ts
@@ -4,6 +4,7 @@ import { ConvexHttpClient } from 'convex/browser'
 import { createClient } from '@/lib/supabase/server'
 import { calculateRizzScore, getRizzTrend, type AnalyticsRow } from '@/lib/rizz'
 import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 const VALID_DAYS = [7, 30, 90] as const
 
@@ -47,7 +48,7 @@ export async function GET(request: NextRequest) {
     convex
       ? convex
           .query(api.telemetry.getDailyForUser, {
-            user_id: user.id,
+            user_id: getFleetUserId(),
             since_day_iso: fmt(rangeStart),
           })
           .catch(() => [])
@@ -55,7 +56,7 @@ export async function GET(request: NextRequest) {
     convex
       ? convex
           .query(api.conversation_stats.listForUser, {
-            user_id: user.id,
+            user_id: getFleetUserId(),
             since_date: fmt(rangeStart),
           })
           .catch(() => [])
@@ -63,7 +64,7 @@ export async function GET(request: NextRequest) {
     convex
       ? convex
           .query(api.spending.listForUser, {
-            user_id: user.id,
+            user_id: getFleetUserId(),
             since_date: fmt(rangeStart),
           })
           .catch(() => [])

--- a/web/app/api/autonomy-approval/[id]/route.ts
+++ b/web/app/api/autonomy-approval/[id]/route.ts
@@ -5,6 +5,7 @@ import * as Sentry from '@sentry/nextjs'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { api } from '@/convex/_generated/api'
 import type { Id } from '@/convex/_generated/dataModel'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 const VALID_STATUSES = new Set(['approved', 'rejected'])
 
@@ -43,7 +44,7 @@ export async function PATCH(
     try {
       updated = await getConvexServerClient().mutation(api.queues.decideApproval, {
         id: id as Id<'approval_queue'>,
-        user_id: user.id,
+        user_id: getFleetUserId(),
         status: status as 'approved' | 'rejected',
         edited_text: edited_text ?? undefined,
       })

--- a/web/app/api/coaching/feedback/route.ts
+++ b/web/app/api/coaching/feedback/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@/lib/supabase/server'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { api } from '@/convex/_generated/api'
 import type { Id } from '@/convex/_generated/dataModel'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 // AI-9537: tip feedback now lives on Convex tip_feedback.
 
@@ -24,7 +25,7 @@ export async function POST(req: NextRequest) {
   try {
     const convex = getConvexServerClient()
     await convex.mutation(api.coaching.upsertTipFeedback, {
-      user_id: user.id,
+      user_id: getFleetUserId(),
       coaching_session_id: sessionId as Id<'coaching_sessions'>,
       tip_index: tipIndex,
       helpful,

--- a/web/app/api/content-library/posting-queue/route.ts
+++ b/web/app/api/content-library/posting-queue/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 export async function GET() {
   const supabase = await createClient()
@@ -13,10 +14,10 @@ export async function GET() {
     const convex = getConvexServerClient()
     const [pending, inProgress] = await Promise.all([
       convex.query(api.queues.listPostsForUser, {
-        user_id: user.id, status: 'pending', limit: 100,
+        user_id: getFleetUserId(), status: 'pending', limit: 100,
       }),
       convex.query(api.queues.listPostsForUser, {
-        user_id: user.id, status: 'in_progress', limit: 100,
+        user_id: getFleetUserId(), status: 'in_progress', limit: 100,
       }),
     ])
     const queue = [...(pending ?? []), ...(inProgress ?? [])]

--- a/web/app/api/conversation/send/route.ts
+++ b/web/app/api/conversation/send/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 export async function POST(request: NextRequest) {
   const supabase = await createClient()
@@ -24,7 +25,7 @@ export async function POST(request: NextRequest) {
     }
 
     await getConvexServerClient().mutation(api.queues.enqueueReply, {
-      user_id: user.id,
+      user_id: getFleetUserId(),
       match_name: matchName,
       platform,
       text,

--- a/web/app/api/imessage/test/route.ts
+++ b/web/app/api/imessage/test/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 function normalizePhone(raw: string): string | null {
   const digits = raw.replace(/\D/g, '')
@@ -41,7 +42,7 @@ export async function POST(request: NextRequest) {
 
   try {
     const data = await getConvexServerClient().mutation(api.queues.enqueueReply, {
-      user_id: user.id,
+      user_id: getFleetUserId(),
       recipient_handle: handle,
       body: body_text,
       status: 'queued',
@@ -66,7 +67,7 @@ export async function GET(_request: NextRequest) {
 
   try {
     const data = await getConvexServerClient().query(api.queues.listRepliesForUser, {
-      user_id: user.id, source: 'web_test', limit: 20,
+      user_id: getFleetUserId(), source: 'web_test', limit: 20,
     })
     return NextResponse.json({ messages: data || [] })
   } catch (err) {

--- a/web/app/api/matches/offline/route.ts
+++ b/web/app/api/matches/offline/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { api } from '@/convex/_generated/api'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { createClient } from '@/lib/supabase/server'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 /**
  * Phase F (AI-8320): Offline contact ingestion.
@@ -90,7 +91,7 @@ export async function POST(req: Request) {
   let upserted: { _id: string; external_id?: string } | null = null
   try {
     const result = await convex.mutation(api.matches.upsertOffline, {
-      user_id: user.id,
+      user_id: getFleetUserId(),
       external_match_id: externalId,
       match_id: externalId,
       external_id: externalId,

--- a/web/app/api/memo/[handle]/route.ts
+++ b/web/app/api/memo/[handle]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 /**
  * GET  /api/memo/[handle]    — fetch the memo content for the current user + handle.
@@ -45,7 +46,7 @@ export async function GET(
   try {
     const convex = getConvexServerClient()
     const row = await convex.query(api.memos.getForContact, {
-      user_id: user.id,
+      user_id: getFleetUserId(),
       contact_handle: handle,
     })
     return NextResponse.json({
@@ -101,7 +102,7 @@ export async function PUT(
   try {
     const convex = getConvexServerClient()
     const result = await convex.mutation(api.memos.upsertMemo, {
-      user_id: user.id,
+      user_id: getFleetUserId(),
       contact_handle: handle,
       content: body.content,
     })

--- a/web/app/api/scheduled-messages/[id]/route.ts
+++ b/web/app/api/scheduled-messages/[id]/route.ts
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { api } from '@/convex/_generated/api'
 import type { Id } from '@/convex/_generated/dataModel'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 export async function PATCH(
   request: NextRequest,
@@ -35,7 +36,7 @@ export async function PATCH(
       api.outbound.updateScheduled,
       {
         id: id as Id<'outbound_scheduled_messages'>,
-        user_id: user.id,
+        user_id: getFleetUserId(),
         status: status as 'pending' | 'approved' | 'rejected' | 'sent' | 'failed' | undefined,
         rejection_reason: rejection_reason ?? undefined,
         message_text: message_text ?? undefined,
@@ -64,7 +65,7 @@ export async function DELETE(
   try {
     await getConvexServerClient().mutation(api.outbound.cancelScheduled, {
       id: id as Id<'outbound_scheduled_messages'>,
-      user_id: user.id,
+      user_id: getFleetUserId(),
     })
     return NextResponse.json({ ok: true })
   } catch (err) {

--- a/web/app/api/scheduled-messages/route.ts
+++ b/web/app/api/scheduled-messages/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 export async function GET(request: NextRequest) {
   const supabase = await createClient()
@@ -14,11 +15,32 @@ export async function GET(request: NextRequest) {
   const limit = parseInt(searchParams.get('limit') ?? '50')
 
   try {
-    const messages = await getConvexServerClient().query(
+    const rows = await getConvexServerClient().query(
       api.outbound.listForUser,
-      { user_id: user.id, status: status ?? undefined, limit },
+      { user_id: getFleetUserId(), status: status ?? undefined, limit },
     )
-    return NextResponse.json({ messages: messages ?? [] })
+    // AI-9582: transform Convex shape (_id, unix-ms timestamps) → UI shape
+    // (id string, ISO timestamps). The /scheduled UI renders id as React key
+    // and scheduled_at via new Date() — wrong shape causes duplicate keys +
+    // "Invalid Date".
+    const messages = (rows ?? []).map((r: any) => ({
+      id: r._id,
+      match_id: r.match_id ?? null,
+      match_name: r.match_name,
+      platform: r.platform,
+      phone: r.phone ?? null,
+      message_text: r.message_text,
+      scheduled_at: new Date(r.scheduled_at).toISOString(),
+      status: r.status,
+      sequence_type: r.sequence_type,
+      sequence_step: r.sequence_step ?? null,
+      delay_hours: r.delay_hours ?? null,
+      rejection_reason: r.rejection_reason ?? null,
+      sent_at: r.sent_at ? new Date(r.sent_at).toISOString() : null,
+      god_draft_id: r.god_draft_id ?? null,
+      created_at: new Date(r.created_at).toISOString(),
+    }))
+    return NextResponse.json({ messages })
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     return NextResponse.json({ error: msg }, { status: 500 })
@@ -56,7 +78,7 @@ export async function POST(request: NextRequest) {
     const created = await getConvexServerClient().mutation(
       api.outbound.enqueueScheduledMessage,
       {
-        user_id: user.id,
+        user_id: getFleetUserId(),
         match_id: match_id ?? undefined,
         match_name,
         platform: platform ?? 'iMessage',
@@ -68,7 +90,27 @@ export async function POST(request: NextRequest) {
         delay_hours: delay_hours ?? undefined,
       },
     )
-    return NextResponse.json({ message: created }, { status: 201 })
+    // AI-9582: transform created row to UI shape
+    const message = created ? {
+      id: (created as any)._id ?? created,
+      match_id: (created as any).match_id ?? null,
+      match_name: (created as any).match_name ?? match_name,
+      platform: (created as any).platform ?? platform ?? 'iMessage',
+      phone: (created as any).phone ?? null,
+      message_text: (created as any).message_text ?? message_text,
+      scheduled_at: typeof (created as any).scheduled_at === 'number'
+        ? new Date((created as any).scheduled_at).toISOString()
+        : new Date(scheduledMs).toISOString(),
+      status: (created as any).status ?? 'pending',
+      sequence_type: (created as any).sequence_type ?? sequence_type ?? 'manual',
+      sequence_step: (created as any).sequence_step ?? null,
+      delay_hours: (created as any).delay_hours ?? null,
+      rejection_reason: null,
+      sent_at: null,
+      god_draft_id: null,
+      created_at: new Date().toISOString(),
+    } : created
+    return NextResponse.json({ message }, { status: 201 })
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err)
     return NextResponse.json({ error: msg }, { status: 500 })

--- a/web/lib/fleet-user.ts
+++ b/web/lib/fleet-user.ts
@@ -1,0 +1,10 @@
+// Single-tenant MVP indirection. All Convex data is stored under one
+// canonical operator user_id ("fleet-julian"). Auth still happens via
+// Supabase, but every Convex query/mutation must use this helper instead
+// of supabase.auth.getUser().id.
+//
+// When this product becomes multi-tenant, swap this for a real lookup
+// (Supabase user.id -> Convex users.byEmail row -> stored fleet user_id).
+export function getFleetUserId(): string {
+  return process.env.NEXT_PUBLIC_CONVEX_FLEET_USER_ID || 'fleet-julian'
+}


### PR DESCRIPTION
Why messages + scheduled queue were empty: dashboard used Supabase auth UUID, agent writes under 'fleet-julian'. Two disjoint Convex namespaces → 200+ conversations invisible to the dashboard.

Linear: AI-9582 (sub of AI-9561)

## Changes

- `web/lib/fleet-user.ts` — new helper `getFleetUserId()` returning `NEXT_PUBLIC_CONVEX_FLEET_USER_ID || 'fleet-julian'`
- 14 files updated: all Convex query/mutation `user_id: user.id` replaced with `getFleetUserId()`
- `/api/scheduled-messages` GET response now maps `_id → id` and unix-ms timestamps → ISO strings (UI was rendering Invalid Date + duplicate React keys)
- POST response also transformed to UI shape
- `matches/[id]/page.tsx` ownership check now compares against `getFleetUserId()` (was always returning 404 since stored `"fleet-julian" !== supabase-uuid`)
- Supabase calls (clapcheeks_agent_jobs, clapcheeks_auto_actions, profiles) left unchanged

## Test plan
- [ ] grep clean: `grep -rn "user_id: user\.id" web/app/ web/lib/ | grep -v supabase` → 0 hits in Convex paths
- [ ] tsc --noEmit: 0 new errors in modified files
- [ ] Build: pre-existing env-var build failure unrelated to this change (referral/convert route)
- [ ] Live verify after deploy: open /scheduled — pending queue shows; open /matches/[id] — messages render; /dashboard — stats populate