### PR TITLE
fix(clapcheeks): AI-9526 Q9+Q24 spend tracker visible + ghosted filter

### DIFF
--- a/web/app/(main)/dashboard/components/spending-chart.tsx
+++ b/web/app/(main)/dashboard/components/spending-chart.tsx
@@ -42,7 +42,11 @@ export function SpendingChart({ totalSpent, costPerMatch, costPerDate, cpn, cpnG
     color: CATEGORY_COLORS[category] || '#94a3b8',
   }))
 
-  if (chartData.length === 0 && totalSpent === 0) return null
+  // AI-9526 Q9 — Always show the Spend Tracker tile, even when totalSpent
+  // is 0. Previously the component returned null which made it look like
+  // the dashboard was hiding spend data. PRD says: show "$0 (no usage
+  // logged this month)" so it's clear the value is real, not stale.
+  const noSpendLogged = chartData.length === 0 && totalSpent === 0
 
   return (
     <div className="bg-white/5 border border-white/10 rounded-xl p-5">
@@ -52,7 +56,12 @@ export function SpendingChart({ totalSpent, costPerMatch, costPerDate, cpn, cpnG
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-3 mb-4">
         <div className="text-center">
           <div className="text-lg font-bold text-white">${totalSpent.toFixed(2)}</div>
-          <div className="text-white/40 text-xs">Total This Month</div>
+          <div className="text-white/40 text-xs">
+            Total This Month
+            {noSpendLogged && (
+              <span className="block text-[10px] text-white/30">(no usage logged)</span>
+            )}
+          </div>
         </div>
         <div className="text-center">
           <div className="text-lg font-bold text-white">${costPerMatch.toFixed(2)}</div>

--- a/web/components/matches/MatchesPageClient.tsx
+++ b/web/components/matches/MatchesPageClient.tsx
@@ -46,7 +46,14 @@ export default function MatchesPageClient({ matches, errorMessage }: Props) {
   const filtered = useMemo(() => {
     return matches.filter((m) => {
       if (filters.platform !== 'all' && m.platform !== filters.platform) return false
-      if (filters.status !== 'all' && m.status !== filters.status) return false
+      // AI-9526 Q24 — default view hides 'ghosted' / 'archived' matches.
+      // The user can opt in to seeing them by selecting status='ghosted'
+      // explicitly. Once they do, that single status is shown.
+      if (filters.status === 'all') {
+        if (m.status === 'ghosted' || m.status === 'archived') return false
+      } else if (m.status !== filters.status) {
+        return false
+      }
       if (filters.minScore > 0) {
         const s = typeof m.final_score === 'number' ? m.final_score : 0
         if (s < filters.minScore) return false


### PR DESCRIPTION
Q9 surfaces $0 (no usage logged) instead of hiding tile. Q24 default view excludes ghosted/archived; explicit Ghosted filter still shows them.