### PR TITLE
AI-9648 dashboard fully live + light teal theme

### DIFF
--- a/web/app/(main)/matches/[id]/match-profile-view.tsx
+++ b/web/app/(main)/matches/[id]/match-profile-view.tsx
@@ -11,6 +11,39 @@ import QuickNotePanel from './quick-note-panel'
 import ThoughtfulQuestions from './thoughtful-questions'
 import AttributeChips, { type MatchAttributes } from '@/components/matches/AttributeChips'
 import ConversationComposer from './conversation-composer'
+import { useQuery } from 'convex/react'
+import { api } from '@/convex/_generated/api'
+
+// AI-9648 — map Convex match doc into the subset of MatchRow this view
+// actually re-renders on. Limited to fields the view actually reads so we
+// don't have to mirror the full ChatRow shape.
+function mapLiveConvexMatch(row: any | null | undefined): Partial<MatchRow> | null {
+  if (!row) return null
+  return {
+    status: row.status ?? null,
+    stage: row.stage ?? null,
+    julian_rank: typeof row.julian_rank === 'number' ? row.julian_rank : null,
+    final_score: typeof row.final_score === 'number' ? row.final_score : null,
+    name: row.name ?? null,
+    age: typeof row.age === 'number' ? row.age : null,
+    bio: row.bio ?? null,
+    job: row.job ?? null,
+    school: row.school ?? null,
+    instagram_handle: row.instagram_handle ?? null,
+    zodiac: row.zodiac ?? null,
+    match_intel: row.match_intel ?? null,
+    photos_jsonb: Array.isArray(row.photos)
+      ? row.photos.map((p: any) => ({
+          url: typeof p?.url === 'string' ? p.url : '',
+          supabase_path: typeof p?.supabase_path === 'string' ? p.supabase_path : null,
+          width: typeof p?.width === 'number' ? p.width : null,
+          height: typeof p?.height === 'number' ? p.height : null,
+        }))
+      : null,
+    health_score: typeof row.health_score === 'number' ? row.health_score : null,
+    attributes: row.attributes ?? null,
+  }
+}
 
 type TabKey = 'profile' | 'conversation' | 'memo' | 'intel'
 
@@ -127,6 +160,19 @@ export default function MatchProfileView({
   const router = useRouter()
   const [m, setM] = useState<MatchRow>(initial)
   const [active, setActive] = useState(0)
+
+  // AI-9648 — live match doc subscription. Convex pushes a new snapshot on
+  // every Hinge / Tinder / IG webhook write to this row, so status / photos /
+  // intel / score stay current without a refresh. SSR `initial` already
+  // covers first paint; useQuery takes over on first hydrate.
+  const liveRow = useQuery(api.matches.resolveByAnyId, {
+    id: initial.id as string,
+  })
+  useEffect(() => {
+    const live = mapLiveConvexMatch(liveRow)
+    if (!live) return
+    setM((prev) => ({ ...prev, ...live } as MatchRow))
+  }, [liveRow])
   // AI-9608 — default to Conversation tab so the operator lands directly on
   // the thread + quick-note + thoughtful-questions on mobile. Previously the
   // page opened on Profile and forced an extra tap on small screens.

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -125,3 +125,126 @@
     @apply bg-background text-foreground;
   }
 }
