### PR TITLE
fix(clapcheeks): AI-9526 Q4 compose writes to outbound_scheduled_messages

### DIFF
--- a/web/app/api/conversation/send/route.ts
+++ b/web/app/api/conversation/send/route.ts
@@ -1,4 +1,8 @@
 // AI-9535 — Migrated to Convex queued_replies.
+// AI-9526 Q4 — Compose-and-send now writes to outbound_scheduled_messages
+// with status="approved" so the Mac outbound drainer picks it up within 60s.
+// Also dual-writes to queued_replies so the legacy queue_poller can still
+// pick it up if the operator hasn't migrated their Mac daemon yet.
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import { getConvexServerClient } from '@/lib/convex/server'
@@ -24,16 +28,49 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    await getConvexServerClient().mutation(api.queues.enqueueReply, {
-      user_id: getFleetUserId(),
+    const userId = getFleetUserId()
+    const convex = getConvexServerClient()
+    const now = Date.now()
+    const recipientHandle = typeof handle === 'string' && handle ? handle : undefined
+    const phone =
+      recipientHandle && recipientHandle.startsWith('+') ? recipientHandle : undefined
+
+    // AI-9526 Q4 — Primary write: outbound_scheduled_messages with
+    // status="approved" + scheduled_at=now so the outbound drainer fires
+    // within ~60s.
+    const scheduled = await convex.mutation(api.outbound.enqueueScheduledMessage, {
+      user_id: userId,
       match_name: matchName,
-      platform,
-      text,
-      recipient_handle: typeof handle === 'string' && handle ? handle : undefined,
-      status: 'queued',
+      platform: typeof platform === 'string' ? platform : 'iMessage',
+      phone,
+      message_text: text,
+      scheduled_at: now,
+      sequence_type: 'manual',
+      immediate_approved: true,
     })
 
-    return NextResponse.json({ success: true })
+    // Dual-write to queued_replies for the legacy queue_poller (pre-9526
+    // daemons). Best-effort — failure doesn't fail the send.
+    try {
+      await convex.mutation(api.queues.enqueueReply, {
+        user_id: userId,
+        match_name: matchName,
+        platform,
+        text,
+        recipient_handle: recipientHandle,
+        status: 'queued',
+      })
+    } catch (e) {
+      console.warn('queued_replies dual-write failed (non-fatal):', e)
+    }
+
+    return NextResponse.json({
+      success: true,
+      scheduled_id:
+        scheduled && typeof scheduled === 'object' && '_id' in scheduled
+          ? (scheduled as { _id: string })._id
+          : null,
+    })
   } catch (error) {
     console.error('Send reply error:', error)
     const msg = error instanceof Error ? error.message : String(error)

--- a/web/convex/outbound.ts
+++ b/web/convex/outbound.ts
@@ -34,6 +34,9 @@ export const enqueueScheduledMessage = mutation({
     sequence_step: v.optional(v.number()),
     delay_hours: v.optional(v.number()),
     legacy_id: v.optional(v.string()),
+    // AI-9526 Q4 — when true, insert directly as "approved" so the Mac
+    // outbound drainer picks it up on the next tick (compose->send flow).
+    immediate_approved: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const now = Date.now();
@@ -45,7 +48,7 @@ export const enqueueScheduledMessage = mutation({
       phone: args.phone ?? undefined,
       message_text: args.message_text,
       scheduled_at: args.scheduled_at,
-      status: "pending",
+      status: args.immediate_approved ? "approved" : "pending",
       sequence_type: args.sequence_type ?? "manual",
       sequence_step: args.sequence_step ?? 0,
       delay_hours: args.delay_hours ?? undefined,


### PR DESCRIPTION
Q4 of AI-9526 30Q PRD. /api/conversation/send now writes to outbound_scheduled_messages with status='approved' so the Mac outbound drainer claims it within 60s. Dual-writes to queued_replies for legacy daemons. Verified end-to-end: row inserted -> drainer fired -> AppleScript send -> status='sent'.

Closes Q4.