### PR TITLE
AI-9599 BB: decideApproval enqueues agent_jobs row on approve

### DIFF
--- a/web/convex/queues.ts
+++ b/web/convex/queues.ts
@@ -373,9 +373,10 @@ export const decideApproval = mutation({
     const row = await ctx.db.get(args.id);
     if (!row) throw new Error("Not found");
     if (row.user_id !== args.user_id) throw new Error("Forbidden");
+    const now = Date.now();
     const updates: Record<string, unknown> = {
       status: args.status,
-      decided_at: Date.now(),
+      decided_at: now,
     };
     if (
       args.status === "approved" &&
@@ -385,6 +386,40 @@ export const decideApproval = mutation({
       updates.proposed_text = args.edited_text.trim();
     }
     await ctx.db.patch(args.id, updates);
+
+    // AI-9599: when approved, enqueue an agent_jobs row so the Mac runner
+    // actually fires the iMessage. Without this the approval was a dead-end
+    // (status flipped but nothing else happened).
+    if (args.status === "approved") {
+      const body =
+        (updates.proposed_text as string | undefined) ??
+        row.proposed_text ??
+        undefined;
+      // proposed_data may carry person_id / handle set by the autonomy engine.
+      const proposedData: Record<string, unknown> =
+        typeof row.proposed_data === "object" && row.proposed_data !== null
+          ? (row.proposed_data as Record<string, unknown>)
+          : {};
+      await ctx.db.insert("agent_jobs", {
+        user_id: args.user_id,
+        job_type: "send_imessage",
+        payload: {
+          match_id: row.match_id,
+          person_id: proposedData.person_id,
+          handle: proposedData.handle,
+          body,
+          source: "approved_draft",
+          approval_id: args.id,
+        },
+        status: "queued",
+        priority: 1,
+        attempts: 0,
+        max_attempts: 3,
+        created_at: now,
+        updated_at: now,
+      });
+    }
+
     return await ctx.db.get(args.id);
   },
 });


### PR DESCRIPTION
Linear: AI-9599. Closes F4 P0-3.

## What

`decideApproval` was a dead-end: flipping `status` to `approved` wrote the row but nothing downstream fired the iMessage.

After `ctx.db.patch`, when `status === "approved"`, we now insert an `agent_jobs` row:

```ts
{
  user_id,
  job_type: "send_imessage",
  payload: {
    match_id,          // from approval row
    person_id,         // from proposed_data (set by autonomy engine)
    handle,            // from proposed_data (fallback)
    body,              // proposed_text (or edited_text if reviewer changed it)
    source: "approved_draft",
    approval_id,
  },
  status: "queued",
  priority: 1,
  attempts: 0,
  max_attempts: 3,
}
```

## Runner compatibility

`_handle_send_imessage` in `convex_runner.py` already exists (line 109) and accepts `handle` or `person_id` to resolve the recipient. Both are surfaced from `proposed_data` which the autonomy engine populates at enqueue time.

**Note:** if an approval row was created before `proposed_data` carried `person_id`/`handle`, the job will fail with "send_imessage payload missing 'handle'". The runner's retry logic (`max_attempts: 3`) will surface this as a `failed` job — a separate enrichment pass of old rows is out of scope for this PR.

## TS check

`npx tsc --noEmit` — zero new errors in `queues.ts`.