### PR TITLE
AI-9647 matches list reactive via Convex useQuery

### DIFF
--- a/web/components/matches/MatchesPageClient.tsx
+++ b/web/components/matches/MatchesPageClient.tsx
@@ -11,6 +11,64 @@ import {
   matchHasAllAttributes,
   type MatchWithAttributes,
 } from '@/lib/matches/attribute-filter'
+import { useQuery } from 'convex/react'
+import { api } from '@/convex/_generated/api'
+import { getFleetUserId } from '@/lib/fleet-user'
+
+// AI-9647 — Convex row → legacy match shape mapper.
+// Mirrors the server-side mapper in app/(main)/matches/page.tsx so the live
+// useQuery path produces what the rest of this component expects.
+function numberToIso(n: unknown): string | null {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return null
+  return new Date(n).toISOString()
+}
+
+function mapConvexRows(rows: unknown): MatchWithAttributes[] {
+  if (!Array.isArray(rows)) return []
+  return rows.map((r: any) => {
+    const platform = (r.platform ?? 'tinder') as MatchWithAttributes['platform']
+    return {
+      id: (r.supabase_match_id ?? r._id) as string,
+      user_id: r.user_id,
+      platform,
+      external_id: r.external_match_id ?? null,
+      name: r.name ?? null,
+      age: r.age ?? null,
+      bio: r.bio ?? null,
+      photos_jsonb: Array.isArray(r.photos)
+        ? r.photos.map((p: Record<string, unknown>) => ({
+            url: typeof p.url === 'string' ? p.url : '',
+            supabase_path:
+              typeof p.supabase_path === 'string' ? p.supabase_path : null,
+            width: typeof p.width === 'number' ? p.width : null,
+            height: typeof p.height === 'number' ? p.height : null,
+          }))
+        : null,
+      prompts_jsonb: null,
+      job: r.job ?? null,
+      school: r.school ?? null,
+      instagram_handle: r.instagram_handle ?? null,
+      spotify_artists: null,
+      birth_date: null,
+      zodiac: r.zodiac ?? null,
+      match_intel: r.match_intel ?? null,
+      vision_summary: null,
+      instagram_intel: null,
+      status: (r.status ?? 'new') as MatchWithAttributes['status'],
+      last_activity_at: numberToIso(r.last_activity_at),
+      created_at: numberToIso(r.created_at) ?? new Date().toISOString(),
+      updated_at: numberToIso(r.updated_at) ?? new Date().toISOString(),
+      final_score: typeof r.final_score === 'number' ? r.final_score : null,
+      location_score: null,
+      criteria_score: null,
+      scoring_reason: null,
+      julian_rank: typeof r.julian_rank === 'number' ? r.julian_rank : null,
+      stage: r.stage ?? null,
+      health_score: typeof r.health_score === 'number' ? r.health_score : null,
+      attributes: r.attributes ?? null,
+    } as MatchWithAttributes
+  })
+}
 
 const DEFAULT_FILTERS: MatchListFilters = {
   platform: 'all',
@@ -38,8 +96,23 @@ function intelInterests(intel: unknown): string[] {
   return Array.isArray(v) ? (v as string[]).filter((x) => typeof x === 'string') : []
 }
 
-export default function MatchesPageClient({ matches, errorMessage }: Props) {
+export default function MatchesPageClient({ matches: ssrMatches, errorMessage }: Props) {
   const [filters, setFilters] = useState<MatchListFilters>(DEFAULT_FILTERS)
+
+  // AI-9647 — live reactive matches via Convex useQuery. The SSR-rendered
+  // `ssrMatches` prop is the initial paint (no spinner on first load); once
+  // Convex pushes a fresh snapshot the live data takes over and stays
+  // reactive for every subsequent webhook write to `matches`. Fixes the
+  // "matches don't update" symptom — the page used to render once and never
+  // refetch.
+  const liveRows = useQuery(api.matches.listForUser, {
+    user_id: getFleetUserId(),
+    limit: 200,
+  })
+  const matches = useMemo<MatchWithAttributes[]>(() => {
+    if (liveRows === undefined) return ssrMatches
+    return mapConvexRows(liveRows)
+  }, [liveRows, ssrMatches])
 
   const attributeOptions = useMemo(() => aggregateAttributes(matches), [matches])
 


### PR DESCRIPTION
Matches dashboard wasn't updating because MatchesPageClient consumed SSR data statically. Now wraps the prop in a useQuery subscription so every Convex write to `matches` (Hinge/Tinder/IG sync, manual edit) reflects live without a refresh. SSR data still drives first paint.