### PR TITLE
fix(clapcheeks): AI-9526 Q7+Q14 /scheduled queue view + Convex user_id sweep

### DIFF
--- a/web/app/(main)/scheduled/page.tsx
+++ b/web/app/(main)/scheduled/page.tsx
@@ -54,7 +54,10 @@ const SEQ_LABELS: Record<string, string> = {
 export default function ScheduledPage() {
   const [messages, setMessages] = useState<ScheduledMessage[]>([])
   const [loading, setLoading] = useState(true)
-  const [filter, setFilter] = useState<string>('pending')
+  // AI-9526 Q7: default view = queued (pending + approved), per PRD
+  // "renders all outbound_scheduled_messages for fleet-julian where status
+  // IN (pending, approved) AND scheduled_at > now".
+  const [filter, setFilter] = useState<string>('queued')
   const [actionLoading, setActionLoading] = useState<string | null>(null)
   const [showCompose, setShowCompose] = useState(false)
   const [compose, setCompose] = useState<{
@@ -313,7 +316,7 @@ export default function ScheduledPage() {
 
         {/* Filter Tabs */}
         <div className="flex gap-2 mb-6 flex-wrap">
-          {['pending', 'approved', 'sent', 'rejected', 'all'].map(f => (
+          {['queued', 'pending', 'approved', 'sent', 'rejected', 'all'].map(f => (
             <button
               key={f}
               onClick={() => setFilter(f)}

--- a/web/app/api/coaching/tips/route.ts
+++ b/web/app/api/coaching/tips/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { ConvexHttpClient } from 'convex/browser'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 import { createClient } from '@/lib/supabase/server'
 import { getLatestCoaching, generateCoaching } from '@/lib/coaching/generate'
@@ -30,11 +31,13 @@ export async function GET() {
   const convex = convexUrl ? new ConvexHttpClient(convexUrl) : null
 
   // AI-9575: conversation_stats migrated to Convex.
+  // AI-9526 Q14: Convex namespace is fleet-julian, not the Supabase auth UUID.
+  const fleetUserId = getFleetUserId()
   const [analyticsRows, convoRows] = await Promise.all([
     convex
       ? convex
           .query(api.telemetry.getDailyForUser, {
-            user_id: user.id,
+            user_id: fleetUserId,
             since_day_iso: sinceStr,
           })
           .catch(() => [])
@@ -42,7 +45,7 @@ export async function GET() {
     convex
       ? convex
           .query(api.conversation_stats.listForUser, {
-            user_id: user.id,
+            user_id: fleetUserId,
             since_date: sinceStr,
           })
           .catch(() => [])

--- a/web/app/api/match-profile/add/route.ts
+++ b/web/app/api/match-profile/add/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { api } from '@/convex/_generated/api'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { createClient } from '@/lib/supabase/server'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 /**
  * POST /api/match-profile/add — create a manually-added match profile.
@@ -70,7 +71,10 @@ export async function POST(request: NextRequest) {
   let inserted: { _id: string } | null = null
   try {
     const result = await convex.mutation(api.matches.insertManual, {
-      user_id: user.id,
+      // AI-9526 Q14: use fleet-julian for Convex writes (matches webhook
+      // receiver namespace). user.id is the Supabase UUID — wrong for
+      // Convex.
+      user_id: getFleetUserId(),
       platform: normalizedPlatform,
       external_match_id: match_id,
       match_id,
@@ -106,7 +110,7 @@ export async function POST(request: NextRequest) {
     ? {
         id: inserted._id,
         _id: inserted._id,
-        user_id: user.id,
+        user_id: getFleetUserId(),
         platform: normalizedPlatform,
         match_id,
         external_id: match_id,
@@ -140,7 +144,8 @@ export async function GET() {
   let data: Array<Record<string, unknown> & { _id?: unknown }> = []
   try {
     const rows = (await convex.query(api.matches.listManualByUser, {
-      user_id: user.id,
+      // AI-9526 Q14: read with fleet-julian to match write namespace.
+      user_id: getFleetUserId(),
       limit: 200,
     })) as Array<Record<string, unknown>>
     data = (rows ?? []) as Array<Record<string, unknown> & { _id?: unknown }>

--- a/web/app/api/match-profile/enrich/route.ts
+++ b/web/app/api/match-profile/enrich/route.ts
@@ -3,6 +3,7 @@ import { api } from '@/convex/_generated/api'
 import type { Id } from '@/convex/_generated/dataModel'
 import { getConvexServerClient } from '@/lib/convex/server'
 import { createClient } from '@/lib/supabase/server'
+import { getFleetUserId } from '@/lib/fleet-user'
 import { signFromBirthday, signFromText, getCompatibility, TRAITS, ELEMENTS, MODALITIES, EMOJIS } from '@/lib/match-profile/zodiac'
 import { buildDiscProfile } from '@/lib/match-profile/disc-profiler'
 import { extractInterestsKeyword } from '@/lib/match-profile/interest-extractor'
@@ -46,7 +47,14 @@ export async function POST(request: NextRequest) {
       })
     | null
 
-  if (!profile || !profile._id || profile.user_id !== user.id) {
+  // AI-9526 Q14: matches in Convex are namespaced by fleet-julian.
+  // The profile.user_id WILL be 'fleet-julian' (post Q14 fix to add route),
+  // not user.id. Compare against fleet-julian going forward; allow the
+  // legacy user.id case for rows written before the Q14 fix.
+  const fleetUserId = getFleetUserId()
+  const profileOwnerOk =
+    profile && profile.user_id && (profile.user_id === fleetUserId || profile.user_id === user.id)
+  if (!profile || !profile._id || !profileOwnerOk) {
     return NextResponse.json({ error: 'Profile not found' }, { status: 404 })
   }
   const profileConvexId = profile._id
@@ -64,7 +72,8 @@ export async function POST(request: NextRequest) {
     try {
       await convex.mutation(api.matches.patchByUser, {
         id: profileConvexId,
-        user_id: user.id,
+        // AI-9526 Q14: Convex writes use fleet-julian.
+        user_id: fleetUserId,
         match_intel: partialIntel,
       })
     } catch {
@@ -195,7 +204,8 @@ export async function POST(request: NextRequest) {
   try {
     await convex.mutation(api.matches.patchByUser, {
       id: profileConvexId,
-      user_id: user.id,
+      // AI-9526 Q14: Convex writes use fleet-julian.
+      user_id: fleetUserId,
       match_intel: intel,
       ...((directUpdates.zodiac !== undefined
         ? { zodiac: directUpdates.zodiac as string }

--- a/web/app/api/scheduled-messages/route.ts
+++ b/web/app/api/scheduled-messages/route.ts
@@ -15,14 +15,36 @@ export async function GET(request: NextRequest) {
   const limit = parseInt(searchParams.get('limit') ?? '50')
 
   try {
-    const rows = await getConvexServerClient().query(
-      api.outbound.listForUser,
-      { user_id: getFleetUserId(), status: status ?? undefined, limit },
-    )
+    // AI-9526 Q7 — composite "queued" view = pending + approved AND
+    // scheduled_at > now. Two queries combined client-side because the
+    // Convex by_user_status index doesn't support OR.
+    let rows: unknown[]
+    if (status === 'queued') {
+      const convex = getConvexServerClient()
+      const [pendingRows, approvedRows] = await Promise.all([
+        convex.query(api.outbound.listForUser, {
+          user_id: getFleetUserId(), status: 'pending', limit,
+        }),
+        convex.query(api.outbound.listForUser, {
+          user_id: getFleetUserId(), status: 'approved', limit,
+        }),
+      ])
+      const nowMs = Date.now()
+      rows = [...(pendingRows ?? []), ...(approvedRows ?? [])]
+        .filter((r: any) => typeof r?.scheduled_at === 'number' && r.scheduled_at > nowMs)
+        .sort((a: any, b: any) => a.scheduled_at - b.scheduled_at)
+        .slice(0, limit)
+    } else {
+      rows = await getConvexServerClient().query(
+        api.outbound.listForUser,
+        { user_id: getFleetUserId(), status: status ?? undefined, limit },
+      )
+    }
     // AI-9582: transform Convex shape (_id, unix-ms timestamps) → UI shape
     // (id string, ISO timestamps). The /scheduled UI renders id as React key
     // and scheduled_at via new Date() — wrong shape causes duplicate keys +
     // "Invalid Date".
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const messages = (rows ?? []).map((r: any) => ({
       id: r._id,
       match_id: r.match_id ?? null,


### PR DESCRIPTION
Q7: /scheduled now defaults to 'queued' (pending+approved AND scheduled_at>now). Q14: 3 API routes finally use getFleetUserId() for Convex writes/reads. Closes Q7 and Q14.