### PR TITLE
AI-9643 live messages dashboard + comms prefs + quick actions

### DIFF
--- a/web/app/admin/clapcheeks-ops/messages/page.tsx
+++ b/web/app/admin/clapcheeks-ops/messages/page.tsx
@@ -1,0 +1,467 @@
+/**
+ * AI-9643 — Live messages ops dashboard.
+ *
+ * Three-zone layout:
+ *   - LEFT (live feed): real-time stream of recent inbound + outbound messages
+ *     across the entire network. Convex `useQuery` pushes new rows the moment
+ *     BlueBubbles / Hinge / IG webhooks land. Filter chips + name search.
+ *   - RIGHT TOP (next 24h schedule): touches firing in the next 24h with quick
+ *     actions (send now, regenerate, edit draft inline, cancel).
+ *   - RIGHT BOTTOM (comms prefs): editable preferences panel for whichever
+ *     person is currently selected in the feed.
+ *
+ * Click any message row → focuses that person in the right rail.
+ */
+"use client"
+
+import { useQuery, useMutation } from "convex/react"
+import { api } from "@/convex/_generated/api"
+import { Id } from "@/convex/_generated/dataModel"
+import Link from "next/link"
+import { useMemo, useState, useEffect, useRef } from "react"
+import { CommsPreferencesPanel } from "@/components/clapcheeks-ops/comms-preferences-panel"
+
+const FLEET_USER_ID = "fleet-julian"
+
+type FilterKind = "all" | "inbound" | "needs_response" | "cooling" | "hot"
+
+const TWELVE_H = 12 * 3600 * 1000
+const THREE_D = 3 * 24 * 3600 * 1000
+const THIRTY_D = 30 * 24 * 3600 * 1000
+
+export default function LiveMessagesDashboard() {
+  const [filter, setFilter] = useState<FilterKind>("all")
+  const [search, setSearch] = useState("")
+  const [focusedPersonId, setFocusedPersonId] = useState<string | null>(null)
+  const [pingOnInbound, setPingOnInbound] = useState(false)
+
+  const recent = useQuery(api.messages.recentForUser, { user_id: FLEET_USER_ID, limit: 100 })
+  const people = useQuery(api.people.listForUser, { user_id: FLEET_USER_ID, limit: 2000, only_cc_tech: false })
+  const upcoming = useQuery(api.touches.listUpcoming, {
+    user_id: FLEET_USER_ID, horizon_hours: 24, limit: 100,
+  })
+
+  // Build a fast person index keyed by id so each message can render display_name + signals.
+  const peopleById = useMemo(() => {
+    const m = new Map<string, any>()
+    for (const p of people ?? []) m.set(p._id, p)
+    return m
+  }, [people])
+
+  // Annotate each message with the person row + a "needs response" flag.
+  type EnrichedRow = { msg: any; person: any | null; isNeedsResponse: boolean }
+  const enriched = useMemo<EnrichedRow[]>(() => {
+    if (!recent) return []
+    return recent
+      .map((m: any): EnrichedRow => {
+        const p = m.person_id ? peopleById.get(m.person_id) : null
+        const isNeedsResponse =
+          m.direction === "inbound" &&
+          !!p &&
+          (!p.last_outbound_at || p.last_outbound_at < (m.sent_at ?? 0))
+        return { msg: m, person: p, isNeedsResponse }
+      })
+      .filter((row: EnrichedRow) => {
+        if (search) {
+          const q = search.toLowerCase()
+          const name = (row.person?.display_name ?? "").toLowerCase()
+          const body = (row.msg?.body ?? "").toLowerCase()
+          if (!name.includes(q) && !body.includes(q)) return false
+        }
+        if (filter === "inbound") return row.msg.direction === "inbound"
+        if (filter === "needs_response") return row.isNeedsResponse
+        if (filter === "cooling") {
+          const p = row.person
+          if (!p?.last_inbound_at) return false
+          const sinceIn = Date.now() - p.last_inbound_at
+          return sinceIn >= THREE_D && sinceIn < THIRTY_D
+        }
+        if (filter === "hot") return (row.person?.cadence_profile === "hot")
+        return true
+      })
+  }, [recent, peopleById, filter, search])
+
+  // Audio ping on first new inbound. Debounced + only after explicit opt-in.
+  const lastSeenInboundRef = useRef<number>(Date.now())
+  useEffect(() => {
+    if (!pingOnInbound || !recent?.length) return
+    const newestInbound = recent.find((m: any) => m.direction === "inbound")
+    if (!newestInbound) return
+    if (newestInbound.sent_at > lastSeenInboundRef.current) {
+      lastSeenInboundRef.current = newestInbound.sent_at
+      try {
+        // tiny WebAudio blip (no asset needed)
+        const ctx = new (window.AudioContext || (window as any).webkitAudioContext)()
+        const o = ctx.createOscillator()
+        const g = ctx.createGain()
+        o.frequency.value = 880
+        g.gain.value = 0.04
+        o.connect(g); g.connect(ctx.destination)
+        o.start(); o.stop(ctx.currentTime + 0.12)
+      } catch { /* no-op */ }
+    }
+  }, [recent, pingOnInbound])
+
+  const focusedPerson = focusedPersonId ? peopleById.get(focusedPersonId) : null
+
+  // Counts for the chips (only the visible portion after search).
+  const counts = useMemo(() => {
+    const visible = (recent ?? []).filter((m: any) => {
+      if (!search) return true
+      const p = m.person_id ? peopleById.get(m.person_id) : null
+      const q = search.toLowerCase()
+      const name = (p?.display_name ?? "").toLowerCase()
+      const body = (m.body ?? "").toLowerCase()
+      return name.includes(q) || body.includes(q)
+    })
+    const inbound = visible.filter((m: any) => m.direction === "inbound").length
+    const needsResp = visible.filter((m: any) => {
+      if (m.direction !== "inbound" || !m.person_id) return false
+      const p = peopleById.get(m.person_id)
+      if (!p) return false
+      return !p.last_outbound_at || p.last_outbound_at < (m.sent_at ?? 0)
+    }).length
+    return { all: visible.length, inbound, needsResp }
+  }, [recent, peopleById, search])
+
+  if (recent === undefined || people === undefined) {
+    return <div className="p-8 text-gray-500">Loading live feed...</div>
+  }
+
+  return (
+    <div className="p-3 sm:p-6 max-w-[1600px]">
+      <div className="flex items-baseline justify-between mb-4">
+        <div>
+          <h1 className="text-2xl sm:text-3xl font-bold">Live messages</h1>
+          <p className="text-gray-500 text-xs">Real-time. Updates the moment a message lands. Click a row to focus.</p>
+        </div>
+        <div className="flex items-center gap-3 text-xs">
+          <label className="flex items-center gap-1.5 cursor-pointer text-gray-400">
+            <input type="checkbox" checked={pingOnInbound} onChange={(e) => setPingOnInbound(e.target.checked)} />
+            ping on inbound
+          </label>
+          <Link href="/admin/clapcheeks-ops/touches" className="text-purple-400 hover:text-purple-300">all touches →</Link>
+          <Link href="/admin/clapcheeks-ops/network" className="text-purple-400 hover:text-purple-300">network →</Link>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {/* LEFT — live feed */}
+        <div className="lg:col-span-2">
+          <div className="flex flex-wrap gap-2 mb-3 items-center">
+            <Chip active={filter === "all"} onClick={() => setFilter("all")}>All ({counts.all})</Chip>
+            <Chip active={filter === "inbound"} onClick={() => setFilter("inbound")}>Inbound ({counts.inbound})</Chip>
+            <Chip active={filter === "needs_response"} onClick={() => setFilter("needs_response")} accent="rose">
+              Needs response ({counts.needsResp})
+            </Chip>
+            <Chip active={filter === "cooling"} onClick={() => setFilter("cooling")} accent="amber">Cooling</Chip>
+            <Chip active={filter === "hot"} onClick={() => setFilter("hot")} accent="pink">Hot cadence</Chip>
+            <input
+              type="text"
+              value={search}
+              placeholder="search name or body..."
+              onChange={(e) => setSearch(e.target.value)}
+              className="ml-auto bg-gray-950 border border-gray-800 rounded px-3 py-1.5 text-xs w-48"
+            />
+          </div>
+
+          <div className="space-y-1.5 max-h-[78vh] overflow-y-auto pr-2">
+            {enriched.length === 0 ? (
+              <div className="text-gray-500 text-sm py-8 text-center">
+                No messages match. Try clearing the filter or search.
+              </div>
+            ) : enriched.map((row: EnrichedRow) => (
+              <MessageRow
+                key={row.msg._id}
+                msg={row.msg}
+                person={row.person}
+                isNeedsResponse={row.isNeedsResponse}
+                focused={focusedPersonId === row.person?._id}
+                onFocus={() => row.person?._id && setFocusedPersonId(row.person._id)}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* RIGHT — schedule + prefs */}
+        <div className="space-y-4">
+          <NextTouchesColumn upcoming={upcoming} peopleById={peopleById} onFocusPerson={setFocusedPersonId} />
+          {focusedPerson ? (
+            <CommsPreferencesPanel person={focusedPerson} compact />
+          ) : (
+            <div className="bg-gray-900 border border-dashed border-gray-800 rounded-lg p-4 text-xs text-gray-500">
+              Click any message row on the left to load that person's communication preferences here.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ----------------------------------------------------------------------------
+
+function MessageRow({
+  msg, person, isNeedsResponse, focused, onFocus,
+}: {
+  msg: any; person: any | null; isNeedsResponse: boolean; focused: boolean; onFocus: () => void;
+}) {
+  const isOut = msg.direction === "outbound"
+  const ago = formatAgo(msg.sent_at)
+  const platform: string = inferPlatform(msg)
+  const channelChip = PLATFORM_CHIP[platform] ?? PLATFORM_CHIP.imessage
+
+  // Insight chips on the row — date-ask readiness, quiet thread, hot cadence.
+  const dateAskReady = typeof person?.time_to_ask_score === "number" && person.time_to_ask_score >= 0.7
+  const isQuiet = typeof person?.her_question_ratio_7d === "number"
+    && person.her_question_ratio_7d < 0.15
+    && person?.last_inbound_at && (Date.now() - person.last_inbound_at) > 24 * 3600 * 1000
+
+  return (
+    <div
+      onClick={onFocus}
+      className={`group cursor-pointer rounded-lg border px-3 py-2 transition-colors ${
+        focused
+          ? "border-purple-600 bg-purple-950/30"
+          : isNeedsResponse
+          ? "border-rose-800/60 bg-rose-950/20 hover:border-rose-600"
+          : "border-gray-800 bg-gray-900 hover:border-gray-600"
+      }`}
+    >
+      <div className="flex items-start gap-2">
+        {/* Direction marker */}
+        <div className={`shrink-0 mt-1 w-1.5 h-1.5 rounded-full ${
+          isNeedsResponse ? "bg-rose-400" : isOut ? "bg-purple-500" : "bg-emerald-500"
+        }`} />
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap text-xs">
+            <span className="font-medium text-gray-100 truncate">
+              {person?.display_name ?? "(unlinked)"}
+            </span>
+            <span className={`px-1.5 py-0.5 rounded text-[10px] border ${channelChip.cls}`}>
+              {channelChip.icon} {platform}
+            </span>
+            <span className={`text-[10px] ${isOut ? "text-purple-400" : "text-emerald-400"}`}>
+              {isOut ? "→ sent" : "← inbound"}
+            </span>
+            <span className="text-[10px] text-gray-500">{ago}</span>
+            {dateAskReady && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-pink-900/40 text-pink-200 border border-pink-700/50" title="time_to_ask_score >= 0.7">
+                🎯 ask now
+              </span>
+            )}
+            {isQuiet && (
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-900/40 text-amber-200 border border-amber-700/50" title="her_question_ratio_7d < 0.15">
+                💤 quiet
+              </span>
+            )}
+            {person?.cadence_profile === "hot" && (
+              <span className="text-[10px] text-rose-400">🔥 hot cadence</span>
+            )}
+          </div>
+          <div className="text-sm text-gray-200 mt-0.5 line-clamp-2 whitespace-pre-wrap">
+            {msg.body || <span className="text-gray-600 italic">(no body)</span>}
+          </div>
+        </div>
+
+        {person?._id && (
+          <Link
+            href={`/admin/clapcheeks-ops/people/${person._id}`}
+            onClick={(e) => e.stopPropagation()}
+            className="shrink-0 opacity-0 group-hover:opacity-100 text-[10px] text-purple-400 hover:text-purple-300 underline self-center"
+          >
+            dossier
+          </Link>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ----------------------------------------------------------------------------
+
+function NextTouchesColumn({
+  upcoming, peopleById, onFocusPerson,
+}: {
+  upcoming: any[] | undefined;
+  peopleById: Map<string, any>;
+  onFocusPerson: (id: string) => void;
+}) {
+  const cancel = useMutation(api.touches.cancelOne)
+  const fireNow = useMutation(api.touches.fireNow)
+  const regenerate = useMutation(api.touches.regenerateDraft)
+  const editDraft = useMutation(api.touches.editDraft)
+
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draftText, setDraftText] = useState("")
+
+  if (upcoming === undefined) {
+    return <div className="bg-gray-900 border border-gray-800 rounded-lg p-3 text-xs text-gray-500">Loading schedule...</div>
+  }
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-lg p-3">
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-sm font-semibold text-gray-200">Next 24h schedule</div>
+        <span className="text-[11px] text-gray-500">{upcoming.length} queued</span>
+      </div>
+      {upcoming.length === 0 ? (
+        <div className="text-xs text-gray-500 py-2">Nothing queued in the next 24h.</div>
+      ) : (
+        <div className="space-y-2 max-h-[44vh] overflow-y-auto pr-1">
+          {upcoming.map((t: any) => {
+            const person = t.person_id ? peopleById.get(t.person_id) : null
+            const fireIn = t.scheduled_for - Date.now()
+            const fireInText = fireIn < 60_000 ? "now" : fireIn < 3_600_000
+              ? `in ${Math.round(fireIn / 60_000)}m`
+              : `at ${new Date(t.scheduled_for).toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`
+            const isEditing = editingId === t._id
+            return (
+              <div key={t._id} className={`rounded border ${t.urgency === "hot" ? "border-rose-800/60" : "border-gray-800"} bg-gray-950/40 p-2`}>
+                <div className="flex items-center gap-1.5 text-[11px] flex-wrap">
+                  <button
+                    onClick={() => person?._id && onFocusPerson(person._id)}
+                    className="font-medium text-gray-100 hover:text-purple-300 truncate"
+                  >
+                    {person?.display_name ?? "(unlinked)"}
+                  </button>
+                  <span className="text-gray-600">·</span>
+                  <span className="text-purple-300">{t.type.replace(/_/g, " ")}</span>
+                  <span className="text-gray-600">·</span>
+                  <span className="text-amber-300">{fireInText}</span>
+                  {t.urgency && (
+                    <span className={`text-[10px] px-1 py-0.5 rounded ${
+                      t.urgency === "hot" ? "bg-rose-900 text-rose-200"
+                      : t.urgency === "warm" ? "bg-yellow-900 text-yellow-200"
+                      : "bg-gray-800 text-gray-400"
+                    }`}>{t.urgency}</span>
+                  )}
+                </div>
+
+                {/* Draft body / edit textarea */}
+                {isEditing ? (
+                  <div className="mt-1.5">
+                    <textarea
+                      value={draftText}
+                      onChange={(e) => setDraftText(e.target.value)}
+                      rows={3}
+                      className="w-full bg-gray-950 border border-gray-700 rounded px-2 py-1 text-xs"
+                      placeholder="rewrite..."
+                    />
+                    <div className="flex gap-1.5 mt-1.5">
+                      <button
+                        onClick={async () => {
+                          await editDraft({ touch_id: t._id, draft_body: draftText })
+                          setEditingId(null)
+                        }}
+                        className="text-[11px] px-2 py-1 rounded bg-emerald-700 hover:bg-emerald-600 text-white"
+                      >save</button>
+                      <button
+                        onClick={() => setEditingId(null)}
+                        className="text-[11px] px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-300"
+                      >cancel</button>
+                    </div>
+                  </div>
+                ) : t.draft_body ? (
+                  <div className="text-xs text-gray-300 mt-1 line-clamp-2">{t.draft_body}</div>
+                ) : (
+                  <div className="text-xs text-gray-600 mt-1 italic">drafting at fire time...</div>
+                )}
+
+                {!isEditing && (
+                  <div className="flex gap-1 mt-1.5 flex-wrap">
+                    <ActionButton
+                      label="Send now"
+                      kind="hot"
+                      onClick={() => fireNow({ touch_id: t._id })}
+                    />
+                    <ActionButton
+                      label="Regenerate"
+                      onClick={() => regenerate({ touch_id: t._id })}
+                    />
+                    <ActionButton
+                      label="Edit"
+                      onClick={() => { setEditingId(t._id); setDraftText(t.draft_body ?? "") }}
+                    />
+                    <ActionButton
+                      label="Cancel"
+                      kind="muted"
+                      onClick={() => cancel({ touch_id: t._id, reason: "manual_cancel_dashboard" })}
+                    />
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ----------------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------------
+
+function Chip({
+  active, onClick, accent, children,
+}: { active: boolean; onClick: () => void; accent?: "rose" | "amber" | "pink"; children: React.ReactNode }) {
+  const accentCls = accent === "rose"
+    ? "bg-rose-900/40 border-rose-700 text-rose-200"
+    : accent === "amber"
+    ? "bg-amber-900/40 border-amber-700 text-amber-200"
+    : accent === "pink"
+    ? "bg-pink-900/40 border-pink-700 text-pink-200"
+    : "bg-purple-900/40 border-purple-700 text-purple-200"
+  return (
+    <button
+      onClick={onClick}
+      className={`text-xs px-3 py-1 rounded border ${
+        active ? accentCls : "bg-gray-900 border-gray-800 text-gray-400 hover:border-gray-600"
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+function ActionButton({
+  label, onClick, kind,
+}: { label: string; onClick: () => void; kind?: "hot" | "muted" }) {
+  const cls = kind === "hot"
+    ? "bg-purple-700 hover:bg-purple-600 text-white"
+    : kind === "muted"
+    ? "bg-gray-900 hover:bg-gray-800 text-gray-500 hover:text-rose-300"
+    : "bg-gray-800 hover:bg-gray-700 text-gray-200"
+  return (
+    <button onClick={onClick} className={`text-[11px] px-2 py-0.5 rounded ${cls}`}>{label}</button>
+  )
+}
+
+const PLATFORM_CHIP: Record<string, { icon: string; cls: string }> = {
+  imessage: { icon: "📱", cls: "border-blue-700/60 text-blue-300" },
+  hinge: { icon: "💜", cls: "border-purple-700/60 text-purple-300" },
+  bumble: { icon: "🟡", cls: "border-yellow-700/60 text-yellow-300" },
+  tinder: { icon: "🔴", cls: "border-rose-700/60 text-rose-300" },
+  instagram: { icon: "📷", cls: "border-pink-700/60 text-pink-300" },
+  telegram: { icon: "✈️", cls: "border-cyan-700/60 text-cyan-300" },
+  email: { icon: "✉️", cls: "border-gray-700/60 text-gray-300" },
+  sms: { icon: "💬", cls: "border-emerald-700/60 text-emerald-300" },
+  whatsapp: { icon: "🟢", cls: "border-green-700/60 text-green-300" },
+}
+
+function inferPlatform(msg: any): string {
+  if (msg.transport === "sms") return "sms"
+  if (msg._platform) return msg._platform
+  return "imessage"
+}
+
+function formatAgo(ts?: number | null): string {
+  if (!ts) return "—"
+  const diff = Date.now() - ts
+  if (diff < 60_000) return "just now"
+  if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m ago`
+  if (diff < 86_400_000) return `${Math.round(diff / 3_600_000)}h ago`
+  return `${Math.round(diff / 86_400_000)}d ago`
+}

--- a/web/app/admin/clapcheeks-ops/network/page.tsx
+++ b/web/app/admin/clapcheeks-ops/network/page.tsx
@@ -2,12 +2,18 @@
  * Network — operator's dating-relevant people, ranked by hotness × recency.
  * Click a person → /admin/clapcheeks-ops/people/[id] for the full dossier.
  *
- * Filter (default ON): only show people who are dating-relevant —
- *   - status in {lead, active, dating, paused} AND
- *   - (has any iMessage/dating-app handle OR last_inbound_at within 90d
- *     OR explicitly hotness_rating set OR vibe_classification=="dating")
+ * Filter (default ON): show only people who are actually dating prospects.
+ *   1. status in {lead, active, dating, paused}
+ *   2. NOT classified as platonic or professional (hard exclude)
+ *   3. has at least one DEFINITIVE dating signal:
+ *        - imported from a dating-app profile screenshot, OR
+ *        - vibe_classification === "dating", OR
+ *        - operator set hotness_rating or effort_rating, OR
+ *        - has a handle on Hinge / Tinder / Bumble (dating-only platforms)
  *
- * Toggle the "Everyone" switch to drop the filter and see all 500+ rows.
+ * iMessage / SMS / Instagram handles alone are NOT enough — those channels are
+ * full of guys, family, clients, etc. Recent inbound alone is also not enough
+ * for the same reason. The "show all" toggle bypasses every filter.
  */
 "use client"
 
@@ -25,16 +31,32 @@ const STAGE_ORDER = [
 
 const NINETY_DAYS = 90 * 24 * 60 * 60 * 1000
 
+// Dating-only platforms: presence of one of these handles is itself a strong
+// signal the person is a romantic prospect. iMessage / SMS / Instagram /
+// Telegram / WhatsApp / email are all general-purpose and routinely carry
+// guys, family, clients, etc., so they don't count as a dating signal on
+// their own.
+const DATING_ONLY_CHANNELS = new Set(["hinge", "tinder", "bumble"])
+
 function isDatingRelevant(p: any): boolean {
   if (!["lead", "active", "dating", "paused"].includes(p.status)) return false
-  const hasHandle = (p.handles ?? []).some((h: any) =>
-    ["imessage", "hinge", "tinder", "bumble", "instagram"].includes(h.channel)
-  )
-  const hasRecentInbound = p.last_inbound_at && (Date.now() - p.last_inbound_at) < NINETY_DAYS
-  const hasOperatorRating = p.hotness_rating !== undefined || p.effort_rating !== undefined
-  const isDatingVibe = p.vibe_classification === "dating"
+
+  // Hard exclude: anyone the vibe classifier already tagged as not-dating.
+  // This is the main fix for guys' names showing up in the network — Hitesh,
+  // Sean, Brendan, etc. all classify as "professional" or "platonic".
+  if (p.vibe_classification === "platonic" || p.vibe_classification === "professional") {
+    return false
+  }
+
+  // Definitive dating signals — any one of these is enough on its own.
   const isImported = p.imported_from_profile_screenshot === true
-  return Boolean(hasHandle || hasRecentInbound || hasOperatorRating || isDatingVibe || isImported)
+  const isDatingVibe = p.vibe_classification === "dating"
+  const hasOperatorRating = p.hotness_rating !== undefined || p.effort_rating !== undefined
+  const hasDatingAppHandle = (p.handles ?? []).some((h: any) =>
+    DATING_ONLY_CHANNELS.has(h.channel)
+  )
+
+  return Boolean(isImported || isDatingVibe || hasOperatorRating || hasDatingAppHandle)
 }
 
 function priorityScore(p: any): number {
@@ -160,7 +182,7 @@ export default function NetworkPage() {
       <div className="text-xs text-gray-600 mb-4">
         {showArchived
           ? "Archived people — auto-cut after 30d silence or manually cut from the cut list."
-          : "Default view: lead/active/dating/paused with dating-channel handle, recent inbound, operator rating, or dating vibe."
+          : "Default view: dating prospects only. Excludes anyone classified as platonic or professional. Toggle 'show all' to include the rest of the network."
         }
       </div>
 

--- a/web/app/admin/clapcheeks-ops/page.tsx
+++ b/web/app/admin/clapcheeks-ops/page.tsx
@@ -63,6 +63,21 @@ export default function ClapcheeksOpsOverview() {
         Your dating co-pilot — live state, ranked surfaces, one-tap controls.
       </p>
 
+      {/* AI-9643 — Live messages dashboard nav card */}
+      <Link href="/admin/clapcheeks-ops/messages"
+            className="block mb-4 bg-gradient-to-r from-rose-950 to-gray-900 border border-rose-800 rounded-xl p-5 hover:border-rose-600 transition">
+        <div className="flex items-center gap-3">
+          <span className="text-2xl">💬</span>
+          <div>
+            <div className="font-bold text-lg text-white">Live messages dashboard</div>
+            <div className="text-sm text-rose-300">
+              Real-time inbound + outbound feed across the network. Quick send, regenerate, edit, and comms preferences in one screen.
+            </div>
+          </div>
+          <span className="ml-auto text-rose-400 text-xl">→</span>
+        </div>
+      </Link>
+
       {/* AI-9500 W2 #M — Cohort retro nav card */}
       <Link href="/admin/clapcheeks-ops/cohort"
             className="block mb-4 bg-gradient-to-r from-indigo-950 to-gray-900 border border-indigo-800 rounded-xl p-5 hover:border-indigo-600 transition">

--- a/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
+++ b/web/app/admin/clapcheeks-ops/people/[id]/page.tsx
@@ -20,6 +20,7 @@ import { useState, useMemo } from "react"
 import { useParams } from "next/navigation"
 import Link from "next/link"
 import { Id } from "@/convex/_generated/dataModel"
+import { CommsPreferencesPanel } from "@/components/clapcheeks-ops/comms-preferences-panel"
 
 const TABS = ["Timeline", "Memory", "Schedule", "Media", "Profile", "Notes"] as const
 type TabName = typeof TABS[number]
@@ -102,6 +103,13 @@ export default function PersonDossierPage() {
       <TagsRow person={person} />
 
       <OperatorPanel person={person} />
+
+      {/* AI-9643 — Unified communication preferences (cadence, active hours,
+          whitelist, pursuit posture, response insights). Single source of
+          truth, mirrored on /messages right rail. */}
+      <div className="mt-4">
+        <CommsPreferencesPanel person={person} />
+      </div>
 
       <PreDateDebriefCard touches={scheduled_touches ?? []} />
 

--- a/web/app/admin/clapcheeks-ops/touches/page.tsx
+++ b/web/app/admin/clapcheeks-ops/touches/page.tsx
@@ -28,7 +28,12 @@ export default function TouchesPage() {
     user_id: FLEET_USER_ID, horizon_hours: horizon, limit: 200,
   })
   const cancel = useMutation(api.touches.cancelOne)
+  const fireNow = useMutation(api.touches.fireNow)
+  const regenerate = useMutation(api.touches.regenerateDraft)
+  const editDraft = useMutation(api.touches.editDraft)
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [draftText, setDraftText] = useState("")
 
   if (upcoming === undefined) return <div className="p-8 text-gray-500">Loading…</div>
 
@@ -108,11 +113,34 @@ export default function TouchesPage() {
                           </Link>
                         )}
                       </div>
-                      {/* Draft preview (non-debrief) */}
-                      {t.draft_body && !isDebriefTouch && (
+                      {/* Draft preview / inline editor (non-debrief) */}
+                      {!isDebriefTouch && editingId === t._id ? (
+                        <div className="mt-1.5">
+                          <textarea
+                            value={draftText}
+                            onChange={(e) => setDraftText(e.target.value)}
+                            rows={3}
+                            className="w-full bg-gray-950 border border-gray-700 rounded px-2 py-1 text-sm"
+                            placeholder="rewrite..."
+                          />
+                          <div className="flex gap-1.5 mt-1.5">
+                            <button
+                              onClick={async () => {
+                                await editDraft({ touch_id: t._id, draft_body: draftText })
+                                setEditingId(null)
+                              }}
+                              className="text-xs px-2 py-1 rounded bg-emerald-700 hover:bg-emerald-600 text-white"
+                            >save draft</button>
+                            <button
+                              onClick={() => setEditingId(null)}
+                              className="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-300"
+                            >cancel edit</button>
+                          </div>
+                        </div>
+                      ) : t.draft_body && !isDebriefTouch ? (
                         <div className="text-sm text-gray-400 mt-1 line-clamp-2">{t.draft_body}</div>
-                      )}
-                      {t.prompt_template && !t.draft_body && (
+                      ) : null}
+                      {t.prompt_template && !t.draft_body && !isDebriefTouch && editingId !== t._id && (
                         <div className="text-xs text-gray-500 mt-1 italic">
                           regenerate at fire time · template={t.prompt_template}
                         </div>
@@ -125,6 +153,23 @@ export default function TouchesPage() {
                         >
                           {isExpanded ? "▲ hide debrief" : "▼ show debrief"}
                         </button>
+                      )}
+                      {/* Quick actions row (non-debrief, not editing) */}
+                      {!isDebriefTouch && editingId !== t._id && (
+                        <div className="flex gap-1.5 mt-2 flex-wrap">
+                          <button
+                            onClick={() => fireNow({ touch_id: t._id })}
+                            className="text-xs px-2 py-1 rounded bg-purple-700 hover:bg-purple-600 text-white"
+                          >Send now</button>
+                          <button
+                            onClick={() => regenerate({ touch_id: t._id })}
+                            className="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-200"
+                          >Regenerate</button>
+                          <button
+                            onClick={() => { setEditingId(t._id); setDraftText(t.draft_body ?? "") }}
+                            className="text-xs px-2 py-1 rounded bg-gray-800 hover:bg-gray-700 text-gray-200"
+                          >Edit draft</button>
+                        </div>
                       )}
                     </div>
                     <button onClick={() => cancel({ touch_id: t._id, reason: "manual_cancel" })}

--- a/web/components/clapcheeks-ops/comms-preferences-panel.tsx
+++ b/web/components/clapcheeks-ops/comms-preferences-panel.tsx
@@ -1,0 +1,307 @@
+/**
+ * CommsPreferencesPanel — single source of truth for a person's communication
+ * preferences. Used in:
+ *   - The dossier page (replaces the scattered cadence/whitelist/active_hours
+ *     widgets formerly spread across the operator panel + facts sidebar)
+ *   - The /messages live dashboard right rail
+ *
+ * Reads + writes via Convex `people.patchPerson` so every edit is reactive
+ * everywhere the dashboard renders this person.
+ */
+"use client"
+
+import { useMutation } from "convex/react"
+import { api } from "@/convex/_generated/api"
+import { Id } from "@/convex/_generated/dataModel"
+import { useState, useEffect } from "react"
+
+const CADENCES = [
+  { value: "hot", label: "Hot", hint: "reply 5-30m" },
+  { value: "warm", label: "Warm", hint: "reply 1-4h" },
+  { value: "slow_burn", label: "Slow burn", hint: "1/day" },
+  { value: "nurture", label: "Nurture", hint: "2-3/week" },
+  { value: "dormant", label: "Dormant", hint: "1/month" },
+] as const
+
+const NURTURE_STATES = [
+  { value: "active_pursuit", label: "Active pursuit", hint: "chase, fast cadence, willing to invest" },
+  { value: "steady", label: "Steady", hint: "consistent, not aggressive" },
+  { value: "nurture", label: "Nurture", hint: "light keep-warm" },
+  { value: "dormant", label: "Dormant", hint: "re-awaken occasionally" },
+  { value: "close", label: "Close", hint: "wind down, stop sending" },
+] as const
+
+const FOLLOWUP_KINDS = [
+  "reply", "nudge", "date_ask", "pattern_interrupt", "event_followup", "none",
+] as const
+
+const COMMON_TIMEZONES = [
+  "America/Los_Angeles",
+  "America/Denver",
+  "America/Chicago",
+  "America/New_York",
+  "America/Phoenix",
+  "America/Anchorage",
+  "Pacific/Honolulu",
+  "Europe/London",
+]
+
+type Person = any
+
+export function CommsPreferencesPanel({ person, compact = false }: { person: Person; compact?: boolean }) {
+  const patch = useMutation(api.people.patchPerson)
+  const [saving, setSaving] = useState<string | null>(null)
+  const [savedAt, setSavedAt] = useState<number | null>(null)
+
+  async function save(field: string, value: any) {
+    if (!person?._id) return
+    setSaving(field)
+    try {
+      await patch({ person_id: person._id as Id<"people">, [field]: value } as any)
+      setSavedAt(Date.now())
+    } finally {
+      setTimeout(() => setSaving(null), 300)
+    }
+  }
+
+  const tz = person?.active_hours_local?.tz ?? "America/Los_Angeles"
+  const startHour = person?.active_hours_local?.start_hour ?? 9
+  const endHour = person?.active_hours_local?.end_hour ?? 22
+
+  const responseRate = typeof person?.response_rate === "number" ? person.response_rate : null
+  const avgRespMin = typeof person?.avg_response_time_minutes === "number" ? person.avg_response_time_minutes : null
+
+  return (
+    <div className={`bg-gray-900 border border-gray-800 rounded-lg ${compact ? "p-3" : "p-4"}`}>
+      <div className="flex items-center justify-between mb-3">
+        <div>
+          <div className="text-sm font-semibold text-gray-200">Communication preferences</div>
+          {!compact && person?.display_name && (
+            <div className="text-xs text-gray-500">{person.display_name}</div>
+          )}
+        </div>
+        <SaveBadge saving={saving} savedAt={savedAt} />
+      </div>
+
+      {/* Whitelist toggle — biggest, most honest control */}
+      <label className={`flex items-center justify-between gap-3 px-3 py-2 rounded border cursor-pointer mb-3 ${
+        person?.whitelist_for_autoreply
+          ? "border-green-700/60 bg-green-950/30"
+          : "border-red-800/60 bg-red-950/20"
+      }`}>
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium">
+            {person?.whitelist_for_autoreply ? "Auto-reply ON" : "Auto-reply OFF"}
+          </div>
+          <div className="text-[11px] text-gray-500">
+            {person?.whitelist_for_autoreply
+              ? "AI may draft + send within active hours"
+              : "drafts only, no auto-send"}
+          </div>
+        </div>
+        <input
+          type="checkbox"
+          className="w-5 h-5"
+          checked={person?.whitelist_for_autoreply ?? false}
+          onChange={(e) => save("whitelist_for_autoreply", e.target.checked)}
+          disabled={saving === "whitelist_for_autoreply"}
+        />
+      </label>
+
+      {/* Cadence */}
+      <div className="mb-3">
+        <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Cadence</div>
+        <div className="grid grid-cols-5 gap-1">
+          {CADENCES.map((c) => (
+            <button
+              key={c.value}
+              onClick={() => save("cadence_profile", c.value)}
+              disabled={saving === "cadence_profile"}
+              className={`text-[11px] py-1.5 rounded border ${
+                person?.cadence_profile === c.value
+                  ? "border-purple-500 bg-purple-900/40 text-purple-100"
+                  : "border-gray-800 bg-gray-950 text-gray-400 hover:border-gray-600"
+              }`}
+              title={c.hint}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Active hours band */}
+      <div className="mb-3">
+        <div className="flex items-center justify-between mb-1">
+          <div className="text-xs uppercase tracking-wide text-gray-500">Active hours</div>
+          <div className="text-[11px] text-gray-500">{tz.split("/").pop()?.replace("_", " ")}</div>
+        </div>
+        <ActiveHoursBand startHour={startHour} endHour={endHour} />
+        <div className="grid grid-cols-3 gap-2 mt-2">
+          <select
+            value={tz}
+            onChange={(e) => save("active_hours_local", { tz: e.target.value, start_hour: startHour, end_hour: endHour })}
+            disabled={saving === "active_hours_local"}
+            className="bg-gray-950 border border-gray-800 rounded px-2 py-1 text-xs"
+          >
+            {COMMON_TIMEZONES.map((z) => <option key={z} value={z}>{z}</option>)}
+          </select>
+          <HourSelect
+            label="from"
+            value={startHour}
+            onChange={(h) => save("active_hours_local", { tz, start_hour: h, end_hour: endHour })}
+            disabled={saving === "active_hours_local"}
+          />
+          <HourSelect
+            label="to"
+            value={endHour}
+            onChange={(h) => save("active_hours_local", { tz, start_hour: startHour, end_hour: h })}
+            disabled={saving === "active_hours_local"}
+          />
+        </div>
+      </div>
+
+      {/* Nurture state — radio-style */}
+      <div className="mb-3">
+        <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Pursuit posture</div>
+        <div className="grid grid-cols-5 gap-1">
+          {NURTURE_STATES.map((n) => (
+            <button
+              key={n.value}
+              onClick={() => save("nurture_state", n.value)}
+              disabled={saving === "nurture_state"}
+              className={`text-[11px] py-1.5 rounded border ${
+                person?.nurture_state === n.value
+                  ? "border-pink-500 bg-pink-900/40 text-pink-100"
+                  : "border-gray-800 bg-gray-950 text-gray-400 hover:border-gray-600"
+              }`}
+              title={n.hint}
+            >
+              {n.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Next followup kind */}
+      <div className="mb-3">
+        <div className="text-xs uppercase tracking-wide text-gray-500 mb-1">Next followup kind</div>
+        <select
+          value={person?.next_followup_kind ?? "reply"}
+          onChange={(e) => save("next_followup_kind", e.target.value)}
+          disabled={saving === "next_followup_kind"}
+          className="bg-gray-950 border border-gray-800 rounded px-2 py-1.5 text-xs w-full"
+        >
+          {FOLLOWUP_KINDS.map((k) => <option key={k} value={k}>{k.replace(/_/g, " ")}</option>)}
+        </select>
+      </div>
+
+      {/* Insights strip */}
+      <div className="grid grid-cols-2 gap-2 text-[11px]">
+        <Insight
+          label="Response rate"
+          value={responseRate !== null ? `${Math.round(responseRate * 100)}%` : "—"}
+          hint="fraction of your outbound that gets a reply"
+        />
+        <Insight
+          label="Avg reply time"
+          value={avgRespMin !== null ? formatMinutes(avgRespMin) : "—"}
+          hint="median time she takes to respond"
+        />
+        <Insight
+          label="Question ratio 7d"
+          value={typeof person?.her_question_ratio_7d === "number"
+            ? `${Math.round(person.her_question_ratio_7d * 100)}%` : "—"}
+          hint="how often she asks something back; <15% = quiet thread"
+        />
+        <Insight
+          label="Time-to-ask"
+          value={typeof person?.time_to_ask_score === "number"
+            ? person.time_to_ask_score.toFixed(2) : "—"}
+          hint="0-1 model score; >0.7 means propose a date"
+        />
+      </div>
+    </div>
+  )
+}
+
+function ActiveHoursBand({ startHour, endHour }: { startHour: number; endHour: number }) {
+  const cells = Array.from({ length: 24 }, (_, h) => h)
+  // wrap-around windows (e.g. 22 -> 4) handled by checking either side
+  const isActive = (h: number) =>
+    startHour <= endHour ? (h >= startHour && h < endHour) : (h >= startHour || h < endHour)
+
+  const [now, setNow] = useState(new Date())
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60_000)
+    return () => clearInterval(id)
+  }, [])
+  const currentHour = now.getHours()
+
+  return (
+    <div className="flex h-5 w-full overflow-hidden rounded border border-gray-800">
+      {cells.map((h) => (
+        <div
+          key={h}
+          className={`flex-1 border-r border-gray-900 last:border-r-0 ${
+            isActive(h) ? "bg-emerald-700/70" : "bg-gray-950"
+          } ${currentHour === h ? "ring-2 ring-amber-400 ring-inset" : ""}`}
+          title={`${h.toString().padStart(2, "0")}:00${isActive(h) ? " (active)" : ""}${currentHour === h ? " ← now (your tz)" : ""}`}
+        />
+      ))}
+    </div>
+  )
+}
+
+function HourSelect({
+  label, value, onChange, disabled,
+}: { label: string; value: number; onChange: (h: number) => void; disabled?: boolean }) {
+  return (
+    <label className="flex items-center gap-1 text-[11px] text-gray-500">
+      <span className="w-8">{label}</span>
+      <select
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        disabled={disabled}
+        className="flex-1 bg-gray-950 border border-gray-800 rounded px-2 py-1"
+      >
+        {Array.from({ length: 24 }, (_, h) => h).map((h) => (
+          <option key={h} value={h}>{h.toString().padStart(2, "0")}:00</option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function SaveBadge({ saving, savedAt }: { saving: string | null; savedAt: number | null }) {
+  const [tick, setTick] = useState(0)
+  useEffect(() => {
+    if (!savedAt) return
+    const id = setInterval(() => setTick((t) => t + 1), 1000)
+    return () => clearInterval(id)
+  }, [savedAt])
+  if (saving) {
+    return <span className="text-[11px] text-amber-400">saving...</span>
+  }
+  if (!savedAt) {
+    return <span className="text-[11px] text-gray-600">unsaved edits not lost; everything autosaves</span>
+  }
+  const secs = Math.max(1, Math.round((Date.now() - savedAt) / 1000))
+  void tick
+  return <span className="text-[11px] text-emerald-500">saved {secs}s ago</span>
+}
+
+function Insight({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded border border-gray-800 bg-gray-950 px-2 py-1.5" title={hint}>
+      <div className="text-[10px] uppercase tracking-wide text-gray-500">{label}</div>
+      <div className="text-sm font-medium text-gray-200">{value}</div>
+    </div>
+  )
+}
+
+function formatMinutes(m: number): string {
+  if (m < 60) return `${Math.round(m)}m`
+  if (m < 60 * 24) return `${(m / 60).toFixed(1)}h`
+  return `${(m / 60 / 24).toFixed(1)}d`
+}

--- a/web/convex/touches.ts
+++ b/web/convex/touches.ts
@@ -1182,6 +1182,66 @@ export const cancelOne = mutation({
   },
 });
 
+// AI-9643 — Quick-action: edit a draft inline from the dashboard. Patches
+// draft_body and clears generate_at_fire_time so the operator's edit is
+// preserved through fireOne.
+export const editDraft = mutation({
+  args: {
+    touch_id: v.id("scheduled_touches"),
+    draft_body: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const t = await ctx.db.get(args.touch_id);
+    if (!t) return { not_found: true };
+    if (t.status !== "scheduled") return { skipped: true, status: t.status };
+    const trimmed = args.draft_body.trim();
+    if (!trimmed) return { skipped: true, reason: "empty" };
+    await ctx.db.patch(args.touch_id, {
+      draft_body: trimmed,
+      generate_at_fire_time: false,
+      updated_at: Date.now(),
+    });
+    return { ok: true };
+  },
+});
+
+// AI-9643 — Quick-action: fire a touch immediately. Pulls scheduled_for to now
+// so drainDue picks it up on the next 5s tick. Safer than calling fireOne
+// directly because the standard safety brakes (whitelist, active hours,
+// anti-loop, boundary) still run.
+export const fireNow = mutation({
+  args: { touch_id: v.id("scheduled_touches") },
+  handler: async (ctx, args) => {
+    const t = await ctx.db.get(args.touch_id);
+    if (!t) return { not_found: true };
+    if (t.status !== "scheduled") return { skipped: true, status: t.status };
+    await ctx.db.patch(args.touch_id, {
+      scheduled_for: Date.now(),
+      updated_at: Date.now(),
+    });
+    return { ok: true, fires_within: "next 5s tick" };
+  },
+});
+
+// AI-9643 — Quick-action: regenerate a draft. Clears draft_body and sets
+// generate_at_fire_time so the next fire pass redrafts via the LLM cascade
+// using the same template + person context. Reactive subscriptions on
+// listUpcoming pick up the swap automatically.
+export const regenerateDraft = mutation({
+  args: { touch_id: v.id("scheduled_touches") },
+  handler: async (ctx, args) => {
+    const t = await ctx.db.get(args.touch_id);
+    if (!t) return { not_found: true };
+    if (t.status !== "scheduled") return { skipped: true, status: t.status };
+    await ctx.db.patch(args.touch_id, {
+      draft_body: undefined,
+      generate_at_fire_time: true,
+      updated_at: Date.now(),
+    });
+    return { ok: true };
+  },
+});
+
 // Public reader for dashboard.
 export const listForPerson = query({
   args: { person_id: v.id("people"), limit: v.optional(v.number()) },


### PR DESCRIPTION
## Summary
- New `/admin/clapcheeks-ops/messages` — live cross-person feed (Convex reactive), 5 filter chips, search, click-to-focus, optional inbound audio ping
- Right rail: next-24h schedule with `Send now` / `Regenerate` / `Edit inline` / `Cancel`, plus the new `CommsPreferencesPanel`
- Same panel mounted on the dossier so edits sync everywhere
- Network filter hard-excludes platonic/professional vibes and requires a definitive dating signal — fixes guys showing up as prospects
- 3 new Convex mutations on `touches.ts`: `editDraft`, `fireNow`, `regenerateDraft`
- Insights chips on every feed row: 🎯 ask now / 💤 quiet thread / 🔥 hot cadence
- Nav card on ops overview

## Test plan
- [x] `npx tsc --noEmit` clean for all touched files (26 pre-existing errors, none in AI-9643 paths)
- [x] Convex codegen resolves `api.touches.{editDraft,fireNow,regenerateDraft}`
- [ ] Convex deploy lands the mutations on `valiant-oriole-651`
- [ ] Vercel auto-deploys `messages/page.tsx`
- [ ] Operator clicks Send on a real preview → message lands (BB pipeline already verified working in clapcheeks-local PR #18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)