### PR TITLE
AI-9645 dev_mode_bypass_overpursue field + UI toggle

### DIFF
--- a/web/components/clapcheeks-ops/comms-preferences-panel.tsx
+++ b/web/components/clapcheeks-ops/comms-preferences-panel.tsx
@@ -196,6 +196,37 @@ export function CommsPreferencesPanel({ person, compact = false }: { person: Per
         </select>
       </div>
 
+      {/* AI-9645 — Dev-mode bypass for over-pursue protection. ONLY visible on
+          rows already flagged as dev tests OR explicitly toggled here. Hidden
+          from the casual operator flow so it doesn't get misused on real
+          prospects. */}
+      <details className="mb-3">
+        <summary className="text-[11px] text-gray-500 cursor-pointer hover:text-gray-300">
+          🧪 dev test settings (advanced)
+        </summary>
+        <label className={`mt-2 flex items-center justify-between gap-3 px-3 py-2 rounded border cursor-pointer ${
+          person?.dev_mode_bypass_overpursue
+            ? "border-amber-700/60 bg-amber-950/30"
+            : "border-gray-800 bg-gray-950/40"
+        }`}>
+          <div className="flex-1 min-w-0">
+            <div className="text-xs font-medium">
+              {person?.dev_mode_bypass_overpursue ? "🧪 Dev test target — over-pursue bypassed" : "Dev test target (bypass over-pursue)"}
+            </div>
+            <div className="text-[10px] text-gray-500">
+              When ON, cadence-runner will NOT auto-flip whitelist=false on 3+ unanswered outbounds. Use ONLY on rows you control for testing the send pipeline. Never on real prospects.
+            </div>
+          </div>
+          <input
+            type="checkbox"
+            className="w-4 h-4"
+            checked={person?.dev_mode_bypass_overpursue ?? false}
+            onChange={(e) => save("dev_mode_bypass_overpursue", e.target.checked)}
+            disabled={saving === "dev_mode_bypass_overpursue"}
+          />
+        </label>
+      </details>
+
       {/* Insights strip */}
       <div className="grid grid-cols-2 gap-2 text-[11px]">
         <Insight

--- a/web/convex/people.ts
+++ b/web/convex/people.ts
@@ -1134,6 +1134,8 @@ export const patchPerson = mutation({
       start_hour: v.number(),
       end_hour: v.number(),
     })),
+    // AI-9645 — dev-mode bypass for over-pursue safety. ONLY for test rows.
+    dev_mode_bypass_overpursue: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const now = Date.now();
@@ -1143,6 +1145,7 @@ export const patchPerson = mutation({
       "courtship_stage", "hotness_rating", "effort_rating", "nurture_state",
       "next_followup_kind", "operator_notes", "interests", "boundaries_stated",
       "things_she_loves", "things_she_dislikes", "active_hours_local",
+      "dev_mode_bypass_overpursue",
     ];
     for (const k of allowed) {
       const v_ = (args as any)[k];

--- a/web/convex/schema.ts
+++ b/web/convex/schema.ts
@@ -535,6 +535,13 @@ export default defineSchema({
     // for daemon to autoreply. Default false.
     whitelist_for_autoreply: v.boolean(),
 
+    // AI-9645 — dev-mode bypass for the AI-9608 over-pursue protection.
+    // When true, cadence_runner._tick will NOT auto-flip whitelist to false
+    // even if the most-recent-6 messages are all unanswered outbounds. Use
+    // ONLY on dedicated test rows for E2E send-pipeline verification. Real
+    // prospects must never have this set. Operator-set, default unset.
+    dev_mode_bypass_overpursue: v.optional(v.boolean()),
+
     created_at: v.number(),
     updated_at: v.number(),
   })


### PR DESCRIPTION
## Summary
Operator-set per-person flag to bypass the AI-9608 over-pursue auto-pause. Lets E2E tests against a known target survive the 3+ unanswered-outbounds threshold without the safety brake reverting whitelist=true.

## Schema
- `people.dev_mode_bypass_overpursue: v.optional(v.boolean())`
- `patchPerson` accepts the field

## UI
- Collapsed "🧪 dev test settings (advanced)" inside CommsPreferencesPanel — hidden by default to prevent casual misuse on real prospects. Amber border + warning copy when active.

## Runner side
The cadence-runner respects-the-flag change ships in companion PR on clapcheeks-local. Schema first so the field is queryable when the Mac reads the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)