### PR TITLE
fix(clapcheeks): AI-9605 AiActiveSwitch enables for new users w/o settings row

### DIFF
--- a/web/components/header/AiActiveSwitch.tsx
+++ b/web/components/header/AiActiveSwitch.tsx
@@ -53,12 +53,21 @@ export default function AiActiveSwitch() {
       if (!user) return
       setUserId(user.id)
 
+      // AI-9605: settings row may not exist yet for a new user. `.single()`
+      // returns an error in that case; default to ai_active=true so the
+      // toggle is interactive instead of permanently `disabled`.
       const { data } = await supabase
         .from('clapcheeks_user_settings')
         .select('ai_active, ai_paused_until, ai_paused_reason')
         .eq('user_id', user.id)
-        .single()
-      if (data) setSettings(data as AiSettings)
+        .maybeSingle()
+      setSettings(
+        (data as AiSettings | null) ?? {
+          ai_active: true,
+          ai_paused_until: null,
+          ai_paused_reason: null,
+        },
+      )
     })()
   }, [])
 


### PR DESCRIPTION
## Bug

The header AI Active toggle was permanently `[disabled]` for any user that didn't already have a `clapcheeks_user_settings` row in Supabase. New users (and any user where the row was never created) saw a dead toggle they could never click — across **every page** in the app.

## Cause

`AiActiveSwitch.tsx` set `settings` only when `.single()` returned data. The button is `disabled={saving || !settings}`, so a missing row left it disabled forever.

## Fix

Use `.maybeSingle()` (returns null instead of erroring) and default `settings` to `{ ai_active: true, ai_paused_until: null, ai_paused_reason: null }` when the row doesn't exist. First click triggers the existing upsert path which creates the row.

## Verified by

QA loop with fresh Supabase user `qa-2026@aiacrobatics.com`:
- Pre-fix: `<button \"AI Active\" [disabled]>` on /dashboard, /matches, /matches/[id], /coaching, /autonomy, /scheduled, /settings, /leads, /conversation, /intelligence, /intel/health, /photos, /analytics, /studio/voice, /dashboard/content-library, /nurture, /billing, /referrals, /support
- Post-fix (will deploy): toggle clickable on first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)