+
+/* AI-9648 — Light teal theme.
+ *
+ * Activated when <html class="light-teal">. The clapcheeks-ops dashboard
+ * surfaces use hardcoded dark-mode utility classes (bg-black, bg-gray-900,
+ * text-white, etc.) — rewriting all of them in component code would be a
+ * months-long migration. Instead this layer remaps the most common
+ * hardcoded dark classes to teal equivalents whenever the theme is active.
+ * Existing dark / default themes are unchanged.
+ *
+ * Palette anchors (Julian: "light teal"):
+ *   page bg          #eff7f8   very light teal-50
+ *   surface          #d6f0f2   teal-100
+ *   surface alt      #c5e7ea   teal-200
+ *   surface deep     #b3dee2   teal-300
+ *   text default     #0f3a3f   deep teal
+ *   text secondary   #2a5860
+ *   text muted       #5a8e96
+ *   text subtle      #7aa9b0
+ *   border           #99e6ea   teal-200
+ *   border strong    #80d8de
+ *   accent           #14b8a6   teal-500 (kept for ring/active)
+ */
+.light-teal {
+  --background: #eff7f8;
+  --foreground: #0f3a3f;
+  --card: #d6f0f2;
+  --card-foreground: #0f3a3f;
+  --popover: #ffffff;
+  --popover-foreground: #0f3a3f;
+  --primary: #14b8a6;
+  --primary-foreground: #ffffff;
+  --secondary: #c5e7ea;
+  --secondary-foreground: #0f3a3f;
+  --muted: #c5e7ea;
+  --muted-foreground: #5a8e96;
+  --accent: #99e6ea;
+  --accent-foreground: #0f3a3f;
+  --border: #99e6ea;
+  --input: #c5e7ea;
+  --ring: #14b8a6;
+  --sidebar: #d6f0f2;
+  --sidebar-foreground: #0f3a3f;
+  --sidebar-primary: #14b8a6;
+  --sidebar-primary-foreground: #ffffff;
+  --sidebar-accent: #c5e7ea;
+  --sidebar-accent-foreground: #0f3a3f;
+  --sidebar-border: #99e6ea;
+  --sidebar-ring: #14b8a6;
+}
+
+.light-teal body {
+  background-color: #eff7f8;
+  color: #0f3a3f;
+}
+
+/* Background remaps. Order matters — most-specific first. */
+.light-teal .bg-black { background-color: #eff7f8 !important; }
+.light-teal .bg-gray-950 { background-color: #c5e7ea !important; }
+.light-teal .bg-gray-900 { background-color: #d6f0f2 !important; }
+.light-teal .bg-gray-800 { background-color: #c5e7ea !important; }
+.light-teal .bg-gray-800\/60 { background-color: rgba(197, 231, 234, 0.6) !important; }
+.light-teal .bg-gray-900\/60 { background-color: rgba(214, 240, 242, 0.6) !important; }
+.light-teal .bg-gray-950\/40 { background-color: rgba(197, 231, 234, 0.4) !important; }
+.light-teal .bg-gray-700 { background-color: #b3dee2 !important; }
+.light-teal .bg-gray-700\/40 { background-color: rgba(179, 222, 226, 0.4) !important; }
+
+/* Gradient surfaces — flatten to single tone for readability. */
+.light-teal [class*="from-gray-950"],
+.light-teal [class*="from-gray-900"],
+.light-teal [class*="to-gray-950"],
+.light-teal [class*="to-gray-900"] {
+  background-image: none !important;
+  background-color: #d6f0f2 !important;
+}
+
+/* Text remaps. Keep brand accents (purple, pink, emerald, amber, rose) as-is
+ * so important affordances stay readable on the new background. */
+.light-teal .text-white { color: #0f3a3f !important; }
+.light-teal .text-gray-100 { color: #0f3a3f !important; }
+.light-teal .text-gray-200 { color: #234e54 !important; }
+.light-teal .text-gray-300 { color: #2a5860 !important; }
+.light-teal .text-gray-400 { color: #4a7780 !important; }
+.light-teal .text-gray-500 { color: #5a8e96 !important; }
+.light-teal .text-gray-600 { color: #7aa9b0 !important; }
+
+/* Brand accents on light bg — bump saturation for legibility. */
+.light-teal .text-purple-300 { color: #6b21a8 !important; }
+.light-teal .text-purple-400 { color: #7e22ce !important; }
+.light-teal .text-pink-300 { color: #be185d !important; }
+.light-teal .text-rose-300 { color: #be123c !important; }
+.light-teal .text-rose-400 { color: #e11d48 !important; }
+.light-teal .text-amber-300 { color: #b45309 !important; }
+.light-teal .text-amber-400 { color: #d97706 !important; }
+.light-teal .text-emerald-400 { color: #047857 !important; }
+.light-teal .text-emerald-500 { color: #059669 !important; }
+
+/* Borders. */
+.light-teal .border-gray-700 { border-color: #80d8de !important; }
+.light-teal .border-gray-700\/50 { border-color: rgba(128, 216, 222, 0.5) !important; }
+.light-teal .border-gray-800 { border-color: #99e6ea !important; }
+.light-teal .border-gray-800\/50 { border-color: rgba(153, 230, 234, 0.5) !important; }
+.light-teal .border-gray-900 { border-color: #b3dee2 !important; }
+.light-teal .border-gray-950 { border-color: #b3dee2 !important; }
+
+/* Hover states stay subtle on the lighter palette. */
+.light-teal .hover\:border-gray-500:hover { border-color: #14b8a6 !important; }
+.light-teal .hover\:border-gray-600:hover { border-color: #14b8a6 !important; }
+.light-teal .hover\:border-gray-700:hover { border-color: #80d8de !important; }
+.light-teal .hover\:bg-gray-700:hover { background-color: #b3dee2 !important; }
+.light-teal .hover\:bg-gray-800:hover { background-color: #c5e7ea !important; }
+.light-teal .hover\:bg-gray-800\/60:hover { background-color: rgba(197, 231, 234, 0.7) !important; }
+
+/* Inputs. */
+.light-teal input, .light-teal textarea, .light-teal select {
+  background-color: #ffffff !important;
+  color: #0f3a3f !important;
+  border-color: #80d8de !important;
+}
+.light-teal input::placeholder,
+.light-teal textarea::placeholder {
+  color: #7aa9b0 !important;
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -92,6 +92,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           defaultTheme="dark"
           enableSystem
           disableTransitionOnChange
+          themes={['light', 'dark', 'system', 'light-teal']}
         >
           <ConvexProvider>
             {children}

--- a/web/components/layout/app-sidebar.tsx
+++ b/web/components/layout/app-sidebar.tsx
@@ -6,6 +6,7 @@ import { memo, useCallback, useEffect, useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
 import { logout } from '@/app/auth/actions'
 import AiActiveSwitch from '@/components/header/AiActiveSwitch'
+import { ThemeToggle } from '@/components/theme-toggle'
 
 // AI-9500: defer non-critical work until the browser is idle so it doesn't
 // compete with first paint and worsen INP. The sidebar mounts on every authed
@@ -213,12 +214,16 @@ export default function AppSidebar() {
       >
         {/* Logo header */}
         <div className="px-5 pt-5 pb-4 border-b border-white/8">
-          <Link href="/dashboard" className="flex items-center gap-2">
-            <Logo />
-            <span className="font-display text-2xl gold-text uppercase tracking-wide">
-              Clapcheeks
-            </span>
-          </Link>
+          <div className="flex items-center justify-between">
+            <Link href="/dashboard" className="flex items-center gap-2">
+              <Logo />
+              <span className="font-display text-2xl gold-text uppercase tracking-wide">
+                Clapcheeks
+              </span>
+            </Link>
+            {/* AI-9648 — theme toggle (dark / light teal / light) */}
+            <ThemeToggle className="text-white/70 hover:text-white shrink-0" />
+          </div>
           <p className="mt-1 ml-9 text-[10px] uppercase tracking-widest text-white/30 font-mono">
             co-pilot v1
           </p>

--- a/web/components/theme-toggle.tsx
+++ b/web/components/theme-toggle.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import * as React from 'react'
-import { Moon, Sun, Monitor } from 'lucide-react'
+import { Moon, Sun, Monitor, Waves } from 'lucide-react'
 import { useTheme } from 'next-themes'
 
 import { Button } from '@/components/ui/button'
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 
 export function ThemeToggle({ className }: { className?: string }) {
-  const { setTheme } = useTheme()
+  const { setTheme, theme } = useTheme()
 
   return (
     <DropdownMenu>
@@ -24,8 +24,14 @@ export function ThemeToggle({ className }: { className?: string }) {
           className={className}
           aria-label="Toggle theme"
         >
-          <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-          <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          {theme === 'light-teal' ? (
+            <Waves className="h-4 w-4 text-teal-500" />
+          ) : (
+            <>
+              <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+              <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+            </>
+          )}
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
@@ -34,6 +40,9 @@ export function ThemeToggle({ className }: { className?: string }) {
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme('dark')}>
           <Moon className="mr-2 h-4 w-4" /> Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('light-teal')}>
+          <Waves className="mr-2 h-4 w-4 text-teal-500" /> Light teal
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme('system')}>
           <Monitor className="mr-2 h-4 w-4" /> System


### PR DESCRIPTION
Live: /matches/[id] dossier now reactive (status / photos / intel update on every Hinge/Tinder/IG webhook write, no refresh). Theme: new 'light teal' variant in next-themes — fresh ocean palette, sidebar toggle. Class-level remap so hardcoded dark utility classes get teal equivalents without a component-wide migration.