### PR TITLE
AI-9598 AA: outbound auto-fire cron

### DIFF
--- a/web/convex/crons.ts
+++ b/web/convex/crons.ts
@@ -6,12 +6,14 @@ import { internal } from "./_generated/api";
 
 const crons = cronJobs();
 
-// Drain due scheduled_messages every 30 seconds. Replaces the previous
-// PG worker that polled clapcheeks_scheduled_messages.
+// AI-9598 — Drain due outbound_scheduled_messages every 60 seconds.
+// Replaces the broken pointer to internal.scheduled_messages.sendDue
+// (legacy table). Finds approved rows whose scheduled_at has passed,
+// inserts agent_jobs send_imessage rows, and marks them sent atomically.
 crons.interval(
   "send-due-scheduled-messages",
-  { seconds: 30 },
-  internal.scheduled_messages.sendDue,
+  { seconds: 60 },
+  internal.outbound.sendDue,
 );
 
 // Advance the drip state machine every 5 minutes. Replaces the periodic

--- a/web/convex/outbound.ts
+++ b/web/convex/outbound.ts
@@ -279,6 +279,74 @@ export const claimNextDue = internalMutation({
 });
 
 // ------------------------------------------------------------
+// Cron drain — called every 60 s by crons.ts.
+// Finds approved rows whose scheduled_at has passed, enqueues a
+// send_imessage agent_jobs row for each, and marks the row sent to
+// prevent double-fire on the next tick.
+// AI-9598 — fixes the missing auto-fire that was broken because
+// crons.ts pointed at the old scheduled_messages table.
+// ------------------------------------------------------------
+
+export const sendDue = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const now = Date.now();
+    const due = await ctx.db
+      .query("outbound_scheduled_messages")
+      .withIndex("by_status_due", (q) =>
+        q.eq("status", "approved").lte("scheduled_at", now),
+      )
+      .take(25);
+
+    const enqueued: string[] = [];
+    for (const row of due) {
+      if (!row.phone) {
+        // No delivery handle — skip rather than silently drop.
+        await ctx.db.patch(row._id, {
+          status: "failed",
+          rejection_reason: "no phone/handle; cannot deliver",
+          updated_at: now,
+        });
+        continue;
+      }
+
+      // Mark sent first (atomic mutation serialization prevents
+      // a concurrent tick from claiming the same row).
+      await ctx.db.patch(row._id, {
+        status: "sent",
+        sent_at: now,
+        updated_at: now,
+      });
+
+      // Enqueue a send_imessage job for the Mac Mini runner.
+      // Payload mirrors the shape expected by _handle_send_imessage in
+      // agent/clapcheeks/convex_runner.py: { handle, body }.
+      await ctx.db.insert("agent_jobs", {
+        user_id: row.user_id,
+        job_type: "send_imessage",
+        payload: {
+          handle: row.phone,
+          body: row.message_text,
+          outbound_scheduled_message_id: row._id,
+          match_name: row.match_name,
+          source: "outbound_cron",
+        },
+        status: "queued",
+        priority: 1,
+        attempts: 0,
+        max_attempts: 3,
+        created_at: now,
+        updated_at: now,
+      });
+
+      enqueued.push(row._id);
+    }
+
+    return { enqueued_count: enqueued.length, enqueued };
+  },
+});
+
+// ------------------------------------------------------------
 // Backfill helper — used by scripts/backfill_outbound_supabase_to_convex.py.
 // Idempotent: if a row with the same legacy_id already exists, skip.
 // ------------------------------------------------------------


### PR DESCRIPTION
Linear: AI-9598 (sub of AI-9561). Closes F3 P0-2.

## Summary
- Cron `send-due-scheduled-messages` was pointing at `internal.scheduled_messages.sendDue` (legacy table, wrong after AI-9535 migration)
- Added `sendDue` internalMutation to `web/convex/outbound.ts`: queries `by_status_due` index for `approved` rows with `scheduled_at <= now`, inserts a `send_imessage` agent_jobs row per message (Mac Mini convex_runner picks up), marks outbound row `sent` atomically to prevent double-fire
- Updated `crons.ts`: repointed `send-due-scheduled-messages` at `internal.outbound.sendDue`, interval 60s

## Test plan
- [ ] TypeScript: no errors in changed files
- [ ] Deploy to Convex staging; create approved row with past `scheduled_at`; confirm agent_jobs row inserted + original row flipped to `sent` within 60s
- [ ] Confirm no double-fire on next tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)