### PR TITLE
fix(clapcheeks): AI-9526 F9 weekly coaching cron + sessionId in feedback POST

### DIFF
--- a/web/app/(main)/coaching/page.tsx
+++ b/web/app/(main)/coaching/page.tsx
@@ -20,6 +20,8 @@ interface BenchmarkComparison {
 }
 
 interface CoachingData {
+  // AI-9526 F9 — sessionId required by /api/coaching/feedback POST.
+  sessionId: string | null
   score: number
   tips: CoachingTip[]
   benchmarks: BenchmarkComparison[]
@@ -87,10 +89,13 @@ export default function CoachingPage() {
   async function handleFeedback(tipIndex: number, helpful: boolean) {
     setFeedbackState((prev) => ({ ...prev, [tipIndex]: helpful }))
 
+    // AI-9526 F9 — include sessionId in body; required by API route.
+    const sessionId = data?.sessionId
+    if (!sessionId) return
     await fetch('/api/coaching/feedback', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ tipIndex, helpful }),
+      body: JSON.stringify({ sessionId, tipIndex, helpful }),
     })
   }
 

--- a/web/app/api/coaching/tips/route.ts
+++ b/web/app/api/coaching/tips/route.ts
@@ -117,6 +117,9 @@ export async function GET() {
   }
 
   return NextResponse.json({
+    // AI-9526 F9 — surface sessionId so the page can pass it back when posting
+    // tip feedback. /api/coaching/feedback otherwise 400s with missing fields.
+    sessionId: coaching?.id ?? null,
     score,
     tips: coaching?.tips || [],
     benchmarks,

--- a/web/convex/coaching.ts
+++ b/web/convex/coaching.ts
@@ -1,8 +1,24 @@
-import { mutation, query } from "./_generated/server";
+import { mutation, query, internalAction } from "./_generated/server";
 import { v } from "convex/values";
 
 // AI-9537 — Coaching sessions + tip feedback (replaces
 // clapcheeks_coaching_sessions + clapcheeks_tip_feedback).
+
+// AI-9526 F9 — Weekly coaching session generator. Wired to a Convex cron
+// (Mondays 9am PT). Heavy generation (LLM tip synthesis) lives in the
+// Next.js API route /api/coaching/tips today; this action exists so the
+// cron has a callable target. It currently no-ops and lets the next page
+// load lazy-generate. Future: move generation logic here and write the
+// session row directly.
+export const generateSession = internalAction({
+  args: {},
+  handler: async () => {
+    // Placeholder: a future iteration will call the existing analytics
+    // pipeline from inside Convex and call upsertSession directly.
+    console.log("[coaching.generateSession] weekly cron tick");
+    return { ok: true as const };
+  },
+});
 
 // ---------------------------------------------------------------------------
 // coaching_sessions

--- a/web/convex/crons.ts
+++ b/web/convex/crons.ts
@@ -183,4 +183,13 @@ crons.interval(
 //   internal.enrichment.sweepCompetitionSignalCandidates,
 // );
 
+// AI-9526 F9 — Weekly coaching session refresh. Mondays 9am Pacific.
+// PT = UTC-8 (winter) / UTC-7 (summer). 17:00 UTC ≈ 9am PT in winter;
+// shift to 16:00 UTC if a DST-aware schedule becomes important.
+crons.weekly(
+  "weekly-coaching-session",
+  { dayOfWeek: "monday", hourUTC: 17, minuteUTC: 0 },
+  internal.coaching.generateSession,
+);
+
 export default crons;


### PR DESCRIPTION
AI-9526 P1 follow-up — three sub-fixes:
- Add weekly Convex cron Mon 9am PT (17:00 UTC) calling internal.coaching.generateSession (placeholder action; full generation logic still in lib/coaching/generate.ts)
- /api/coaching/tips returns sessionId; /coaching page passes sessionId in feedback POST body so /api/coaching/feedback no longer 400s

Skipped: 30 -> 7 day window change in coach.ts. The constant THIRTY_DAYS_MS is shared by 7 different read-only coach dashboard queries; flipping it would change unrelated views. Noted for follow-up.