### PR TITLE
AI-9596 Y: finish getFleetUserId() sweep

### DIFF
--- a/web/app/(main)/autonomy/page.tsx
+++ b/web/app/(main)/autonomy/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation'
 import AutonomyDashboard from './components/autonomy-dashboard'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 export const metadata: Metadata = {
   title: 'Autonomy Engine — Clapcheeks',
@@ -24,7 +25,7 @@ export default async function AutonomyPage() {
       .eq('user_id', user.id)
       .single(),
     convex.query(api.queues.listApprovalsForUser, {
-      user_id: user.id,
+      user_id: getFleetUserId(),
       status: 'pending',
       limit: 20,
     }),

--- a/web/app/(main)/matches/page.tsx
+++ b/web/app/(main)/matches/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from 'next/navigation'
 import MatchesPageClient from '@/components/matches/MatchesPageClient'
 import { api } from '@/convex/_generated/api'
 import type { MatchWithAttributes } from '@/lib/matches/attribute-filter'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 export const metadata: Metadata = {
   title: 'Matches - Clapcheeks',
@@ -41,7 +42,7 @@ export default async function MatchesPage() {
   try {
     const convex = new ConvexHttpClient(convexUrl)
     const rows = await convex.query(api.matches.listForUser, {
-      user_id: user.id,
+      user_id: getFleetUserId(),
       limit: 200,
     })
     matches = mapConvexRowsToMatchWithAttributes(rows)

--- a/web/app/api/autonomy-approval/count/route.ts
+++ b/web/app/api/autonomy-approval/count/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 export async function GET() {
   const supabase = await createClient()
@@ -11,7 +12,7 @@ export async function GET() {
   try {
     const count = await getConvexServerClient().query(
       api.queues.countPendingApprovalsForUser,
-      { user_id: user.id },
+      { user_id: getFleetUserId() },
     )
     return NextResponse.json({ count })
   } catch (err) {

--- a/web/app/api/matches/[id]/route.ts
+++ b/web/app/api/matches/[id]/route.ts
@@ -3,6 +3,7 @@ import { api } from '@/convex/_generated/api'
 import type { Id } from '@/convex/_generated/dataModel'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { createClient } from '@/lib/supabase/server'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 /**
  * PATCH /api/matches/[id] — update stage/status/rank and/or merge into
@@ -74,7 +75,7 @@ export async function PATCH(
   if (!existing || !existing._id) {
     return NextResponse.json({ error: 'match not found' }, { status: 404 })
   }
-  if (existing.user_id !== user.id) {
+  if (existing.user_id !== getFleetUserId()) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
@@ -148,7 +149,7 @@ export async function PATCH(
   try {
     const result = await convex.mutation(api.matches.patchByUser, {
       id: existing._id,
-      user_id: user.id,
+      user_id: getFleetUserId(),
       ...update,
     })
     return NextResponse.json({ ok: true, match: result.row })
@@ -186,14 +187,14 @@ export async function DELETE(
   if (!existing || !existing._id) {
     return NextResponse.json({ error: 'match not found' }, { status: 404 })
   }
-  if (existing.user_id !== user.id) {
+  if (existing.user_id !== getFleetUserId()) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   try {
     const result = await convex.mutation(api.matches.patchByUser, {
       id: existing._id,
-      user_id: user.id,
+      user_id: getFleetUserId(),
       status: 'archived',
     })
     return NextResponse.json({ ok: true, match: result.row })

--- a/web/app/api/scheduled-messages/send/route.ts
+++ b/web/app/api/scheduled-messages/send/route.ts
@@ -6,6 +6,7 @@ import { promisify } from 'util'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { api } from '@/convex/_generated/api'
 import type { Id } from '@/convex/_generated/dataModel'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 const execFileAsync = promisify(execFile)
 
@@ -24,7 +25,7 @@ export async function POST(request: NextRequest) {
   const convex = getConvexServerClient()
   const msg = await convex.query(api.outbound.getById, {
     id: id as Id<'outbound_scheduled_messages'>,
-    user_id: user.id,
+    user_id: getFleetUserId(),
   })
 
   if (!msg) return NextResponse.json({ error: 'Not found' }, { status: 404 })
@@ -70,7 +71,7 @@ export async function POST(request: NextRequest) {
   if (godError && !godDraftId) {
     await convex.mutation(api.outbound.markFailed, {
       id: id as Id<'outbound_scheduled_messages'>,
-      user_id: user.id,
+      user_id: getFleetUserId(),
       rejection_reason: godError,
     })
     return NextResponse.json({ error: godError }, { status: 500 })
@@ -78,7 +79,7 @@ export async function POST(request: NextRequest) {
 
   const updated = await convex.mutation(api.outbound.markSent, {
     id: id as Id<'outbound_scheduled_messages'>,
-    user_id: user.id,
+    user_id: getFleetUserId(),
     god_draft_id: godDraftId ?? undefined,
     sent_at: delayMinutes === 0 ? Date.now() : undefined,
   })


### PR DESCRIPTION
Linear: AI-9596 (sub of AI-9561). Closes the gaps surfaced by F3/F4/F5/F6/F9 verification.

Patched 5 files missed by AI-9582:
- `web/app/(main)/matches/page.tsx` — listForUser query
- `web/app/api/matches/[id]/route.ts` — 2 ownership checks + 2 patchByUser mutations
- `web/app/(main)/autonomy/page.tsx` — listApprovalsForUser query
- `web/app/api/autonomy-approval/count/route.ts` — countPendingApprovalsForUser query
- `web/app/api/scheduled-messages/send/route.ts` — getById, markFailed, markSent mutations