### PR TITLE
fix(clapcheeks): AI-9526 F8 drop lingering Date-ready funnel stage

### DIFF
--- a/web/app/(main)/intelligence/page.tsx
+++ b/web/app/(main)/intelligence/page.tsx
@@ -94,10 +94,11 @@ export default function IntelligencePage() {
   }
 
   const funnel = stats?.stage_funnel || { opened: 0, replied: 0, date_ready: 0, booked: 0 }
+  // AI-9526 F8 — drop the lingering "Date-ready" funnel stage. It was a
+  // fabricated bucket that doesn't map to any real Convex/Supabase signal.
   const funnelSteps = [
     { label: 'Opened', value: funnel.opened },
     { label: 'Replied', value: funnel.replied },
-    { label: 'Date-ready', value: funnel.date_ready },
     { label: 'Booked', value: funnel.booked },
   ]
 


### PR DESCRIPTION
AI-9526 P1 follow-up. Remove the Date-ready entry from intelligence funnelSteps (the dashboard funnel array referenced in the brief did not contain Date-ready; it lives on intelligence/page.tsx). Fabricated bucket that doesn't map to real Convex data. Brief mentioned dashboard/page.tsx but the only Date-ready instance was in intelligence/page.tsx.