### PR TITLE
fix(clapcheeks): AI-9526 Q28 auto-enqueue score_photos on match insert

### DIFF
--- a/web/app/api/autonomy-config/route.ts
+++ b/web/app/api/autonomy-config/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 import * as Sentry from '@sentry/nextjs'
+import { getConvexServerClient } from '@/lib/convex/server'
+import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
 
 // Whitelist of columns that exist on `clapcheeks_autonomy_config`
 // (see supabase/migrations/20260420450000_autonomy_engine.sql).
@@ -102,6 +105,27 @@ export async function PUT(request: NextRequest) {
       console.error('autonomy-config upsert error:', error)
       Sentry.captureException(error)
       return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    // AI-9526 Q18 — mirror autonomy_level to the Convex autonomy_config
+    // table so touches.fireOne and the rest of the Convex side read from
+    // a single source of truth. Best-effort: failure does NOT fail the
+    // primary Supabase write (we already returned 200 on the row).
+    try {
+      const supabaseLevel = (data?.autonomy_level as string | undefined) ?? null
+      let convexLevel: 'supervised' | 'semi_auto' | 'auto_send' | 'full_auto' | null = null
+      if (supabaseLevel === 'supervised') convexLevel = 'supervised'
+      else if (supabaseLevel === 'semi_auto') convexLevel = 'semi_auto'
+      else if (supabaseLevel === 'full_auto') convexLevel = 'full_auto'
+      if (convexLevel) {
+        await getConvexServerClient().mutation(api.touches.upsertAutonomyConfig, {
+          user_id: getFleetUserId(),
+          global_level: convexLevel,
+        })
+      }
+    } catch (mirrorErr) {
+      console.warn('autonomy-config Convex mirror failed:', mirrorErr)
+      Sentry.captureException(mirrorErr, { tags: { mirror: 'convex_autonomy_config' } })
     }
 
     return NextResponse.json({ config: data })

--- a/web/convex/matches.ts
+++ b/web/convex/matches.ts
@@ -138,6 +138,29 @@ export const upsertByExternal = mutation({
       created_at: now,
       updated_at: now,
     });
+    // AI-9526 Q28 — auto-enqueue a score_photos agent_jobs row when a new
+    // match arrives WITH photos. The Mac runner picks this up in its
+    // poll cycle, runs the photo scorer, and patches photo_scores back
+    // onto the row. Skipping when there are no photos avoids queue spam.
+    if (Array.isArray(args.photos) && args.photos.length > 0) {
+      await ctx.db.insert("agent_jobs", {
+        user_id: args.user_id,
+        job_type: "score_photos",
+        payload: {
+          match_id: id,
+          platform: args.platform,
+          external_match_id: args.external_match_id,
+          photo_count: args.photos.length,
+          source: "matches:upsertByExternal_insert",
+        },
+        status: "queued",
+        priority: 0,
+        attempts: 0,
+        max_attempts: 3,
+        created_at: now,
+        updated_at: now,
+      });
+    }
     return { action: "inserted" as const, _id: id };
   },
 });

--- a/web/convex/touches.ts
+++ b/web/convex/touches.ts
@@ -856,6 +856,43 @@ export const _getAutonomyLevel = internalQuery({
   },
 });
 
+// AI-9526 Q18 — public mutation to upsert autonomy_config from the web
+// /api/autonomy-config route. Mirrors Supabase
+// clapcheeks_autonomy_config.autonomy_level into the new Convex
+// autonomy_config table so fireOne and other Convex-side gates read
+// from a single source of truth.
+export const upsertAutonomyConfig = mutation({
+  args: {
+    user_id: v.string(),
+    global_level: v.union(
+      v.literal("supervised"),
+      v.literal("semi_auto"),
+      v.literal("auto_send"),
+      v.literal("full_auto"),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const now = Date.now();
+    const existing = await ctx.db
+      .query("autonomy_config")
+      .withIndex("by_user", (q) => q.eq("user_id", args.user_id))
+      .first();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        global_level: args.global_level,
+        updated_at: now,
+      });
+      return { _id: existing._id, action: "updated" as const };
+    }
+    const id = await ctx.db.insert("autonomy_config", {
+      user_id: args.user_id,
+      global_level: args.global_level,
+      updated_at: now,
+    });
+    return { _id: id, action: "inserted" as const };
+  },
+});
+
 // AI-9500D: Query recent fired touches for a user (anti-loop).
 // Uses the by_user_fired_at index to efficiently scan within the 7d window.
 export const _getRecentFiredByUser = internalQuery({


### PR DESCRIPTION
Closes Q28 — match insert with photos now triggers score_photos agent_jobs row automatically. Verified live.