### PR TITLE
fix(clapcheeks): AI-9526 F6 tel:/imessage: links in MatchDetail

### DIFF
--- a/web/components/matches/MatchDetail.tsx
+++ b/web/components/matches/MatchDetail.tsx
@@ -173,6 +173,24 @@ export default function MatchDetail({ match, messages, clusterRisk }: Props) {
                 {statusBusy === s.key ? '...' : s.label}
               </button>
             ))}
+            {/* AI-9526 F6 — Profile-tab Call / iMessage shortcut.
+                Renders only when her_phone is on the row (offline + handed-off matches). */}
+            {current.her_phone && (
+              <>
+                <a
+                  href={`tel:${current.her_phone}`}
+                  className="text-xs px-3 py-1.5 rounded-lg border bg-white/5 text-white/70 border-white/10 hover:bg-white/10 transition-all"
+                >
+                  Call
+                </a>
+                <a
+                  href={`imessage://${current.her_phone}`}
+                  className="text-xs px-3 py-1.5 rounded-lg border bg-white/5 text-white/70 border-white/10 hover:bg-white/10 transition-all"
+                >
+                  iMessage
+                </a>
+              </>
+            )}
           </div>
         </div>
 

--- a/web/lib/matches/convex-mapper.ts
+++ b/web/lib/matches/convex-mapper.ts
@@ -113,6 +113,8 @@ export function mapConvexMatchRowToLegacy(
     cluster_rank: asNumber(r.cluster_rank),
     social_graph_confidence: asNumber(r.social_graph_confidence),
     social_graph_sources: asArray<string>(r.social_graph_sources),
+    // AI-9526 F6 — surface her_phone for tel:/imessage: links.
+    her_phone: asString(r.her_phone),
   }
 }
 

--- a/web/lib/matches/types.ts
+++ b/web/lib/matches/types.ts
@@ -130,6 +130,9 @@ export type ClapcheeksMatchRow = {
   social_graph_confidence?: number | null
   social_graph_sources?: string[] | null
   social_graph_scanned_at?: string | null
+  // AI-9526 F6 — phone surface in MatchDetail Profile tab so operator can
+  // tap Call / iMessage from the dashboard.
+  her_phone?: string | null
 }
 
 export type MatchListFilters = {


### PR DESCRIPTION
AI-9526 P1 follow-up. Render Call (tel:) and iMessage (imessage://) anchors next to the action bar when match.her_phone is set. Plumbs her_phone through ClapcheeksMatchRow + mapConvexMatchRowToLegacy.